### PR TITLE
Update FhirDeathRecord HTTP Microservice Dockerfile to build a linux executable for use in Docker

### DIFF
--- a/VRDR.HTTP/Dockerfile
+++ b/VRDR.HTTP/Dockerfile
@@ -1,5 +1,11 @@
-FROM microsoft/dotnet:sdk AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+COPY . /app
+WORKDIR /app/VRDR.HTTP
+RUN dotnet publish -c Release -r linux-x64 -o out
+
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1 AS runtime
 WORKDIR /app
-COPY bin/Debug/netcoreapp3.1/publish .
+
+COPY --from=build-env /app/VRDR.HTTP/out .
 EXPOSE 8080
-ENTRYPOINT ["dotnet", "VRDR.HTTP.dll"]
+ENTRYPOINT ["./FhirDeathRecord.HTTP"]


### PR DESCRIPTION
Previously the SDK had to be installed, now only the runtime needs to be.
The build command was also previously run outside of Docker, it now runs in docker during build.

I am setting this up so it can just be pulled from `mitre/vrdr-microservice` once this is merged.