### PR TITLE
Convert Examiner Contacted Frontend from a FhirBoolean to a CodeableConcept

### DIFF
--- a/VRDR.CLI/1.json
+++ b/VRDR.CLI/1.json
@@ -1284,7 +1284,13 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1478,5 +1484,3 @@
     }
   ]
 }
-
-

--- a/VRDR.CLI/1.xml
+++ b/VRDR.CLI/1.xml
@@ -1044,7 +1044,13 @@
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <valueBoolean value="false" />
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+            <code value="N" />
+            <display value="No" />
+          </coding>
+        </valueCodeableConcept>
       </Observation>
     </resource>
   </entry>
@@ -1207,5 +1213,3 @@
     </resource>
   </entry>
 </Bundle>
-
-

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -361,7 +361,11 @@ namespace VRDR.CLI
                 deathRecord.TransportationRole = tr;
 
                 // ExaminerContacted
-                deathRecord.ExaminerContacted = false;
+                Dictionary<string, string> excon = new Dictionary<string, string>();
+                excon.Add("code", "Y");
+                excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
+                excon.Add("display", "Yes");
+                deathRecord.ExaminerContacted = excon;
 
                 // TobaccoUse
                 Dictionary<string, string> tbu = new Dictionary<string, string>();

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -361,11 +361,7 @@ namespace VRDR.CLI
                 deathRecord.TransportationRole = tr;
 
                 // ExaminerContacted
-                Dictionary<string, string> excon = new Dictionary<string, string>();
-                excon.Add("code", "Y");
-                excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                excon.Add("display", "Yes");
-                deathRecord.ExaminerContacted = excon;
+                deathRecord.ExaminerContacted = false;
 
                 // TobaccoUse
                 Dictionary<string, string> tbu = new Dictionary<string, string>();

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1735,25 +1735,17 @@ namespace VRDR.Tests
         [Fact]
         public void Set_ExaminerContacted()
         {
-            Dictionary<string, string> excon = new Dictionary<string, string>();
-            excon.Add("code", "Y");
-            excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-            excon.Add("display", "Yes");
-            SetterDeathRecord.ExaminerContacted = excon;
-            Assert.Equal("Y", SetterDeathRecord.ExaminerContacted["code"]);
-            Assert.Equal("http://terminology.hl7.org/CodeSystem/v2-0136", SetterDeathRecord.ExaminerContacted["system"]);
-            Assert.Equal("Yes", SetterDeathRecord.ExaminerContacted["display"]);
+            SetterDeathRecord.ExaminerContacted = true;
+            Assert.True(SetterDeathRecord.ExaminerContacted);
+            SetterDeathRecord.ExaminerContacted = false;
+            Assert.False(SetterDeathRecord.ExaminerContacted);
         }
 
         [Fact]
         public void Get_ExaminerContacted()
         {
-            Assert.Equal("N", ((DeathRecord)JSONRecords[0]).ExaminerContacted["code"]);
-            Assert.Equal("http://terminology.hl7.org/CodeSystem/v2-0136", ((DeathRecord)JSONRecords[0]).ExaminerContacted["system"]);
-            Assert.Equal("No", ((DeathRecord)JSONRecords[0]).ExaminerContacted["display"]);
-            Assert.Equal("N", ((DeathRecord)XMLRecords[0]).ExaminerContacted["code"]);
-            Assert.Equal("http://terminology.hl7.org/CodeSystem/v2-0136", ((DeathRecord)XMLRecords[0]).ExaminerContacted["system"]);
-            Assert.Equal("No", ((DeathRecord)XMLRecords[0]).ExaminerContacted["display"]);
+            Assert.False(((DeathRecord)JSONRecords[0]).ExaminerContacted);
+            Assert.False(((DeathRecord)XMLRecords[0]).ExaminerContacted);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1735,17 +1735,25 @@ namespace VRDR.Tests
         [Fact]
         public void Set_ExaminerContacted()
         {
-            SetterDeathRecord.ExaminerContacted = true;
-            Assert.True(SetterDeathRecord.ExaminerContacted);
-            SetterDeathRecord.ExaminerContacted = false;
-            Assert.False(SetterDeathRecord.ExaminerContacted);
+            Dictionary<string, string> excon = new Dictionary<string, string>();
+            excon.Add("code", "Y");
+            excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
+            excon.Add("display", "Yes");
+            SetterDeathRecord.ExaminerContacted = excon;
+            Assert.Equal("Y", SetterDeathRecord.ExaminerContacted["code"]);
+            Assert.Equal("http://terminology.hl7.org/CodeSystem/v2-0136", SetterDeathRecord.ExaminerContacted["system"]);
+            Assert.Equal("Yes", SetterDeathRecord.ExaminerContacted["display"]);
         }
 
         [Fact]
         public void Get_ExaminerContacted()
         {
-            Assert.False(((DeathRecord)JSONRecords[0]).ExaminerContacted);
-            Assert.False(((DeathRecord)XMLRecords[0]).ExaminerContacted);
+            Assert.Equal("N", ((DeathRecord)JSONRecords[0]).ExaminerContacted["code"]);
+            Assert.Equal("http://terminology.hl7.org/CodeSystem/v2-0136", ((DeathRecord)JSONRecords[0]).ExaminerContacted["system"]);
+            Assert.Equal("No", ((DeathRecord)JSONRecords[0]).ExaminerContacted["display"]);
+            Assert.Equal("N", ((DeathRecord)XMLRecords[0]).ExaminerContacted["code"]);
+            Assert.Equal("http://terminology.hl7.org/CodeSystem/v2-0136", ((DeathRecord)XMLRecords[0]).ExaminerContacted["system"]);
+            Assert.Equal("No", ((DeathRecord)XMLRecords[0]).ExaminerContacted["display"]);
         }
 
         [Fact]

--- a/VRDR.Tests/fixtures/json/BadConditions.json
+++ b/VRDR.Tests/fixtures/json/BadConditions.json
@@ -1260,7 +1260,13 @@
         "subject": {
           "reference": "urn:uuid:9521f45f-d8ca-4c62-9878-0686f1028bf5"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1420,5 +1426,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -1284,7 +1284,13 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1478,5 +1484,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
@@ -1278,7 +1278,13 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1472,5 +1478,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/DeathRecordSubmission.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordSubmission.json
@@ -826,7 +826,11 @@
                                 "display": "Medical examiner or coroner was contacted"
                             }]},
                             "subject": {"reference": "urn:uuid:e29e6433-1acf-4cff-b979-0f3413ce36a2"},
-                            "valueBoolean": false
+                            "valueCodeableConcept": {"coding": [{
+                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                "code": "N",
+                                "display": "No"
+                            }]}
                         }
                     },
                     {

--- a/VRDR.Tests/fixtures/json/DeathRecordSubmissionNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordSubmissionNoIdentifiers.json
@@ -785,7 +785,11 @@
                                 "display": "Medical examiner or coroner was contacted"
                             }]},
                             "subject": {"reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"},
-                            "valueBoolean": false
+                            "valueCodeableConcept": {"coding": [{
+                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                "code": "N",
+                                "display": "No"
+                            }]}
                         }
                     },
                     {

--- a/VRDR.Tests/fixtures/json/DeathRecordUpdate.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordUpdate.json
@@ -826,7 +826,13 @@
                                 "display": "Medical examiner or coroner was contacted"
                             }]},
                             "subject": {"reference": "urn:uuid:e29e6433-1acf-4cff-b979-0f3413ce36a2"},
-                            "valueBoolean": false
+                            "valueCodeableConcept": {
+                                "coding": [{
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                    "code": "N",
+                                    "display": "No"
+                                }]
+                            }
                         }
                     },
                     {

--- a/VRDR.Tests/fixtures/json/DeathRecordUpdateNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordUpdateNoIdentifiers.json
@@ -785,7 +785,13 @@
                                 "display": "Medical examiner or coroner was contacted"
                             }]},
                             "subject": {"reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"},
-                            "valueBoolean": false
+                            "valueCodeableConcept": {
+                                "coding": [{
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                    "code": "N",
+                                    "display": "No"
+                                }]
+                            }
                         }
                     },
                     {

--- a/VRDR.Tests/fixtures/json/MissingCertifier.json
+++ b/VRDR.Tests/fixtures/json/MissingCertifier.json
@@ -1190,7 +1190,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1350,5 +1356,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/MissingComposition.json
+++ b/VRDR.Tests/fixtures/json/MissingComposition.json
@@ -1081,7 +1081,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1241,5 +1247,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/MissingCompositionAttestor.json
+++ b/VRDR.Tests/fixtures/json/MissingCompositionAttestor.json
@@ -1232,7 +1232,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1392,5 +1398,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/MissingCompositionSubject.json
+++ b/VRDR.Tests/fixtures/json/MissingCompositionSubject.json
@@ -1238,7 +1238,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1398,5 +1404,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/MissingDecedent.json
+++ b/VRDR.Tests/fixtures/json/MissingDecedent.json
@@ -1099,7 +1099,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1259,5 +1265,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/MissingObservationCode.json
+++ b/VRDR.Tests/fixtures/json/MissingObservationCode.json
@@ -1235,7 +1235,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1395,5 +1401,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/json/MissingRelatedPersonRelationshipCode.json
+++ b/VRDR.Tests/fixtures/json/MissingRelatedPersonRelationshipCode.json
@@ -1237,7 +1237,13 @@
         "subject": {
           "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
         },
-        "valueBoolean": false
+        "valueCodeableConcept": {
+          "coding": [{
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+            "code": "N",
+            "display": "No"
+          }]
+        }
       }
     },
     {
@@ -1397,5 +1403,3 @@
     }
   ]
 }
-
-

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -1044,7 +1044,13 @@
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <valueBoolean value="false" />
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+            <code value="N" />
+            <display value="No" />
+          </coding>
+        </valueCodeableConcept>
       </Observation>
     </resource>
   </entry>
@@ -1207,5 +1213,3 @@
     </resource>
   </entry>
 </Bundle>
-
-

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5600,34 +5600,24 @@ namespace VRDR
 
         /// <summary>Examiner Contacted.</summary>
         /// <value>if a medical examiner was contacted.
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
         /// </value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; excon = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>excon.Add("code", "Y");</para>
-        /// <para>excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
-        /// <para>excon.Add("display", "Yes");</para>
-        /// <para>ExampleDeathRecord.ExaminerContacted = excon;</para>
+        /// <para>ExampleDeathRecord.ExaminerContacted = false;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
+        /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
         /// </example>
-        [Property("Examiner Contacted", Property.Types.Dictionary, "Death Investigation", "Examiner Contacted.", true, "http://hl7.org/fhir/us/vrdr/2019May/ExaminerContacted.html", true, 60)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
+        [Property("Examiner Contacted", Property.Types.Bool, "Death Investigation", "Examiner Contacted.", true, "http://hl7.org/fhir/us/vrdr/2019May/ExaminerContacted.html", true, 60)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='74497-9')", "")]
-        public Dictionary<string, string> ExaminerContacted
+        public bool? ExaminerContacted
         {
             get
             {
                 if (ExaminerContactedObs != null && ExaminerContactedObs.Value as CodeableConcept != null)
                 {
-                    return CodeableConceptToDict((CodeableConcept)ExaminerContactedObs.Value);
+                    return CodeableConceptToDict(((CodeableConcept)ExaminerContactedObs.Value))["code"] == "Y";
                 }
-                return EmptyCodeDict();
+                return null;
             }
             set
             {
@@ -5641,13 +5631,13 @@ namespace VRDR
                     ExaminerContactedObs.Status = ObservationStatus.Final;
                     ExaminerContactedObs.Code = new CodeableConcept("http://loinc.org", "74497-9", "Medical examiner or coroner was contacted", null);
                     ExaminerContactedObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    ExaminerContactedObs.Value = DictToCodeableConcept(value);
+                    ExaminerContactedObs.Value = BoolToCodeableConcept((Boolean)value);
                     AddReferenceToComposition(ExaminerContactedObs.Id);
                     Bundle.AddResourceEntry(ExaminerContactedObs, "urn:uuid:" + ExaminerContactedObs.Id);
                 }
                 else
                 {
-                    ExaminerContactedObs.Value = DictToCodeableConcept(value);
+                    ExaminerContactedObs.Value = BoolToCodeableConcept((Boolean)value);
                 }
             }
         }
@@ -6493,6 +6483,20 @@ namespace VRDR
                     coding.Display = dict["display"];
                 }
             }
+            codeableConcept.Coding.Add(coding);
+            return codeableConcept;
+        }
+
+        /// <summary>Convert a Boolean to a FHIR CodableConcept.</summary>
+        /// <param name="value">A true/false value.</param>
+        /// <returns>the corresponding CodeableConcept representation of the code.</returns>
+        private CodeableConcept BoolToCodeableConcept(Boolean value)
+        {
+            CodeableConcept codeableConcept = new CodeableConcept();
+            Coding coding = new Coding();
+            coding.Code = value ? "Y" : "N";
+            coding.System = "http://terminology.hl7.org/CodeSystem/v2-0136";
+            coding.Display = value ? "Yes" : "No";
             codeableConcept.Coding.Add(coding);
             return codeableConcept;
         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -4615,7 +4615,7 @@ namespace VRDR
         /// <para>mserv.Add("code", "Y");</para>
         /// <para>mserv.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
         /// <para>mserv.Add("display", "Yes");</para>
-        /// <para>ExampleDeathRecord.MilitaryService = uind;</para>
+        /// <para>ExampleDeathRecord.MilitaryService = mserv;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Military Service: {ExampleDeathRecord.MilitaryService['display']}");</para>
         /// </example>
@@ -5599,24 +5599,35 @@ namespace VRDR
         }
 
         /// <summary>Examiner Contacted.</summary>
-        /// <value>if a medical examiner was contacted.</value>
+        /// <value>if a medical examiner was contacted.
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.ExaminerContacted = false;</para>
+        /// <para>Dictionary&lt;string, string&gt; excon = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>excon.Add("code", "Y");</para>
+        /// <para>excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
+        /// <para>excon.Add("display", "Yes");</para>
+        /// <para>ExampleDeathRecord.ExaminerContacted = excon;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
+        /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
         /// </example>
-        [Property("Examiner Contacted", Property.Types.Bool, "Death Investigation", "Examiner Contacted.", true, "http://hl7.org/fhir/us/vrdr/2019May/ExaminerContacted.html", true, 60)]
+        [Property("Examiner Contacted", Property.Types.Dictionary, "Death Investigation", "Examiner Contacted.", true, "http://hl7.org/fhir/us/vrdr/2019May/ExaminerContacted.html", true, 60)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='74497-9')", "")]
-        public bool? ExaminerContacted
+        public Dictionary<string, string> ExaminerContacted
         {
             get
             {
-                if (ExaminerContactedObs != null && ExaminerContactedObs.Value != null)
+                if (ExaminerContactedObs != null && ExaminerContactedObs.Value as CodeableConcept != null)
                 {
-                    return ((FhirBoolean)ExaminerContactedObs.Value).Value == true;
+                    return CodeableConceptToDict((CodeableConcept)ExaminerContactedObs.Value);
                 }
-                return null;
+                return EmptyCodeDict();
             }
             set
             {
@@ -5630,13 +5641,13 @@ namespace VRDR
                     ExaminerContactedObs.Status = ObservationStatus.Final;
                     ExaminerContactedObs.Code = new CodeableConcept("http://loinc.org", "74497-9", "Medical examiner or coroner was contacted", null);
                     ExaminerContactedObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    ExaminerContactedObs.Value = new FhirBoolean(value);
+                    ExaminerContactedObs.Value = DictToCodeableConcept(value);
                     AddReferenceToComposition(ExaminerContactedObs.Id);
                     Bundle.AddResourceEntry(ExaminerContactedObs, "urn:uuid:" + ExaminerContactedObs.Id);
                 }
                 else
                 {
-                    ExaminerContactedObs.Value = new FhirBoolean(value);
+                    ExaminerContactedObs.Value = DictToCodeableConcept(value);
                 }
             }
         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5600,24 +5600,34 @@ namespace VRDR
 
         /// <summary>Examiner Contacted.</summary>
         /// <value>if a medical examiner was contacted.
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
         /// </value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.ExaminerContacted = false;</para>
+        /// <para>Dictionary&lt;string, string&gt; excon = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>excon.Add("code", "Y");</para>
+        /// <para>excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
+        /// <para>excon.Add("display", "Yes");</para>
+        /// <para>ExampleDeathRecord.ExaminerContacted = excon;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
+        /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
         /// </example>
-        [Property("Examiner Contacted", Property.Types.Bool, "Death Investigation", "Examiner Contacted.", true, "http://hl7.org/fhir/us/vrdr/2019May/ExaminerContacted.html", true, 60)]
+        [Property("Examiner Contacted", Property.Types.Dictionary, "Death Investigation", "Examiner Contacted.", true, "http://hl7.org/fhir/us/vrdr/2019May/ExaminerContacted.html", true, 60)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='74497-9')", "")]
-        public bool? ExaminerContacted
+        public Dictionary<string, string> ExaminerContacted
         {
             get
             {
                 if (ExaminerContactedObs != null && ExaminerContactedObs.Value as CodeableConcept != null)
                 {
-                    return CodeableConceptToDict(((CodeableConcept)ExaminerContactedObs.Value))["code"] == "Y";
+                    return CodeableConceptToDict((CodeableConcept)ExaminerContactedObs.Value);
                 }
-                return null;
+                return EmptyCodeDict();
             }
             set
             {
@@ -5631,13 +5641,13 @@ namespace VRDR
                     ExaminerContactedObs.Status = ObservationStatus.Final;
                     ExaminerContactedObs.Code = new CodeableConcept("http://loinc.org", "74497-9", "Medical examiner or coroner was contacted", null);
                     ExaminerContactedObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    ExaminerContactedObs.Value = BoolToCodeableConcept((Boolean)value);
+                    ExaminerContactedObs.Value = DictToCodeableConcept(value);
                     AddReferenceToComposition(ExaminerContactedObs.Id);
                     Bundle.AddResourceEntry(ExaminerContactedObs, "urn:uuid:" + ExaminerContactedObs.Id);
                 }
                 else
                 {
-                    ExaminerContactedObs.Value = BoolToCodeableConcept((Boolean)value);
+                    ExaminerContactedObs.Value = DictToCodeableConcept(value);
                 }
             }
         }
@@ -6483,20 +6493,6 @@ namespace VRDR
                     coding.Display = dict["display"];
                 }
             }
-            codeableConcept.Coding.Add(coding);
-            return codeableConcept;
-        }
-
-        /// <summary>Convert a Boolean to a FHIR CodableConcept.</summary>
-        /// <param name="value">A true/false value.</param>
-        /// <returns>the corresponding CodeableConcept representation of the code.</returns>
-        private CodeableConcept BoolToCodeableConcept(Boolean value)
-        {
-            CodeableConcept codeableConcept = new CodeableConcept();
-            Coding coding = new Coding();
-            coding.Code = value ? "Y" : "N";
-            coding.System = "http://terminology.hl7.org/CodeSystem/v2-0136";
-            coding.Display = value ? "Yes" : "No";
             codeableConcept.Coding.Add(coding);
             return codeableConcept;
         }

--- a/VRDR/DeathRecord.md
+++ b/VRDR/DeathRecord.md
@@ -348,7 +348,6 @@
   - [Get_Race_NHOPI_Literals()](#M-VRDR-IJEMortality-Get_Race_NHOPI_Literals 'VRDR.IJEMortality.Get_Race_NHOPI_Literals')
   - [Get_Race_OTHER_Literals()](#M-VRDR-IJEMortality-Get_Race_OTHER_Literals 'VRDR.IJEMortality.Get_Race_OTHER_Literals')
   - [Get_Race_W_Literals()](#M-VRDR-IJEMortality-Get_Race_W_Literals 'VRDR.IJEMortality.Get_Race_W_Literals')
-  - [Get_YNU()](#M-VRDR-IJEMortality-Get_YNU-System-String- 'VRDR.IJEMortality.Get_YNU(System.String)')
   - [HispanicOrigin()](#M-VRDR-IJEMortality-HispanicOrigin 'VRDR.IJEMortality.HispanicOrigin')
   - [HispanicOriginOther()](#M-VRDR-IJEMortality-HispanicOriginOther 'VRDR.IJEMortality.HispanicOriginOther')
   - [LeftJustified_Get()](#M-VRDR-IJEMortality-LeftJustified_Get-System-String,System-String- 'VRDR.IJEMortality.LeftJustified_Get(System.String,System.String)')
@@ -356,7 +355,6 @@
   - [RightJustifiedZeroed_Get()](#M-VRDR-IJEMortality-RightJustifiedZeroed_Get-System-String,System-String- 'VRDR.IJEMortality.RightJustifiedZeroed_Get(System.String,System.String)')
   - [RightJustifiedZeroed_Set()](#M-VRDR-IJEMortality-RightJustifiedZeroed_Set-System-String,System-String,System-String- 'VRDR.IJEMortality.RightJustifiedZeroed_Set(System.String,System.String,System.String)')
   - [Set_Race()](#M-VRDR-IJEMortality-Set_Race-System-String,System-String- 'VRDR.IJEMortality.Set_Race(System.String,System.String)')
-  - [Set_YNU()](#M-VRDR-IJEMortality-Set_YNU-System-String,System-String- 'VRDR.IJEMortality.Set_YNU(System.String,System.String)')
   - [ToDeathRecord()](#M-VRDR-IJEMortality-ToDeathRecord 'VRDR.IJEMortality.ToDeathRecord')
   - [ToString()](#M-VRDR-IJEMortality-ToString 'VRDR.IJEMortality.ToString')
   - [Truncate()](#M-VRDR-IJEMortality-Truncate-System-String,System-Int32- 'VRDR.IJEMortality.Truncate(System.String,System.Int32)')
@@ -4687,17 +4685,6 @@ Retrieves White Race literals on the record.
 
 This method has no parameters.
 
-<a name='M-VRDR-IJEMortality-Get_YNU-System-String-'></a>
-### Get_YNU() `method`
-
-##### Summary
-
-Gets a "Yes", "No", or "Unkown" value.
-
-##### Parameters
-
-This method has no parameters.
-
 <a name='M-VRDR-IJEMortality-HispanicOrigin'></a>
 ### HispanicOrigin() `method`
 
@@ -4770,17 +4757,6 @@ This method has no parameters.
 ##### Summary
 
 Adds the given race to the record.
-
-##### Parameters
-
-This method has no parameters.
-
-<a name='M-VRDR-IJEMortality-Set_YNU-System-String,System-String-'></a>
-### Set_YNU() `method`
-
-##### Summary
-
-Sets a "Yes", "No", or "Unkown" value.
 
 ##### Parameters
 

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1725,12 +1725,19 @@
         <member name="P:VRDR.DeathRecord.ExaminerContacted">
             <summary>Examiner Contacted.</summary>
             <value>if a medical examiner was contacted.
+            <para>"code" - the code</para>
+            <para>"system" - the code system this code belongs to</para>
+            <para>"display" - a human readable meaning of the code</para>
             </value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleDeathRecord.ExaminerContacted = false;</para>
+            <para>Dictionary&lt;string, string&gt; excon = new Dictionary&lt;string, string&gt;();</para>
+            <para>excon.Add("code", "Y");</para>
+            <para>excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
+            <para>excon.Add("display", "Yes");</para>
+            <para>ExampleDeathRecord.ExaminerContacted = excon;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
+            <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
             </example>
         </member>
         <member name="P:VRDR.DeathRecord.InjuryLocationAddress">
@@ -1880,11 +1887,6 @@
         <member name="M:VRDR.DeathRecord.DictToCodeableConcept(System.Collections.Generic.Dictionary{System.String,System.String})">
             <summary>Convert a "code" dictionary to a FHIR CodableConcept.</summary>
             <param name="dict">represents a code.</param>
-            <returns>the corresponding CodeableConcept representation of the code.</returns>
-        </member>
-        <member name="M:VRDR.DeathRecord.BoolToCodeableConcept(System.Boolean)">
-            <summary>Convert a Boolean to a FHIR CodableConcept.</summary>
-            <param name="value">A true/false value.</param>
             <returns>the corresponding CodeableConcept representation of the code.</returns>
         </member>
         <member name="M:VRDR.DeathRecord.CodeableConceptToDict(Hl7.Fhir.Model.CodeableConcept)">
@@ -2170,12 +2172,6 @@
         </member>
         <member name="M:VRDR.IJEMortality.Set_Race(System.String,System.String)">
             <summary>Adds the given race to the record.</summary>
-        </member>
-        <member name="M:VRDR.IJEMortality.Get_YNU(System.String)">
-            <summary>Gets a "Yes", "No", or "Unkown" value.</summary>
-        </member>
-        <member name="M:VRDR.IJEMortality.Set_YNU(System.String,System.String)">
-            <summary>Sets a "Yes" or "No" value.</summary>
         </member>
         <member name="P:VRDR.IJEMortality.DOD_YR">
             <summary>Date of Death--Year</summary>

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1441,7 +1441,7 @@
             <para>mserv.Add("code", "Y");</para>
             <para>mserv.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
             <para>mserv.Add("display", "Yes");</para>
-            <para>ExampleDeathRecord.MilitaryService = uind;</para>
+            <para>ExampleDeathRecord.MilitaryService = mserv;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Military Service: {ExampleDeathRecord.MilitaryService['display']}");</para>
             </example>
@@ -1724,12 +1724,20 @@
         </member>
         <member name="P:VRDR.DeathRecord.ExaminerContacted">
             <summary>Examiner Contacted.</summary>
-            <value>if a medical examiner was contacted.</value>
+            <value>if a medical examiner was contacted.
+            <para>"code" - the code</para>
+            <para>"system" - the code system this code belongs to</para>
+            <para>"display" - a human readable meaning of the code</para>
+            </value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleDeathRecord.ExaminerContacted = false;</para>
+            <para>Dictionary&lt;string, string&gt; excon = new Dictionary&lt;string, string&gt;();</para>
+            <para>excon.Add("code", "Y");</para>
+            <para>excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
+            <para>excon.Add("display", "Yes");</para>
+            <para>ExampleDeathRecord.ExaminerContacted = excon;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
+            <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
             </example>
         </member>
         <member name="P:VRDR.DeathRecord.InjuryLocationAddress">
@@ -2123,6 +2131,12 @@
         <member name="M:VRDR.IJEMortality.Dictionary_Set(System.String,System.String,System.String,System.String)">
             <summary>Set a value on the DeathRecord whose property is a Dictionary type.</summary>
         </member>
+        <member name="M:VRDR.IJEMortality.Dictionary_YNU_Get(System.String,System.String)">
+            <summary>Get a value from the DeathRecord whose property is a Yes/No/Unknown value (and is contained in a dictionary).</summary>
+        </member>
+        <member name="M:VRDR.IJEMortality.Dictionary_YNU_Set(System.String,System.String,System.String)">
+            <summary>Set the value on the DeathRecord whose property is a Yes/No/Unknown value (and is contained in a dictionary).</summary>
+        </member>
         <member name="M:VRDR.IJEMortality.Dictionary_Geo_Get(System.String,System.String,System.String,System.String,System.Boolean)">
             <summary>Get a value on the DeathRecord whose property is a geographic type (and is contained in a dictionary).</summary>
         </member>
@@ -2158,12 +2172,6 @@
         </member>
         <member name="M:VRDR.IJEMortality.Set_Race(System.String,System.String)">
             <summary>Adds the given race to the record.</summary>
-        </member>
-        <member name="M:VRDR.IJEMortality.Get_YNU(System.String)">
-            <summary>Gets a "Yes", "No", or "Unknown" value.</summary>
-        </member>
-        <member name="M:VRDR.IJEMortality.Set_YNU(System.String,System.String)">
-            <summary>Sets a "Yes", "No", or "Unkown" value.</summary>
         </member>
         <member name="P:VRDR.IJEMortality.DOD_YR">
             <summary>Date of Death--Year</summary>

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1725,19 +1725,12 @@
         <member name="P:VRDR.DeathRecord.ExaminerContacted">
             <summary>Examiner Contacted.</summary>
             <value>if a medical examiner was contacted.
-            <para>"code" - the code</para>
-            <para>"system" - the code system this code belongs to</para>
-            <para>"display" - a human readable meaning of the code</para>
             </value>
             <example>
             <para>// Setter:</para>
-            <para>Dictionary&lt;string, string&gt; excon = new Dictionary&lt;string, string&gt;();</para>
-            <para>excon.Add("code", "Y");</para>
-            <para>excon.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
-            <para>excon.Add("display", "Yes");</para>
-            <para>ExampleDeathRecord.ExaminerContacted = excon;</para>
+            <para>ExampleDeathRecord.ExaminerContacted = false;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
+            <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
             </example>
         </member>
         <member name="P:VRDR.DeathRecord.InjuryLocationAddress">
@@ -1887,6 +1880,11 @@
         <member name="M:VRDR.DeathRecord.DictToCodeableConcept(System.Collections.Generic.Dictionary{System.String,System.String})">
             <summary>Convert a "code" dictionary to a FHIR CodableConcept.</summary>
             <param name="dict">represents a code.</param>
+            <returns>the corresponding CodeableConcept representation of the code.</returns>
+        </member>
+        <member name="M:VRDR.DeathRecord.BoolToCodeableConcept(System.Boolean)">
+            <summary>Convert a Boolean to a FHIR CodableConcept.</summary>
+            <param name="value">A true/false value.</param>
             <returns>the corresponding CodeableConcept representation of the code.</returns>
         </member>
         <member name="M:VRDR.DeathRecord.CodeableConceptToDict(Hl7.Fhir.Model.CodeableConcept)">
@@ -2172,6 +2170,12 @@
         </member>
         <member name="M:VRDR.IJEMortality.Set_Race(System.String,System.String)">
             <summary>Adds the given race to the record.</summary>
+        </member>
+        <member name="M:VRDR.IJEMortality.Get_YNU(System.String)">
+            <summary>Gets a "Yes", "No", or "Unkown" value.</summary>
+        </member>
+        <member name="M:VRDR.IJEMortality.Set_YNU(System.String,System.String)">
+            <summary>Sets a "Yes" or "No" value.</summary>
         </member>
         <member name="P:VRDR.IJEMortality.DOD_YR">
             <summary>Date of Death--Year</summary>

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -685,6 +685,32 @@ namespace VRDR
             record.Race = raceStatus.Distinct().ToList().ToArray();
         }
 
+        /// <summary>Gets a "Yes", "No", or "Unkown" value.</summary>
+        private string Get_YNU(string fhirFieldName)
+        {
+            object status = typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
+            if (status == null)
+            {
+                return "U";
+            }
+            else
+            {
+                return ((bool)status) ? "Y" : "N";
+            }
+        }
+
+        /// <summary>Sets a "Yes" or "No" value.</summary>
+        private void Set_YNU(string fhirFieldName, string value)
+        {
+            if (value == "Y")
+            {
+                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, true);
+            }
+            else if (value == "N")
+            {
+                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, false);
+            }
+        }
 
         /////////////////////////////////////////////////////////////////////////////////
         //
@@ -3137,12 +3163,14 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_YNU_Get("REFERRED", "ExaminerContacted");
-
+                return Get_YNU("ExaminerContacted");
             }
             set
             {
-                Dictionary_YNU_Set("REFERRED", "ExaminerContacted", value);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Set_YNU("ExaminerContacted", value);
+                }
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -685,32 +685,6 @@ namespace VRDR
             record.Race = raceStatus.Distinct().ToList().ToArray();
         }
 
-        /// <summary>Gets a "Yes", "No", or "Unkown" value.</summary>
-        private string Get_YNU(string fhirFieldName)
-        {
-            object status = typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
-            if (status == null)
-            {
-                return "U";
-            }
-            else
-            {
-                return ((bool)status) ? "Y" : "N";
-            }
-        }
-
-        /// <summary>Sets a "Yes" or "No" value.</summary>
-        private void Set_YNU(string fhirFieldName, string value)
-        {
-            if (value == "Y")
-            {
-                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, true);
-            }
-            else if (value == "N")
-            {
-                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, false);
-            }
-        }
 
         /////////////////////////////////////////////////////////////////////////////////
         //
@@ -3163,14 +3137,12 @@ namespace VRDR
         {
             get
             {
-                return Get_YNU("ExaminerContacted");
+                return Dictionary_YNU_Get("REFERRED", "ExaminerContacted");
+
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    Set_YNU("ExaminerContacted", value);
-                }
+                Dictionary_YNU_Set("REFERRED", "ExaminerContacted", value);
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -398,6 +398,48 @@ namespace VRDR
             typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, dictionary);
         }
 
+        /// <summary>Get a value from the DeathRecord whose property is a Yes/No/Unknown value (and is contained in a dictionary).</summary>
+        private string Dictionary_YNU_Get(string ijeFieldName, string fhirFieldName)
+        {
+            string code = Dictionary_Get_Full(ijeFieldName, fhirFieldName, "code");
+            switch (code)
+            {
+                case "Y": // Yes
+                    return "Y";
+                case "N": // No
+                    return "N";
+                case "UNK": // Unknown
+                    return "U";
+            }
+            return "";
+        }
+
+        /// <summary>Set the value on the DeathRecord whose property is a Yes/No/Unknown value (and is contained in a dictionary).</summary>
+        private void Dictionary_YNU_Set(string ijeFieldName, string fhirFieldName, string value)
+        {
+            if (!String.IsNullOrWhiteSpace(value))
+            {
+                switch (value)
+                {
+                    case "Y":
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "code", "Y");
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "display", "Yes");
+                        break;
+                    case "N":
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "code", "N");
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "display", "No");
+                        break;
+                    case "U":
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "code", "UNK");
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "system", "http://hl7.org/fhir/v3/NullFlavor");
+                        Dictionary_Set(ijeFieldName, fhirFieldName, "display", "Unknown");
+                        break;
+                }
+            }
+        }
+
         /// <summary>Get a value on the DeathRecord whose property is a geographic type (and is contained in a dictionary).</summary>
         private string Dictionary_Geo_Get(string ijeFieldName, string fhirFieldName, string keyPrefix, string geoType, bool isCoded)
         {
@@ -641,33 +683,6 @@ namespace VRDR
             List<Tuple<string, string>> raceStatus = record.Race.ToList();
             raceStatus.Add(Tuple.Create(display, code));
             record.Race = raceStatus.Distinct().ToList().ToArray();
-        }
-
-        /// <summary>Gets a "Yes", "No", or "Unknown" value.</summary>
-        private string Get_YNU(string fhirFieldName)
-        {
-            object status = typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
-            if (status == null)
-            {
-                return "U";
-            }
-            else
-            {
-                return ((bool)status) ? "Y" : "N";
-            }
-        }
-
-        /// <summary>Sets a "Yes", "No", or "Unkown" value.</summary>
-        private void Set_YNU(string fhirFieldName, string value)
-        {
-            if (value != "U" && value == "Y")
-            {
-                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, true);
-            }
-            else if (value != "U" && value == "N")
-            {
-                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, false);
-            }
         }
 
 
@@ -2546,41 +2561,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("AUTOP", "AutopsyPerformedIndicator", "code");
-                switch (code)
-                {
-                    case "Y": // Yes
-                        return "Y";
-                    case "N": // No
-                        return "N";
-                    case "UNK": // Unknown
-                        return "U";
-                }
-                return "";
+                return Dictionary_YNU_Get("AUTOP", "AutopsyPerformedIndicator");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "Y":
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "code", "Y");
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "display", "Yes");
-                            break;
-                        case "N":
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "code", "N");
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "display", "No");
-                            break;
-                        case "U":
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "code", "UNK");
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "system", "http://hl7.org/fhir/v3/NullFlavor");
-                            Dictionary_Set("AUTOP", "AutopsyPerformedIndicator", "display", "Unknown");
-                            break;
-                    }
-                }
+                Dictionary_YNU_Set("AUTOP", "AutopsyPerformedIndicator", value);
             }
         }
 
@@ -2590,41 +2575,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("AUTOPF", "AutopsyResultsAvailable", "code");
-                switch (code)
-                {
-                    case "Y": // Yes
-                        return "Y";
-                    case "N": // No
-                        return "N";
-                    case "UNK": // Unknown
-                        return "U";
-                }
-                return "";
+                return Dictionary_YNU_Get("AUTOPF", "AutopsyResultsAvailable");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "Y":
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "code", "Y");
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "display", "Yes");
-                            break;
-                        case "N":
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "code", "N");
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "display", "No");
-                            break;
-                        case "U":
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "code", "UNK");
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "system", "http://hl7.org/fhir/v3/NullFlavor");
-                            Dictionary_Set("AUTOPF", "AutopsyResultsAvailable", "display", "Unknown");
-                            break;
-                    }
-                }
+                Dictionary_YNU_Set("AUTOPF", "AutopsyResultsAvailable", value);
             }
         }
 
@@ -2825,41 +2780,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("WORKINJ", "InjuryAtWork", "code");
-                switch (code)
-                {
-                    case "Y": // Yes
-                        return "Y";
-                    case "N": // No
-                        return "N";
-                    case "UNK": // Unknown
-                        return "U";
-                }
-                return "";
+                return Dictionary_YNU_Get("WORKINJ", "InjuryAtWork");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "Y":
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "code", "Y");
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "display", "Yes");
-                            break;
-                        case "N":
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "code", "N");
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "display", "No");
-                            break;
-                        case "U":
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "code", "UNK");
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "system", "http://hl7.org/fhir/v3/NullFlavor");
-                            Dictionary_Set("WORKINJ", "InjuryAtWork", "display", "Unknown");
-                            break;
-                    }
-                }
+                Dictionary_YNU_Set("WORKINJ", "InjuryAtWork", value);
             }
         }
 
@@ -2951,41 +2876,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("ARMEDF", "MilitaryService", "code");
-                switch (code)
-                {
-                    case "Y": // Yes
-                        return "Y";
-                    case "N": // No
-                        return "N";
-                    case "UNK": // Unknown
-                        return "U";
-                }
-                return "";
+                return Dictionary_YNU_Get("ARMEDF", "MilitaryService");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "Y":
-                            Dictionary_Set("ARMEDF", "MilitaryService", "code", "Y");
-                            Dictionary_Set("ARMEDF", "MilitaryService", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("ARMEDF", "MilitaryService", "display", "Yes");
-                            break;
-                        case "N":
-                            Dictionary_Set("ARMEDF", "MilitaryService", "code", "N");
-                            Dictionary_Set("ARMEDF", "MilitaryService", "system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                            Dictionary_Set("ARMEDF", "MilitaryService", "display", "No");
-                            break;
-                        case "U":
-                            Dictionary_Set("ARMEDF", "MilitaryService", "code", "UNK");
-                            Dictionary_Set("ARMEDF", "MilitaryService", "system", "http://hl7.org/fhir/v3/NullFlavor");
-                            Dictionary_Set("ARMEDF", "MilitaryService", "display", "Unknown");
-                            break;
-                    }
-                }
+                Dictionary_YNU_Set("ARMEDF", "MilitaryService", value);
             }
         }
 
@@ -3242,14 +3137,12 @@ namespace VRDR
         {
             get
             {
-                return Get_YNU("ExaminerContacted");
+                return Dictionary_YNU_Get("REFERRED", "ExaminerContacted");
+
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    Set_YNU("ExaminerContacted", value);
-                }
+                Dictionary_YNU_Set("REFERRED", "ExaminerContacted", value);
             }
         }
 


### PR DESCRIPTION
This PR builds on top of #116 to replace the user API with a CodeableConcept Dictionary for ExaminerContacted, which is consistent with what it actually is when XML and JSON documents are generated.

The diff view is currently very confusing since this PR is setup where it should work fine if rebased after the backend PR is merged.