### PR TITLE
Do not attempt to push symbols to Nuget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
           TAG_FORMAT: v* # Format of the git tag, [*] gets replaced with version
           NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key
           PACKAGE_NAME: VRDR
+          INCLUDE_SYMBOLS: false
       - name: publish Messaging on version change
         uses: rohith/publish-nuget@v2
         with:
@@ -33,3 +34,4 @@ jobs:
           TAG_COMMIT: false # We already tag with DeathRecord and the versions should always be the same, no need to do it twice
           NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key
           PACKAGE_NAME: VRDR.Messaging
+          INCLUDE_SYMBOLS: false


### PR DESCRIPTION
We do not build symbols, so trying to push them causes a failure. Explicitly disable their pushing.