### PR TITLE
Add additional fields to CodedResponseMessage

### DIFF
--- a/VRDR.Messaging/CodingResponseMessage.cs
+++ b/VRDR.Messaging/CodingResponseMessage.cs
@@ -69,7 +69,7 @@ namespace VRDR
                 var list = new List<Tuple<string, Base>>();
                 foreach (KeyValuePair<HispanicOrigin, string> item in value)
                 {
-                    var part = Tuple.Create(item.Key.ToString(), 
+                    var part = Tuple.Create(item.Key.ToString(),
                         (Base)(new Coding("https://www.cdc.gov/nchs/data/dvs/HispanicCodeTitles.pdf", item.Value)));
                     list.Add(part);
                 }
@@ -140,11 +140,264 @@ namespace VRDR
                 var list = new List<Tuple<string, Base>>();
                 foreach (KeyValuePair<RaceCode, string> item in value)
                 {
-                    var part = Tuple.Create(item.Key.ToString(), 
-                        (Base)(new Coding("https://www.cdc.gov/nchs/data/dvs/RaceCodeList.pdf", item.Value)));
+                    string codeList = "https://www.cdc.gov/nchs/data/dvs/RaceCodeList.pdf";
+                    // Special case for RACEBRG, it uses a different code document
+                    if(item.Key == RaceCode.RACEBRG) {
+                        codeList = "https://www.cdc.gov/nchs/data/dvs/Multiple_race_documentation_5-10-04.pdf";
+                    }
+                    var part = Tuple.Create(item.Key.ToString(),
+                        (Base)(new Coding(codeList, item.Value)));
                     list.Add(part);
                 }
                 Record.Add("race", list);
+            }
+        }
+
+        /// <summary>Coder Status (Numeric, 0-9)</summary>
+        public uint? CoderStatus
+        {
+            get
+            {
+                return (uint?)Record.GetSingleValue<UnsignedInt>("cs")?.Value;
+            }
+            set
+            {
+                Record.Remove("cs");
+                if (value != null)
+                {
+                    if (value < 0 || value > 9) {
+                        throw new ArgumentException("Valid values for CoderStatus are 0-9 or null");
+                    }
+                    Record.Add("cs", new UnsignedInt((int)value));
+                }
+            }
+        }
+
+        /// <summary>Shipment Number (Alpha Numeric)</summary>
+        public string ShipmentNumber
+        {
+            get
+            {
+                return Record.GetSingleValue<FhirString>("ship")?.Value;
+            }
+            set
+            {
+                Record.Remove("ship");
+                if (value != null)
+                {
+                    Record.Add("ship", new FhirString(value));
+                }
+            }
+        }
+
+        /// <summary>NCHS Receipt Date Month (Numeric, 01-12 or null)</summary>
+        public uint? NCHSReceiptMonth
+        {
+            get
+            {
+                return (uint?)Record.GetSingleValue<UnsignedInt>("rec_mo")?.Value;
+            }
+            set
+            {
+                Record.Remove("rec_mo");
+                if (value != null)
+                {
+                    if (value < 1 || value > 12) {
+                        throw new ArgumentException("Valid values for NCHS Receipt Month are 01-12 or null");
+                    }
+                    Record.Add("rec_mo", new UnsignedInt((int)value));
+                }
+            }
+        }
+
+        /// <summary>NCHS Receipt Date Day (Numeric, 01-31 or blank)</summary>
+        public uint? NCHSReceiptDay
+        {
+            get
+            {
+                return (uint?)Record.GetSingleValue<UnsignedInt>("rec_dy")?.Value;
+            }
+            set
+            {
+                Record.Remove("rec_dy");
+                if (value != null)
+                {
+                    if (value < 1 || value > 31) {
+                        throw new ArgumentException("Valid values for NCHS Receipt Day are 01-31 or null");
+                    }
+                    Record.Add("rec_dy", new UnsignedInt((int)value));
+                }
+            }
+        }
+
+        /// <summary>NCHS Receipt Date Year (Numeric, Greater than year of death or blank)</summary>
+        public uint? NCHSReceiptYear
+        {
+            get
+            {
+                return (uint?)Record.GetSingleValue<UnsignedInt>("rec_yr")?.Value;
+            }
+            set
+            {
+                Record.Remove("rec_yr");
+                if (value != null)
+                {
+                    if (DeathYear != null && value < DeathYear) {
+                        throw new ArgumentException("NCHS Receipt Year must be greater than Death Year, or null");
+                    }
+                    Record.Add("rec_yr", new UnsignedInt((int)value));
+                }
+            }
+        }
+
+        /// <summary>Manner of Death Enum</summary>
+        public enum MannerOfDeathEnum
+        {
+            /// <summary>Natural cause of death</summary>
+            Natural,
+            /// <summary>Accident cause of death</summary>
+            Accident,
+            /// <summary>Suicide cause of death</summary>
+            Suicide,
+            /// <summary>Cause of death is pending investigation</summary>
+            PendingInvestigation,
+            /// <summary>Cause of death could not be determined</summary>
+            CouldNotBeDetermined
+        }
+
+        /// <summary>Manner of Death (or null)</summary>
+        public MannerOfDeathEnum? MannerOfDeath
+        {
+            get
+            {
+                string value = Record.GetSingleValue<FhirString>("manner")?.Value;
+                if(value == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    Enum.TryParse<MannerOfDeathEnum>(value, out MannerOfDeathEnum code);
+                    return code;
+                }
+            }
+            set
+            {
+                Record.Remove("manner");
+                if(value != null)
+                {
+                    Record.Add("manner", new FhirString(value.ToString()));
+                }
+            }
+        }
+
+        /// <summary>Intentional reject (1-5, 9 or null)</summary>
+        public uint? IntentionalReject
+        {
+            get
+            {
+                return (uint?)Record.GetSingleValue<UnsignedInt>("int_rej")?.Value;
+            }
+            set
+            {
+                Record.Remove("int_rej");
+                if (value != null)
+                {
+                    if (value != 9 || value > 5 || value < 1) {
+                        throw new ArgumentException("Intentional Reject must equal 1-5, 9, or null.");
+                    }
+                    Record.Add("int_rej", new UnsignedInt((int)value));
+                }
+            }
+        }
+
+        /// <summary>ACME System Reject Enum</summary>
+        public enum ACMESystemRejectEnum
+        {
+            /// <summary>MICAR Reject - Dictionary Match</summary>
+            MICARRejectDictionaryMatch,
+            /// <summary>ACME Reject</summary>
+            ACMEReject,
+            /// <summary>MICAR Reject - Rule Application</summary>
+            MICARRejectRuleApplication,
+            /// <summary>Not Rejected</summary>
+            NotRejected,
+        }
+
+        /// <summary>ACME system reject codes (or null)</summary>
+        public ACMESystemRejectEnum? ACMESystemRejectCodes
+        {
+            get
+            {
+                string value = Record.GetSingleValue<FhirString>("sys_rej")?.Value;
+                if(value == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    Enum.TryParse<ACMESystemRejectEnum>(value, out ACMESystemRejectEnum code);
+                    return code;
+                }
+            }
+            set
+            {
+                Record.Remove("sys_rej");
+                if(value != null)
+                {
+                    Record.Add("sys_rej", new FhirString(value.ToString()));
+                }
+            }
+        }
+
+        /// <summary>Place of Injury Enum</summary>
+        public enum PlaceOfInjuryEnum
+        {
+            /// <summary>Home</summary>
+            Home,
+            /// <summary>Residential Institution</summary>
+            ResidentialInstution,
+            /// <summary>School, Other Institutions, Public Administrative Area</summary>
+            SchoolOtherInstutionOrPublicAdministrativeArea,
+            /// <summary>Sports and Atheletics Area</summary>
+            SportsAndAthleticsArea,
+            /// <summary>Street/Highway</summary>
+            StreetOrHighway,
+            /// <summary>Trade and Service Area</summary>
+            TradeAndServiceArea,
+            /// <summary>Industrial and Construction Area</summary>
+            IndustrialAndConstructionArea,
+            /// <summary>Farm</summary>
+            Farm,
+            /// <summary>Other Specified Place</summary>
+            OtherSpecifiedPlace,
+            /// <summary>Unspecified Place</summary>
+            UnspecifiedPlace
+        }
+
+        /// <summary>Place of Injury (or null)</summary>
+        public PlaceOfInjuryEnum? PlaceOfInjury
+        {
+            get
+            {
+                string value = Record.GetSingleValue<FhirString>("injpl")?.Value;
+                if(value == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    Enum.TryParse<PlaceOfInjuryEnum>(value, out PlaceOfInjuryEnum code);
+                    return code;
+                }
+            }
+            set
+            {
+                Record.Remove("injpl");
+                if(value != null)
+                {
+                    Record.Add("injpl", new FhirString(value.ToString()));
+                }
             }
         }
 
@@ -185,7 +438,7 @@ namespace VRDR
                 var list = new List<Tuple<string, Base>>();
                 foreach (string code in value)
                 {
-                    var part = Tuple.Create("coding", 
+                    var part = Tuple.Create("coding",
                         (Base)(new Coding("http://hl7.org/fhir/ValueSet/icd-10", code)));
                     list.Add(part);
                 }
@@ -271,7 +524,7 @@ namespace VRDR
     /// <summary>Class for structuring a cause of death entity axis entry</summary>
     public class CauseOfDeathEntityAxisEntry
     {
-        /// <summary>Identifies the line number (values "1" to "6") of the corresponding cause of death entered on the 
+        /// <summary>Identifies the line number (values "1" to "6") of the corresponding cause of death entered on the
         /// death certificate. The following list shows the corresponding line in the death certificate for each value.</summary>
         /// <list type="number">
         /// <item>Part I. Line a</item>

--- a/VRDR.Messaging/CodingResponseMessage.cs
+++ b/VRDR.Messaging/CodingResponseMessage.cs
@@ -357,6 +357,8 @@ namespace VRDR
             ACMEReject,
             /// <summary>MICAR Reject - Rule Application</summary>
             MICARRejectRuleApplication,
+            /// <summary>Record Reviewed</summary>
+            RecordReviewed,
             /// <summary>Not Rejected</summary>
             NotRejected,
         }

--- a/VRDR.Messaging/CodingResponseMessage.cs
+++ b/VRDR.Messaging/CodingResponseMessage.cs
@@ -153,22 +153,19 @@ namespace VRDR
             }
         }
 
-        /// <summary>Coder Status (Numeric, 0-9)</summary>
-        public uint? CoderStatus
+        /// <summary>Coder Status (string, 0-9 or null)</summary>
+        public string CoderStatus
         {
             get
             {
-                return (uint?)Record.GetSingleValue<UnsignedInt>("cs")?.Value;
+                return Record.GetSingleValue<Coding>("cs")?.Code;
             }
             set
             {
                 Record.Remove("cs");
                 if (value != null)
                 {
-                    if (value < 0 || value > 9) {
-                        throw new ArgumentException("Valid values for CoderStatus are 0-9 or null");
-                    }
-                    Record.Add("cs", new UnsignedInt((int)value));
+                    Record.Add("cs", new Coding("https://ftp.cdc.gov/pub/Health_Statistics/NCHS/Software/MICAR/Data_Entry_Software/ACME_TRANSAX/Documentation/auser.pdf", value));
                 }
             }
         }
@@ -210,6 +207,20 @@ namespace VRDR
             }
         }
 
+        /// <summary>NCHS Receipt Date Month (string, 01-12 or null)</summary>
+        public string NCHSReceiptMonthString
+        {
+            get
+            {
+                uint? month = this.NCHSReceiptMonth;
+                return (month != null) ? month.ToString().PadLeft(2, '0') : null;
+            }
+            set
+            {
+                this.NCHSReceiptMonth = (value != null) ? Convert.ToUInt32(value) : (uint?)null;
+            }
+        }
+
         /// <summary>NCHS Receipt Date Day (Numeric, 01-31 or blank)</summary>
         public uint? NCHSReceiptDay
         {
@@ -230,7 +241,21 @@ namespace VRDR
             }
         }
 
-        /// <summary>NCHS Receipt Date Year (Numeric, Greater than year of death or blank)</summary>
+        /// <summary>NCHS Receipt Date Day (string, 01-31 or null)</summary>
+        public string NCHSReceiptDayString
+        {
+            get
+            {
+                uint? month = this.NCHSReceiptDay;
+                return (month != null) ? month.ToString().PadLeft(2, '0') : null;
+            }
+            set
+            {
+                this.NCHSReceiptDay = (value != null) ? Convert.ToUInt32(value) : (uint?)null;
+            }
+        }
+
+        /// <summary>NCHS Receipt Date Year (Numeric, Greater than or equal to year of death or blank)</summary>
         public uint? NCHSReceiptYear
         {
             get
@@ -242,11 +267,25 @@ namespace VRDR
                 Record.Remove("rec_yr");
                 if (value != null)
                 {
-                    if (DeathYear != null && value < DeathYear) {
-                        throw new ArgumentException("NCHS Receipt Year must be greater than Death Year, or null");
+                    if (DeathYear != null && value <= DeathYear) {
+                        throw new ArgumentException("NCHS Receipt Year must be greater than or equal to Death Year, or null");
                     }
                     Record.Add("rec_yr", new UnsignedInt((int)value));
                 }
+            }
+        }
+
+        /// <summary>NCHS Receipt Date Year (string, Greater than year of death or null)</summary>
+        public string NCHSReceiptYearString
+        {
+            get
+            {
+                uint? month = this.NCHSReceiptYear;
+                return (month != null) ? month.ToString() : null;
+            }
+            set
+            {
+                this.NCHSReceiptYear = (value != null) ? Convert.ToUInt32(value) : (uint?)null;
             }
         }
 
@@ -291,22 +330,20 @@ namespace VRDR
             }
         }
 
-        /// <summary>Intentional reject (1-5, 9 or null)</summary>
-        public uint? IntentionalReject
+        /// <summary>Intentional reject (1-5, 9 or null). See Coding one-character reject codes in code document for values.</summary>
+        public string IntentionalReject
         {
             get
             {
-                return (uint?)Record.GetSingleValue<UnsignedInt>("int_rej")?.Value;
+
+                return Record.GetSingleValue<Coding>("int_rej")?.Code;
             }
             set
             {
                 Record.Remove("int_rej");
                 if (value != null)
                 {
-                    if (value != 9 || value > 5 || value < 1) {
-                        throw new ArgumentException("Intentional Reject must equal 1-5, 9, or null.");
-                    }
-                    Record.Add("int_rej", new UnsignedInt((int)value));
+                    Record.Add("int_rej", new Coding("https://www.cdc.gov/nchs/data/dvs/2b_2017.pdf", value));
                 }
             }
         }
@@ -397,6 +434,23 @@ namespace VRDR
                 if(value != null)
                 {
                     Record.Add("injpl", new FhirString(value.ToString()));
+                }
+            }
+        }
+
+        /// <summary>Other Specified Place of Injury</summary>
+        public string OtherSpecifiedPlace
+        {
+            get
+            {
+                return Record.GetSingleValue<FhirString>("other_specified_place")?.Value;
+            }
+            set
+            {
+                Record.Remove("other_specified_place");
+                if (value != null)
+                {
+                    Record.Add("other_specified_place", new FhirString(value));
                 }
             }
         }

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -274,7 +274,7 @@
             <summary>Decedent race coding</summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.CoderStatus">
-            <summary>Coder Status (Numeric, 0-9)</summary>
+            <summary>Coder Status (string, 0-9 or null)</summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.ShipmentNumber">
             <summary>Shipment Number (Alpha Numeric)</summary>
@@ -282,11 +282,20 @@
         <member name="P:VRDR.CodingResponseMessage.NCHSReceiptMonth">
             <summary>NCHS Receipt Date Month (Numeric, 01-12 or null)</summary>
         </member>
+        <member name="P:VRDR.CodingResponseMessage.NCHSReceiptMonthString">
+            <summary>NCHS Receipt Date Month (string, 01-12 or null)</summary>
+        </member>
         <member name="P:VRDR.CodingResponseMessage.NCHSReceiptDay">
             <summary>NCHS Receipt Date Day (Numeric, 01-31 or blank)</summary>
         </member>
+        <member name="P:VRDR.CodingResponseMessage.NCHSReceiptDayString">
+            <summary>NCHS Receipt Date Day (string, 01-31 or null)</summary>
+        </member>
         <member name="P:VRDR.CodingResponseMessage.NCHSReceiptYear">
-            <summary>NCHS Receipt Date Year (Numeric, Greater than year of death or blank)</summary>
+            <summary>NCHS Receipt Date Year (Numeric, Greater than or equal to year of death or blank)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.NCHSReceiptYearString">
+            <summary>NCHS Receipt Date Year (string, Greater than year of death or null)</summary>
         </member>
         <member name="T:VRDR.CodingResponseMessage.MannerOfDeathEnum">
             <summary>Manner of Death Enum</summary>
@@ -310,7 +319,7 @@
             <summary>Manner of Death (or null)</summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.IntentionalReject">
-            <summary>Intentional reject (1-5, 9 or null)</summary>
+            <summary>Intentional reject (1-5, 9 or null). See Coding one-character reject codes in code document for values.</summary>
         </member>
         <member name="T:VRDR.CodingResponseMessage.ACMESystemRejectEnum">
             <summary>ACME System Reject Enum</summary>
@@ -365,6 +374,9 @@
         </member>
         <member name="P:VRDR.CodingResponseMessage.PlaceOfInjury">
             <summary>Place of Injury (or null)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.OtherSpecifiedPlace">
+            <summary>Other Specified Place of Injury</summary>
         </member>
         <member name="P:VRDR.CodingResponseMessage.UnderlyingCauseOfDeath">
             <summary>Underlying cause of death code (ICD-10)</summary>

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -333,6 +333,9 @@
         <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.MICARRejectRuleApplication">
             <summary>MICAR Reject - Rule Application</summary>
         </member>
+        <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.RecordReviewed">
+            <summary>Record Reviewed</summary>
+        </member>
         <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.NotRejected">
             <summary>Not Rejected</summary>
         </member>

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -273,6 +273,99 @@
         <member name="P:VRDR.CodingResponseMessage.Race">
             <summary>Decedent race coding</summary>
         </member>
+        <member name="P:VRDR.CodingResponseMessage.CoderStatus">
+            <summary>Coder Status (Numeric, 0-9)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.ShipmentNumber">
+            <summary>Shipment Number (Alpha Numeric)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.NCHSReceiptMonth">
+            <summary>NCHS Receipt Date Month (Numeric, 01-12 or null)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.NCHSReceiptDay">
+            <summary>NCHS Receipt Date Day (Numeric, 01-31 or blank)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.NCHSReceiptYear">
+            <summary>NCHS Receipt Date Year (Numeric, Greater than year of death or blank)</summary>
+        </member>
+        <member name="T:VRDR.CodingResponseMessage.MannerOfDeathEnum">
+            <summary>Manner of Death Enum</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.MannerOfDeathEnum.Natural">
+            <summary>Natural cause of death</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.MannerOfDeathEnum.Accident">
+            <summary>Accident cause of death</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.MannerOfDeathEnum.Suicide">
+            <summary>Suicide cause of death</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.MannerOfDeathEnum.PendingInvestigation">
+            <summary>Cause of death is pending investigation</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.MannerOfDeathEnum.CouldNotBeDetermined">
+            <summary>Cause of death could not be determined</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.MannerOfDeath">
+            <summary>Manner of Death (or null)</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.IntentionalReject">
+            <summary>Intentional reject (1-5, 9 or null)</summary>
+        </member>
+        <member name="T:VRDR.CodingResponseMessage.ACMESystemRejectEnum">
+            <summary>ACME System Reject Enum</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.MICARRejectDictionaryMatch">
+            <summary>MICAR Reject - Dictionary Match</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.ACMEReject">
+            <summary>ACME Reject</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.MICARRejectRuleApplication">
+            <summary>MICAR Reject - Rule Application</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.ACMESystemRejectEnum.NotRejected">
+            <summary>Not Rejected</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.ACMESystemRejectCodes">
+            <summary>ACME system reject codes (or null)</summary>
+        </member>
+        <member name="T:VRDR.CodingResponseMessage.PlaceOfInjuryEnum">
+            <summary>Place of Injury Enum</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.Home">
+            <summary>Home</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.ResidentialInstution">
+            <summary>Residential Institution</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.SchoolOtherInstutionOrPublicAdministrativeArea">
+            <summary>School, Other Institutions, Public Administrative Area</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.SportsAndAthleticsArea">
+            <summary>Sports and Atheletics Area</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.StreetOrHighway">
+            <summary>Street/Highway</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.TradeAndServiceArea">
+            <summary>Trade and Service Area</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.IndustrialAndConstructionArea">
+            <summary>Industrial and Construction Area</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.Farm">
+            <summary>Farm</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.OtherSpecifiedPlace">
+            <summary>Other Specified Place</summary>
+        </member>
+        <member name="F:VRDR.CodingResponseMessage.PlaceOfInjuryEnum.UnspecifiedPlace">
+            <summary>Unspecified Place</summary>
+        </member>
+        <member name="P:VRDR.CodingResponseMessage.PlaceOfInjury">
+            <summary>Place of Injury (or null)</summary>
+        </member>
         <member name="P:VRDR.CodingResponseMessage.UnderlyingCauseOfDeath">
             <summary>Underlying cause of death code (ICD-10)</summary>
         </member>
@@ -299,7 +392,7 @@
             <summary>Class for structuring a cause of death entity axis entry</summary>
         </member>
         <member name="F:VRDR.CauseOfDeathEntityAxisEntry.LineNumber">
-            <summary>Identifies the line number (values "1" to "6") of the corresponding cause of death entered on the 
+            <summary>Identifies the line number (values "1" to "6") of the corresponding cause of death entered on the
             death certificate. The following list shows the corresponding line in the death certificate for each value.</summary>
             <list type="number">
             <item>Part I. Line a</item>

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -271,6 +271,19 @@ namespace VRDR.Tests
             Assert.Equal("xyzzy", line);
             Assert.Equal("1", position);
             Assert.Equal("code2_1", code);
+
+            Assert.Equal("8", message.CoderStatus);
+            Assert.Equal("B202101", message.ShipmentNumber);
+            Assert.Equal((uint)8, message.NCHSReceiptDay);
+            Assert.Equal("08", message.NCHSReceiptDayString);
+            Assert.Equal((uint)1, message.NCHSReceiptMonth);
+            Assert.Equal("01", message.NCHSReceiptMonthString);
+            Assert.Equal((uint)2021, message.NCHSReceiptYear);
+            Assert.Equal("2021", message.NCHSReceiptYearString);
+            Assert.Equal(CodingResponseMessage.MannerOfDeathEnum.Accident, message.MannerOfDeath);
+            Assert.Equal("5", message.IntentionalReject);
+            Assert.Equal(CodingResponseMessage.ACMESystemRejectEnum.ACMEReject, message.ACMESystemRejectCodes);
+            Assert.Equal(CodingResponseMessage.PlaceOfInjuryEnum.Home, message.PlaceOfInjury);
         }
 
         [Fact]
@@ -344,19 +357,16 @@ namespace VRDR.Tests
             Assert.Null(message.NCHSReceiptMonth);
             message.NCHSReceiptMonth = (uint)1;
             Assert.Equal((uint)1, message.NCHSReceiptMonth);
-            message.NCHSReceiptMonth = null;
 
             Assert.Null(message.NCHSReceiptDayString);
             message.NCHSReceiptDayString = "9";
             Assert.Equal("09", message.NCHSReceiptDayString);
             Assert.Equal((uint)9, message.NCHSReceiptDay);
             message.NCHSReceiptDayString = null;
-            Assert.Null(message.NCHSReceiptDayString);
 
             Assert.Null(message.NCHSReceiptDay);
             message.NCHSReceiptDay = (uint)8;
             Assert.Equal((uint)8, message.NCHSReceiptDay);
-            message.NCHSReceiptDay = null;
 
             Assert.Null(message.NCHSReceiptYearString);
             message.NCHSReceiptYearString = "2020";
@@ -368,37 +378,30 @@ namespace VRDR.Tests
             Assert.Null(message.NCHSReceiptYear);
             message.NCHSReceiptYear = (uint)2021;
             Assert.Equal((uint)2021, message.NCHSReceiptYear);
-            message.NCHSReceiptYear = null;
 
             Assert.Null(message.MannerOfDeath);
             message.MannerOfDeath = CodingResponseMessage.MannerOfDeathEnum.Accident;
             Assert.Equal(CodingResponseMessage.MannerOfDeathEnum.Accident, message.MannerOfDeath);
-            message.MannerOfDeath = null;
 
             Assert.Null(message.CoderStatus);
             message.CoderStatus = "8";
             Assert.Equal("8", message.CoderStatus);
-            message.CoderStatus = null;
 
             Assert.Null(message.ShipmentNumber);
             message.ShipmentNumber = "B202101";
             Assert.Equal("B202101", message.ShipmentNumber);
-            message.ShipmentNumber = null;
 
             Assert.Null(message.ACMESystemRejectCodes);
             message.ACMESystemRejectCodes = CodingResponseMessage.ACMESystemRejectEnum.ACMEReject;
             Assert.Equal(CodingResponseMessage.ACMESystemRejectEnum.ACMEReject, message.ACMESystemRejectCodes);
-            message.ACMESystemRejectCodes = null;
 
             Assert.Null(message.PlaceOfInjury);
             message.PlaceOfInjury = CodingResponseMessage.PlaceOfInjuryEnum.Home;
             Assert.Equal(CodingResponseMessage.PlaceOfInjuryEnum.Home, message.PlaceOfInjury);
-            message.PlaceOfInjury = null;
 
             Assert.Null(message.OtherSpecifiedPlace);
             message.OtherSpecifiedPlace = "Unique Location";
             Assert.Equal("Unique Location", message.OtherSpecifiedPlace);
-            message.OtherSpecifiedPlace = null;
 
             Assert.Null(message.DeathJurisdictionID);
             message.DeathJurisdictionID = "NH";
@@ -408,7 +411,6 @@ namespace VRDR.Tests
             Assert.Null(message.IntentionalReject);
             message.IntentionalReject = "5";
             Assert.Equal("5", message.IntentionalReject);
-            message.IntentionalReject = null;
 
             Assert.Empty(message.Ethnicity);
             var ethnicity = new Dictionary<CodingResponseMessage.HispanicOrigin, string>();

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -334,10 +334,81 @@ namespace VRDR.Tests
             message.DeathYear = 2019;
             Assert.Equal((uint)2019, message.DeathYear);
 
+            Assert.Null(message.NCHSReceiptMonthString);
+            message.NCHSReceiptMonthString = "1";
+            Assert.Equal("01", message.NCHSReceiptMonthString);
+            Assert.Equal((uint)1, message.NCHSReceiptMonth);
+            message.NCHSReceiptMonthString = null;
+            Assert.Null(message.NCHSReceiptMonthString);
+
+            Assert.Null(message.NCHSReceiptMonth);
+            message.NCHSReceiptMonth = (uint)1;
+            Assert.Equal((uint)1, message.NCHSReceiptMonth);
+            message.NCHSReceiptMonth = null;
+
+            Assert.Null(message.NCHSReceiptDayString);
+            message.NCHSReceiptDayString = "9";
+            Assert.Equal("09", message.NCHSReceiptDayString);
+            Assert.Equal((uint)9, message.NCHSReceiptDay);
+            message.NCHSReceiptDayString = null;
+            Assert.Null(message.NCHSReceiptDayString);
+
+            Assert.Null(message.NCHSReceiptDay);
+            message.NCHSReceiptDay = (uint)8;
+            Assert.Equal((uint)8, message.NCHSReceiptDay);
+            message.NCHSReceiptDay = null;
+
+            Assert.Null(message.NCHSReceiptYearString);
+            message.NCHSReceiptYearString = "2020";
+            Assert.Equal("2020", message.NCHSReceiptYearString);
+            Assert.Equal((uint)2020, message.NCHSReceiptYear);
+            message.NCHSReceiptYearString = null;
+            Assert.Null(message.NCHSReceiptYearString);
+
+            Assert.Null(message.NCHSReceiptYear);
+            message.NCHSReceiptYear = (uint)2021;
+            Assert.Equal((uint)2021, message.NCHSReceiptYear);
+            message.NCHSReceiptYear = null;
+
+            Assert.Null(message.MannerOfDeath);
+            message.MannerOfDeath = CodingResponseMessage.MannerOfDeathEnum.Accident;
+            Assert.Equal(CodingResponseMessage.MannerOfDeathEnum.Accident, message.MannerOfDeath);
+            message.MannerOfDeath = null;
+
+            Assert.Null(message.CoderStatus);
+            message.CoderStatus = "8";
+            Assert.Equal("8", message.CoderStatus);
+            message.CoderStatus = null;
+
+            Assert.Null(message.ShipmentNumber);
+            message.ShipmentNumber = "B202101";
+            Assert.Equal("B202101", message.ShipmentNumber);
+            message.ShipmentNumber = null;
+
+            Assert.Null(message.ACMESystemRejectCodes);
+            message.ACMESystemRejectCodes = CodingResponseMessage.ACMESystemRejectEnum.ACMEReject;
+            Assert.Equal(CodingResponseMessage.ACMESystemRejectEnum.ACMEReject, message.ACMESystemRejectCodes);
+            message.ACMESystemRejectCodes = null;
+
+            Assert.Null(message.PlaceOfInjury);
+            message.PlaceOfInjury = CodingResponseMessage.PlaceOfInjuryEnum.Home;
+            Assert.Equal(CodingResponseMessage.PlaceOfInjuryEnum.Home, message.PlaceOfInjury);
+            message.PlaceOfInjury = null;
+
+            Assert.Null(message.OtherSpecifiedPlace);
+            message.OtherSpecifiedPlace = "Unique Location";
+            Assert.Equal("Unique Location", message.OtherSpecifiedPlace);
+            message.OtherSpecifiedPlace = null;
+
             Assert.Null(message.DeathJurisdictionID);
             message.DeathJurisdictionID = "NH";
             Assert.Equal("NH", message.DeathJurisdictionID);
             Assert.Equal("2019NH000010", message.NCHSIdentifier);
+
+            Assert.Null(message.IntentionalReject);
+            message.IntentionalReject = "5";
+            Assert.Equal("5", message.IntentionalReject);
+            message.IntentionalReject = null;
 
             Assert.Empty(message.Ethnicity);
             var ethnicity = new Dictionary<CodingResponseMessage.HispanicOrigin, string>();

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -321,7 +321,7 @@ namespace VRDR.Tests
             CodingResponseMessage message = new CodingResponseMessage("destination", "http://nchs.cdc.gov/vrdr_submission");
             Assert.Equal("http://nchs.cdc.gov/vrdr_coding", message.MessageType);
             Assert.Equal("destination", message.MessageDestination);
-            
+
             Assert.Null(message.CertificateNumber);
             message.CertificateNumber = 10;
             Assert.Equal((uint)10, message.CertificateNumber);
@@ -333,7 +333,7 @@ namespace VRDR.Tests
             Assert.Null(message.DeathYear);
             message.DeathYear = 2019;
             Assert.Equal((uint)2019, message.DeathYear);
-            
+
             Assert.Null(message.DeathJurisdictionID);
             message.DeathJurisdictionID = "NH";
             Assert.Equal("NH", message.DeathJurisdictionID);
@@ -425,7 +425,7 @@ namespace VRDR.Tests
             CodingUpdateMessage message = new CodingUpdateMessage("destination", "http://nchs.cdc.gov/vrdr_submission");
             Assert.Equal("http://nchs.cdc.gov/vrdr_coding_update", message.MessageType);
             Assert.Equal("destination", message.MessageDestination);
-            
+
             Assert.Null(message.CertificateNumber);
             message.CertificateNumber = 10;
             Assert.Equal((uint)10, message.CertificateNumber);
@@ -437,7 +437,7 @@ namespace VRDR.Tests
             Assert.Null(message.DeathYear);
             message.DeathYear = 2019;
             Assert.Equal((uint)2019, message.DeathYear);
-            
+
             Assert.Null(message.DeathJurisdictionID);
             message.DeathJurisdictionID = "NH";
             Assert.Equal("NH", message.DeathJurisdictionID);
@@ -642,7 +642,7 @@ namespace VRDR.Tests
             Assert.Null(responseMsg.CertificateNumber);
             Assert.Null(responseMsg.NCHSIdentifier);
             Assert.Null(responseMsg.StateAuxiliaryIdentifier);
-            
+
             ex = Assert.Throws<MessageParseException>(() => BaseMessage.Parse(FixtureStream("fixtures/json/MissingMessageType.json")));
             Assert.Equal("Message type was missing from MessageHeader", ex.Message);
             responseMsg = ex.CreateExtractionErrorMessage();

--- a/VRDR.Tests/fixtures/json/CauseOfDeathCodingMessage.json
+++ b/VRDR.Tests/fixtures/json/CauseOfDeathCodingMessage.json
@@ -76,7 +76,7 @@
                             {
                                 "name": "RACEBRG",
                                 "valueCoding": {
-                                    "system": "https://www.cdc.gov/nchs/data/dvs/RaceCodeList.pdf",
+                                    "system": "https://www.cdc.gov/nchs/data/dvs/Multiple_race_documentation_5-10-04.pdf",
                                     "code": "baz"
                                 }
                             }

--- a/VRDR.Tests/fixtures/json/CauseOfDeathCodingMessage.json
+++ b/VRDR.Tests/fixtures/json/CauseOfDeathCodingMessage.json
@@ -38,6 +38,48 @@
                         "valueString": "MA"
                     },
                     {
+                        "name": "cs",
+                        "valueCoding": {
+                            "system": "https://ftp.cdc.gov/pub/Health_Statistics/NCHS/Software/MICAR/Data_Entry_Software/ACME_TRANSAX/Documentation/auser.pdf",
+                            "code": "8"
+                        }
+                    },
+                    {
+                        "name": "ship",
+                        "valueString": "B202101"
+                    },
+                    {
+                        "name": "rec_mo",
+                        "valueUnsignedInt": 1
+                    },
+                    {
+                        "name": "rec_dy",
+                        "valueUnsignedInt": 8
+                    },
+                    {
+                        "name": "rec_yr",
+                        "valueUnsignedInt": 2021
+                    },
+                    {
+                        "name": "manner",
+                        "valueString": "Accident"
+                    },
+                    {
+                        "name": "int_rej",
+                        "valueCoding": {
+                            "system": "https://www.cdc.gov/nchs/data/dvs/2b_2017.pdf",
+                            "code": "5"
+                        }
+                    },
+                    {
+                        "name": "sys_rej",
+                        "valueString": "ACMEReject"
+                    },
+                    {
+                        "name": "injpl",
+                        "valueString": "Home"
+                    },
+                    {
                         "name": "ethnicity",
                         "part": [
                             {

--- a/VRDR.Tests/fixtures/json/CodingUpdateMessage.json
+++ b/VRDR.Tests/fixtures/json/CodingUpdateMessage.json
@@ -76,7 +76,7 @@
                             {
                                 "name": "RACEBRG",
                                 "valueCoding": {
-                                    "system": "https://www.cdc.gov/nchs/data/dvs/RaceCodeList.pdf",
+                                    "system": "https://www.cdc.gov/nchs/data/dvs/Multiple_race_documentation_5-10-04.pdf",
                                     "code": "baz"
                                 }
                             }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -740,7 +740,7 @@ namespace VRDR
                 {
                     InterestedParty.Identifier.Clear();
                 }
-                
+
                 Identifier identifier = new Identifier();
                 identifier.System = value["system"];
                 identifier.Value = value["value"];
@@ -4774,7 +4774,7 @@ namespace VRDR
         {
             get
             {
-                if (UsualWork != null && UsualWork.Effective != null && UsualWork.Effective as Period != null && ((Period)UsualWork.Effective).Start != null) 
+                if (UsualWork?.Effective != null && UsualWork.Effective as Period != null && ((Period)UsualWork.Effective).Start != null)
                 {
                     return Convert.ToString(((Period)UsualWork.Effective).Start);
                 }
@@ -4821,7 +4821,7 @@ namespace VRDR
         {
             get
             {
-                if (UsualWork != null && UsualWork.Effective != null && UsualWork.Effective as Period != null && ((Period)UsualWork.Effective).End != null) 
+                if (UsualWork?.Effective != null && UsualWork.Effective as Period != null && ((Period)UsualWork.Effective).End != null)
                 {
                     return Convert.ToString(((Period)UsualWork.Effective).End);
                 }
@@ -6724,7 +6724,7 @@ namespace VRDR
         {
             get
             {
-                if (InjuryIncidentObs != null && InjuryIncidentObs.Effective != null)
+                if (InjuryIncidentObs?.Effective != null)
                 {
                     return Convert.ToString(InjuryIncidentObs.Effective);
                 }
@@ -6768,7 +6768,7 @@ namespace VRDR
         {
             get
             {
-                if (InjuryIncidentObs != null && InjuryIncidentObs.Value != null)
+                if (InjuryIncidentObs?.Value != null)
                 {
                     return Convert.ToString(InjuryIncidentObs.Value);
                 }
@@ -6828,7 +6828,7 @@ namespace VRDR
                 {
                     // Find correct component
                     var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
-                    if (placeComp != null && placeComp.Value != null && placeComp.Value != null && placeComp.Value as CodeableConcept != null)
+                    if (placeComp?.Value != null && placeComp.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)placeComp.Value);
                     }
@@ -7182,7 +7182,7 @@ namespace VRDR
         {
             get
             {
-                if (TransportationRoleObs != null && TransportationRoleObs.Value != null && TransportationRoleObs.Value as CodeableConcept != null)
+                if (TransportationRoleObs?.Value != null && TransportationRoleObs.Value as CodeableConcept != null)
                 {
                     return CodeableConceptToDict((CodeableConcept)TransportationRoleObs.Value);
                 }
@@ -7657,7 +7657,7 @@ namespace VRDR
             }
             return coding;
         }
-        
+
         /// <summary>Convert a "code" dictionary to a FHIR CodableConcept.</summary>
         /// <param name="dict">represents a code.</param>
         /// <returns>the corresponding CodeableConcept representation of the code.</returns>

--- a/doc/Messaging.md
+++ b/doc/Messaging.md
@@ -105,7 +105,8 @@ Once NCHS have determined the causes of death they can create a `CodingResponseM
 
 ```cs
 // Create an empty coding response message
-CodingResponseMessage message = new CodingResponseMessage("https://example.org/jurisdiction/endpoint", "http://nchs.cdc.gov/vrdr_submission");
+CodingResponseMessage message = new CodingResponseMessage("https://example.org/jurisdiction/endpoint",
+                                                          "http://nchs.cdc.gov/vrdr_submission");
 
 // Assign the business identifiers
 message.CertificateNumber = 10;

--- a/doc/Messaging.md
+++ b/doc/Messaging.md
@@ -105,44 +105,55 @@ Once NCHS have determined the causes of death they can create a `CodingResponseM
 
 ```cs
 // Create an empty coding response message
-CodingResponseMessage message = new CodingResponseMessage("https://example.org/jurisdiction/endpoint");
+CodingResponseMessage message = new CodingResponseMessage("https://example.org/jurisdiction/endpoint", "http://nchs.cdc.gov/vrdr_submission");
 
 // Assign the business identifiers
-message.CertificateNumber = "...";
-message.StateAuxiliaryIdentifier = "...";
-message.NCHSIdentifier = "...";
+message.CertificateNumber = 10;
+message.StateAuxiliaryIdentifier = "101010";
+message.DeathYear = 2019;
+message.DeathJurisdictionID = "MA";
+
+// Specify additional information
+message.NCHSReceiptMonthString = "1";
+message.NCHSReceiptDayString = "9";
+message.NCHSReceiptYearString = "2020";
+message.MannerOfDeath = CodingResponseMessage.MannerOfDeathEnum.Accident;
+message.CoderStatus = "8";
+message.ShipmentNumber = "B202101";
+message.ACMESystemRejectCodes = CodingResponseMessage.ACMESystemRejectEnum.ACMEReject;
+message.PlaceOfInjury = CodingResponseMessage.PlaceOfInjuryEnum.Home;
+message.OtherSpecifiedPlace = "Unique Location";
+message.IntentionalReject = "5";
 
 // Create the ethnicity coding
 var ethnicity = new Dictionary<CodingResponseMessage.HispanicOrigin, string>();
-ethnicity.Add(CodingResponseMessage.HispanicOrigin.DETHNICE, <ethnicity code>);
-ethnicity.Add(CodingResponseMessage.HispanicOrigin.DETHNIC5C, <ethnicity code>);
+ethnicity.Add(CodingResponseMessage.HispanicOrigin.DETHNICE, "<ethnicity-code>");
+ethnicity.Add(CodingResponseMessage.HispanicOrigin.DETHNIC5C, "<ethnicity-code>");
 message.Ethnicity = ethnicity;
 
 // Create the race coding
 var race = new Dictionary<CodingResponseMessage.RaceCode, string>();
-race.Add(CodingResponseMessage.RaceCode.RACE1E, <race code>);
-race.Add(CodingResponseMessage.RaceCode.RACE17C, <race code>);
-race.Add(CodingResponseMessage.RaceCode.RACEBRG, <race code>);
+race.Add(CodingResponseMessage.RaceCode.RACE1E, "<race-code>");
+race.Add(CodingResponseMessage.RaceCode.RACE17C, "<race-code>");
+race.Add(CodingResponseMessage.RaceCode.RACEBRG, "<race-code>");
 message.Race = race;
 
 // Create the cause of death coding
-message.UnderlyingCauseOfDeath = <icd code>;
+message.UnderlyingCauseOfDeath = "A04.7";
 
 // Assign the record axis codes
 var recordAxisCodes = new List<string>();
-recordAxisCodes.Add(<icd code>);
-recordAxisCodes.Add(<icd code>);
-recordAxisCodes.Add(<icd code>);
-recordAxisCodes.Add(<icd code>);
+recordAxisCodes.Add("A04.7");
+recordAxisCodes.Add("A41.9");
+recordAxisCodes.Add("J18.9");
+recordAxisCodes.Add("J96.0");
 message.CauseOfDeathRecordAxis = recordAxisCodes;
 
 // Assign the entity axis codes
 var builder = new CauseOfDeathEntityAxisBuilder();
-// for each entity axis codes
-...
-builder.Add(<lineNumber>, <positionInLine>, <icd code>);
-...
-// end loop
+builder.Add("1", "1", "line1_code1");
+builder.Add("1", "2", "line1_code2");
+builder.Add("2", "1", "line2_code1");
 message.CauseOfDeathEntityAxis = builder.ToCauseOfDeathEntityAxis();
 
 // Create a JSON representation of the coding response message


### PR DESCRIPTION
Added fields: CoderStatus, ShipmentNumber, NCHSReceiptDate, MannerOfDeath, IntentionalReject, ACMESystemRejectCodes, and PlaceOfInjury

Added a special case for RACEBRG which provides a different code when dealing with this special code.

General question for all of these fields: Do any of them need an accompanying code list? If so, where should such a code list come from?