### PR TITLE
Bump the versions of netcoreapp for the VRDR.CLI and VRDR.Tests.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,12 +31,20 @@ jobs:
     - name: Test
       run: |
           dotnet test VRDR.Tests/DeathRecord.Tests.csproj
-          dotnet run -p VRDR.CLI json2json VRDR.CLI/1.json
-          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1.xml
-          dotnet run -p VRDR.CLI description VRDR.CLI/1.xml
-          dotnet run -p VRDR.CLI description VRDR.CLI/1.json
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.xml
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.json
+          dotnet run -p VRDR.CLI json2json VRDR.CLI/1.json --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI json2json VRDR.CLI/1.json --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1.xml --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1.xml --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI description VRDR.CLI/1.xml --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI description VRDR.CLI/1.xml --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI description VRDR.CLI/1.json --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI description VRDR.CLI/1.json --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.xml --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.xml --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.json --framework netcoreapp2.1
+          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.json --framework netcoreapp3.1
           ./VRDR.Tests/test_translation_service.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,19 +32,19 @@ jobs:
       run: |
           dotnet test VRDR.Tests/DeathRecord.Tests.csproj
           dotnet run -p VRDR.CLI json2json VRDR.CLI/1.json --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI json2json VRDR.CLI/1.json --framework netcoreapp3.1
           dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1.xml --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1.xml --framework netcoreapp3.1
           dotnet run -p VRDR.CLI description VRDR.CLI/1.xml --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI description VRDR.CLI/1.xml --framework netcoreapp3.1
           dotnet run -p VRDR.CLI description VRDR.CLI/1.json --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI description VRDR.CLI/1.json --framework netcoreapp3.1
           dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml --framework netcoreapp3.1
           dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json --framework netcoreapp3.1
           dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.xml --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.xml --framework netcoreapp3.1
           dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.json --framework netcoreapp2.1
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.json --framework netcoreapp3.1
+          dotnet run -p VRDR.CLI json2json VRDR.CLI/1.json
+          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1.xml
+          dotnet run -p VRDR.CLI description VRDR.CLI/1.xml
+          dotnet run -p VRDR.CLI description VRDR.CLI/1.json
+          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml
+          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json
+          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.xml
+          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1.json
           ./VRDR.Tests/test_translation_service.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET Core 2.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.207
+        dotnet-version: 2.1.805
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.201
+    - name: .net Side by Side
+      run: |
+        rsync -a ${DOTNET_ROOT/3.1.201/2.1.805}/* $DOTNET_ROOT/
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Nuget](https://img.shields.io/nuget/v/VRDR.Messaging?label=VRDR.Messaging%20%28nuget%29)](https://www.nuget.org/packages/VRDR.Messaging)
 
 # vrdr-dotnet
-This repository includes .NET (C#) code for 
+This repository includes .NET (C#) code for
 
 - Producing and consuming the Vital Records Death Reporting (VRDR) Health Level 7 (HL7) Fast Healthcare Interoperability Resources (FHIR) standard. [Click here to view the FHIR Implementation Guide](http://hl7.org/fhir/us/vrdr/2019May/).
 - Producing and consuming FHIR messages for the exchange of VRDR documents.
@@ -210,7 +210,7 @@ DeathRecord record = ...;
 // Create a submission message
 DeathRecordSubmission message = new DeathRecordSubmission(record);
 
-// Create a JSON representation of the message (XML is also supported via the ToXML method) 
+// Create a JSON representation of the message (XML is also supported via the ToXML method)
 string jsonMessage = message.ToJSON();
 
 // Send the JSON message
@@ -336,40 +336,42 @@ dotnet test VRDR.Tests/DeathRecord.Tests.csproj
 ### VRDR.CLI
 This directory contains a sample command line interface app that uses the VRDR library to do a few different things.
 
+NOTE: In all of the below commands you must specify your preferred version of dotnet, either netcoreapp2.1 or netcoreapp3.1, depending on whether you have installed dotnet 2.1 or dotnet 3.1 locally on your system.
+
 #### Example Usages
 ```bash
 # Builds a fake death record and print out the record as FHIR XML and JSON
-dotnet run
+dotnet run --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the FHIR XML or JSON death record and print out as IJE
-dotnet run 2ije 1.xml
+dotnet run 2ije 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the IJE death record and print out as FHIR XML
-dotnet run ije2xml 1.MOR
+dotnet run ije2xml 1.MOR --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the IJE death record and print out as FHIR JSON
-dotnet run ije2json 1.MOR
+dotnet run ije2json 1.MOR --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the FHIR XML death record and print out as FHIR JSON
-dotnet run xml2json 1.xml
+dotnet run xml2json 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the FHIR JSON death record and print out as FHIR XML
-dotnet run json2xml 1.json
+dotnet run json2xml 1.json --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the FHIR JSON death record, completely disassemble then reassemble, and print as FHIR JSON
-dotnet run json2json 1.json
+dotnet run json2json 1.json --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the FHIR XML death record, completely disassemble then reassemble, and print as FHIR XML
-dotnet run xml2xml 1.xml
+dotnet run xml2xml 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
-dotnet run checkXml 1.xml
+dotnet run checkXml 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
-dotnet run checkJson 1.json
+dotnet run checkJson 1.json --framework <netcoreapp2.1, netcoreapp3.1>
 
 # Read in and parse an IJE death record and print out the values for every (supported) field
-dotnet run ije 1.MOR
+dotnet run ije 1.MOR --framework <netcoreapp2.1, netcoreapp3.1>
 ```
 
 ### VRDR.HTTP

--- a/README.md
+++ b/README.md
@@ -336,42 +336,42 @@ dotnet test VRDR.Tests/DeathRecord.Tests.csproj
 ### VRDR.CLI
 This directory contains a sample command line interface app that uses the VRDR library to do a few different things.
 
-NOTE: In all of the below commands you must specify your preferred version of dotnet, either netcoreapp2.1 or netcoreapp3.1, depending on whether you have installed dotnet 2.1 or dotnet 3.1 locally on your system.
+NOTE: If you would like to run the CLI using .NET core 2.1, append `--framework netcoreapp2.1` to the end of all the example commands below
 
 #### Example Usages
 ```bash
 # Builds a fake death record and print out the record as FHIR XML and JSON
-dotnet run --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run
 
 # Read in the FHIR XML or JSON death record and print out as IJE
-dotnet run 2ije 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run 2ije 1.xml
 
 # Read in the IJE death record and print out as FHIR XML
-dotnet run ije2xml 1.MOR --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run ije2xml 1.MOR
 
 # Read in the IJE death record and print out as FHIR JSON
-dotnet run ije2json 1.MOR --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run ije2json 1.MOR
 
 # Read in the FHIR XML death record and print out as FHIR JSON
-dotnet run xml2json 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run xml2json 1.xml
 
 # Read in the FHIR JSON death record and print out as FHIR XML
-dotnet run json2xml 1.json --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run json2xml 1.json
 
 # Read in the FHIR JSON death record, completely disassemble then reassemble, and print as FHIR JSON
-dotnet run json2json 1.json --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run json2json 1.json
 
 # Read in the FHIR XML death record, completely disassemble then reassemble, and print as FHIR XML
-dotnet run xml2xml 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run xml2xml 1.xml
 
 # Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
-dotnet run checkXml 1.xml --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run checkXml 1.xml
 
 # Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
-dotnet run checkJson 1.json --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run checkJson 1.json
 
 # Read in and parse an IJE death record and print out the values for every (supported) field
-dotnet run ije 1.MOR --framework <netcoreapp2.1, netcoreapp3.1>
+dotnet run ije 1.MOR
 ```
 
 ### VRDR.HTTP

--- a/VRDR.CLI/DeathRecord.CLI.csproj
+++ b/VRDR.CLI/DeathRecord.CLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\VRDR\DeathRecord.csproj" />

--- a/VRDR.CLI/DeathRecord.CLI.csproj
+++ b/VRDR.CLI/DeathRecord.CLI.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/VRDR.CLI/DeathRecord.CLI.csproj
+++ b/VRDR.CLI/DeathRecord.CLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\VRDR\DeathRecord.csproj" />

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>VRDR.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>VRDR.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Previously had both of those projects were still using netcoreapp2.1 even though we upgraded everything else to dotnet 3.1.

This was causing the following error on a clean install of dotnet 3.1:

```
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - The following frameworks were found:
      3.1.3 at [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.1.0&arch=x64&rid=osx.10.15-x64
```