### PR TITLE
Do not separately track the same version information in every project

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: VRDR/DeathRecord.csproj # Relative to repository root
-          VERSION_FILE_PATH: VRDR/DeathRecord.csproj # Filepath with version info, relative to repository root. Defaults to project file
+          VERSION_FILE_PATH: Directory.Build.props # Filepath with version info, shared between all projects in this repo
           VERSION_REGEX: <Version>(.*)<\/Version> # Regex pattern to extract version info in a capturing group
           TAG_COMMIT: true # Tag the project when the version has changed
           TAG_FORMAT: v* # Format of the git tag, [*] gets replaced with version
@@ -28,7 +28,7 @@ jobs:
         uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: VRDR.Messaging/VRDRMessaging.csproj # Relative to repository root
-          VERSION_FILE_PATH: VRDR.Messaging/VRDRMessaging.csproj # Filepath with version info, relative to repository root. Defaults to project file
+          VERSION_FILE_PATH: Directory.Build.props # Filepath with version info, shared between all projects in this repo
           VERSION_REGEX: <Version>(.*)<\/Version> # Regex pattern to extract version info in a capturing group
           TAG_COMMIT: false # We already tag with DeathRecord and the versions should always be the same, no need to do it twice
           NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>
+        <Version>3.1.0-preview4</Version>
+        <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
+        <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
+    </PropertyGroup>
+</Project>

--- a/VRDR.Messaging/VRDRMessaging.csproj
+++ b/VRDR.Messaging/VRDRMessaging.csproj
@@ -5,9 +5,6 @@
     <DocumentationFile>VRDRMessaging.xml</DocumentationFile>
     <!-- <DocumentationFile>VRDRMessaging.md</DocumentationFile> -->
     <PackageId>VRDR.Messaging</PackageId>
-    <Version>3.1.0-preview3</Version>
-    <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
-    <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     <Title>FHIR VRDR Death Record Messaging</Title>
     <PackageDescription>A library for supporting FHIR messaging for VRDR FHIR death records.</PackageDescription>
     <Authors>aholmes@mitre.org</Authors>

--- a/VRDR/DeathRecord.csproj
+++ b/VRDR/DeathRecord.csproj
@@ -5,9 +5,6 @@
     <DocumentationFile>DeathRecord.xml</DocumentationFile>
     <!-- <DocumentationFile>DeathRecord.md</DocumentationFile> -->
     <PackageId>VRDR</PackageId>
-    <Version>3.1.0-preview3</Version>
-    <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
-    <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     <Title>FHIR VRDR Death Record</Title>
     <PackageDescription>A library for producing and consuming VRDR FHIR death records.</PackageDescription>
     <Authors>aholmes@mitre.org</Authors>


### PR DESCRIPTION
Use a top level Directory.Build.props to house this information.

I have tested this locally and it built successfully, unfortunately unable to test the Github action without merging this in. I have bumped the version to preview4 so we can test this.