### PR TITLE
Collapse DeathRecord XML and JSON parsing blocks into one

### DIFF
--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -2160,7 +2160,7 @@
             <summary>Adds the given race to the record.</summary>
         </member>
         <member name="M:VRDR.IJEMortality.Get_YNU(System.String)">
-            <summary>Gets a "Yes", "No", or "Unkown" value.</summary>
+            <summary>Gets a "Yes", "No", or "Unknown" value.</summary>
         </member>
         <member name="M:VRDR.IJEMortality.Set_YNU(System.String,System.String)">
             <summary>Sets a "Yes", "No", or "Unkown" value.</summary>

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -643,7 +643,7 @@ namespace VRDR
             record.Race = raceStatus.Distinct().ToList().ToArray();
         }
 
-        /// <summary>Gets a "Yes", "No", or "Unkown" value.</summary>
+        /// <summary>Gets a "Yes", "No", or "Unknown" value.</summary>
         private string Get_YNU(string fhirFieldName)
         {
             object status = typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);


### PR DESCRIPTION
Currently we have a lot of duplicated code in the XML and JSON parsing blocks, removes most of the duplication.

Also fix minor typo in comment