### PR TITLE
Add block count to void ack

### DIFF
--- a/VRDR.Messaging/AckMessage.cs
+++ b/VRDR.Messaging/AckMessage.cs
@@ -13,6 +13,12 @@ namespace VRDR
             this.StateAuxiliaryIdentifier = messageToAck?.StateAuxiliaryIdentifier;
             this.DeathJurisdictionID = messageToAck?.DeathJurisdictionID;
             this.DeathYear = messageToAck?.DeathYear;
+
+            if(typeof(VoidMessage).IsInstanceOfType(messageToAck))
+            {
+                VoidMessage voidMessageToAck = (VoidMessage) messageToAck;
+                this.BlockCount = voidMessageToAck?.BlockCount;
+            }
         }
 
         /// <summary>
@@ -50,6 +56,23 @@ namespace VRDR
             set
             {
                 Header.Response.Identifier = value;
+            }
+        }
+
+        /// <summary>The number of records to void starting at the certificate number specified by the `CertificateNumber` parameter</summary>
+        public uint? BlockCount
+        {
+            get
+            {
+                return (uint?)Record?.GetSingleValue<PositiveInt>("block_count")?.Value;
+            }
+            set
+            {
+                Record.Remove("block_count");
+                if (value != null && value > 1)
+                {
+                    Record.Add("block_count", new PositiveInt((int)value));
+                }
             }
         }
 

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -28,6 +28,9 @@
             <summary>The id of the message that is being acknowledged by this message</summary>
             <value>the message id.</value>
         </member>
+        <member name="P:VRDR.AckMessage.BlockCount">
+            <summary>The number of records to void starting at the certificate number specified by the `CertificateNumber` parameter</summary>
+        </member>
         <member name="T:VRDR.BaseMessage">
             <summary>Class <c>BaseMessage</c> is the base class of all messages.</summary>
         </member>

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -540,6 +540,43 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void CreateAckForVoidMessage()
+        {
+            VoidMessage voidMessage = BaseMessage.Parse<VoidMessage>(FixtureStream("fixtures/json/VoidMessage.json"));
+            AckMessage ack = new AckMessage(voidMessage);
+            Assert.Equal("http://nchs.cdc.gov/vrdr_acknowledgement", ack.MessageType);
+            Assert.Equal(voidMessage.MessageId, ack.AckedMessageId);
+            Assert.Equal(voidMessage.MessageSource, ack.MessageDestination);
+            Assert.Equal(voidMessage.MessageDestination, ack.MessageSource);
+            Assert.Equal(voidMessage.StateAuxiliaryIdentifier, ack.StateAuxiliaryIdentifier);
+            Assert.Equal(voidMessage.CertificateNumber, ack.CertificateNumber);
+            Assert.Equal(voidMessage.NCHSIdentifier, ack.NCHSIdentifier);
+            Assert.Equal(voidMessage.BlockCount, ack.BlockCount);
+
+            voidMessage = null;
+            ack = new AckMessage(voidMessage);
+            Assert.Equal("http://nchs.cdc.gov/vrdr_acknowledgement", ack.MessageType);
+            Assert.Null(ack.AckedMessageId);
+            Assert.Null(ack.MessageDestination);
+            Assert.Null(ack.MessageSource);
+            Assert.Null(ack.CertificateNumber);
+            Assert.Null(ack.StateAuxiliaryIdentifier);
+            Assert.Null(ack.NCHSIdentifier);
+            Assert.Null(ack.BlockCount);
+
+            voidMessage = new VoidMessage();
+            ack = new AckMessage(voidMessage);
+            Assert.Equal("http://nchs.cdc.gov/vrdr_acknowledgement", ack.MessageType);
+            Assert.Equal(voidMessage.MessageId, ack.AckedMessageId);
+            Assert.Equal(voidMessage.MessageSource, ack.MessageDestination);
+            Assert.Equal(voidMessage.MessageDestination, ack.MessageSource);
+            Assert.Equal(voidMessage.StateAuxiliaryIdentifier, ack.StateAuxiliaryIdentifier);
+            Assert.Equal(voidMessage.CertificateNumber, ack.CertificateNumber);
+            Assert.Equal(voidMessage.NCHSIdentifier, ack.NCHSIdentifier);
+            Assert.Equal(voidMessage.BlockCount, ack.BlockCount);
+        }
+
+        [Fact]
         public void CreateVoidMessageFromJson()
         {
             VoidMessage message = BaseMessage.Parse<VoidMessage>(FixtureStream("fixtures/json/VoidMessage.json"));


### PR DESCRIPTION
Ticket: Acknowledgements of void messages should include acknowledgement of the block_count field if it's present   

This PR adds the BlockCount field to the AckMessage class. The field is only populated when acknowledging a void message type. Tests were added to verify the AckMessage's BlockCount field is set correctly given a void message. A PR was also submitted with documentation updates. 