### PR TITLE
Entity axis flat list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Change Log
 
+### v3.1.0-preview10 - 2020-06-09
+
+* Added `CauseOfDeathEntityAxisList` property to `CodingResponseMessage` and `CodingUpdateMessage`.
+
 ### v3.1.0-preview9 - 2020-05-29
 
 * Add ability to format output for human readability via `prettyPrint` parameter of `BaseMessage.ToXML` and `BaseMessage.ToJSON`.
-* Move VRDR.Messaging API documentation to new, task-oriented, documentation page.
+* Move VRDR.Messaging API documentation to new, [task-oriented, documentation page](doc/Messaging.md).
 * `ExtractionErrorMessage(sourceMessage)` constructor initializes the `MessageSource` property from `sourceMessage.MessageDestination`. Removed the defaulted `source` parameter from this constructor.
 
 ### v3.1.0-preview8 - 2020-05-27

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>3.1.0-preview9</Version>
+        <Version>3.1.0-preview10</Version>
         <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
         <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR" Version="3.1.0-preview9" />
+  <PackageReference Include="VRDR" Version="3.1.0-preview10" />
   ...
 </ItemGroup>
 ```
@@ -183,7 +183,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR.Messaging" Version="3.1.0-preview9" />
+  <PackageReference Include="VRDR.Messaging" Version="3.1.0-preview10" />
   ...
 </ItemGroup>
 ```

--- a/VRDR.Messaging/CodingResponseMessage.cs
+++ b/VRDR.Messaging/CodingResponseMessage.cs
@@ -192,7 +192,8 @@ namespace VRDR
             }
         }
 
-        /// <summary>Entity axis cause of death coding.</summary>
+        /// <summary>Entity axis cause of death coding grouped by line. An alternate flat list of entity axis codes
+        /// is available via the CauseOfDeathEntityAxisList property, <see cref="CauseOfDeathEntityAxisList"/></summary>
         public List<CauseOfDeathEntityAxisEntry> CauseOfDeathEntityAxis
         {
             get
@@ -234,6 +235,34 @@ namespace VRDR
                     }
                     Record.Add("entity_axis_code", entityAxisEntry);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Entity axis cause of death coding as a flat list. Provided as an alternative to the
+        /// CauseOfDeathEntityAxis property which groups cause codes by line, <see cref="CauseOfDeathEntityAxis"/>.
+        /// </summary>
+        /// <para>Each entry in the list is a tuple with three values:</para>
+        /// <list type="bullet">
+        /// <item>Line: <see cref="CauseOfDeathEntityAxisEntry.LineNumber"/></item>
+        /// <item>Position: Sequence of code within the line</item>
+        /// <item>Code>: ICD code</item>
+        /// </list>
+        public List<(string Line, string Position, string Code)> CauseOfDeathEntityAxisList
+        {
+            get
+            {
+                var entityAxisList = new List<(string Line, string Position, string Code)>();
+                foreach (CauseOfDeathEntityAxisEntry entry in CauseOfDeathEntityAxis)
+                {
+                    int position = 1;
+                    foreach (string code in entry.AssignedCodes)
+                    {
+                        entityAxisList.Add((Line: entry.LineNumber, Position: position.ToString(), Code: code));
+                        position++;
+                    }
+                }
+                return entityAxisList;
             }
         }
     }

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -251,7 +251,20 @@
             <summary>Record axis coding of cause of death</summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxis">
-            <summary>Entity axis cause of death coding.</summary>
+            <summary>Entity axis cause of death coding grouped by line. An alternate flat format
+            is available via the CauseOfDeathEntityAxisList property, <see cref="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxisList"/></summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxisList">
+            <summary>
+            Entity axis cause of death coding as a flat list. Provided as a flat alternative to the
+            CauseOfDeathEntityAxis property which groups cause codes by line, <see cref="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxis"/>.
+            </summary>
+            <para>Each entry in the list is a tuple with three values:</para>
+            <list type="bullet">
+            <item>Line: <see cref="F:VRDR.CauseOfDeathEntityAxisEntry.LineNumber"/></item>
+            <item>Position: Sequence of code within the line</item>
+            <item>Code>: ICD code</item>
+            </list>
         </member>
         <member name="T:VRDR.CauseOfDeathEntityAxisEntry">
             <summary>Class for structuring a cause of death entity axis entry</summary>

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -251,12 +251,12 @@
             <summary>Record axis coding of cause of death</summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxis">
-            <summary>Entity axis cause of death coding grouped by line. An alternate flat format
+            <summary>Entity axis cause of death coding grouped by line. An alternate flat list of entity axis codes
             is available via the CauseOfDeathEntityAxisList property, <see cref="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxisList"/></summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxisList">
             <summary>
-            Entity axis cause of death coding as a flat list. Provided as a flat alternative to the
+            Entity axis cause of death coding as a flat list. Provided as an alternative to the
             CauseOfDeathEntityAxis property which groups cause codes by line, <see cref="P:VRDR.CodingResponseMessage.CauseOfDeathEntityAxis"/>.
             </summary>
             <para>Each entry in the list is a tuple with three values:</para>

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -241,6 +241,20 @@ namespace VRDR.Tests
             Assert.Equal("xyzzy", entityAxisEntries[1].LineNumber);
             Assert.Equal(1, (int)entityAxisEntries[1].AssignedCodes.Count);
             Assert.Equal("code2_1", entityAxisEntries[1].AssignedCodes[0]);
+            var entityAxisEntryList = message.CauseOfDeathEntityAxisList;
+            Assert.Equal(3, (int)entityAxisEntryList.Count);
+            (string line, string position, string code) = entityAxisEntryList[0];
+            Assert.Equal("abcde", line);
+            Assert.Equal("1", position);
+            Assert.Equal("code1_1", code);
+            (line, position, code) = entityAxisEntryList[1];
+            Assert.Equal("abcde", line);
+            Assert.Equal("2", position);
+            Assert.Equal("code1_2", code);
+            (line, position, code) = entityAxisEntryList[2];
+            Assert.Equal("xyzzy", line);
+            Assert.Equal("1", position);
+            Assert.Equal("code2_1", code);
         }
 
         [Fact]
@@ -367,6 +381,20 @@ namespace VRDR.Tests
             Assert.Equal("2", entityAxisEntries[1].LineNumber);
             Assert.Equal(1, (int)entityAxisEntries[1].AssignedCodes.Count);
             Assert.Equal("code2_1", entityAxisEntries[1].AssignedCodes[0]);
+            var entityAxisEntryList = message.CauseOfDeathEntityAxisList;
+            Assert.Equal(3, (int)entityAxisEntryList.Count);
+            (string line, string position, string code) = entityAxisEntryList[0];
+            Assert.Equal("1", line);
+            Assert.Equal("1", position);
+            Assert.Equal("code1_1", code);
+            (line, position, code) = entityAxisEntryList[1];
+            Assert.Equal("1", line);
+            Assert.Equal("2", position);
+            Assert.Equal("code1_2", code);
+            (line, position, code) = entityAxisEntryList[2];
+            Assert.Equal("2", line);
+            Assert.Equal("1", position);
+            Assert.Equal("code2_1", code);
         }
 
         [Fact]


### PR DESCRIPTION
This pull request adds a new alternate accessor for entity axis codes for clients wishing to process them as a flat list of (line, position, code) instead of codes grouped by line.