### PR TITLE
Bump version to reflect change to .NET 3.1 and prepare to build preview1

### DIFF
--- a/VRDR/DeathRecord.csproj
+++ b/VRDR/DeathRecord.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>DeathRecord.xml</DocumentationFile>
     <!-- <DocumentationFile>DeathRecord.md</DocumentationFile> -->
     <PackageId>VRDR</PackageId>
-    <Version>2.14.0</Version>
+    <Version>3.1.0-preview1</Version>
     <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
     <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     <Title>FHIR VRDR Death Record</Title>


### PR DESCRIPTION
In order to signify the change from .NET 2.2 -> 3.1 we are bumping the application version appropriately. This should be everything necessary to build a new Nuget package.