### PR TITLE
Generate doxygen documentation and publish to Github Pages on push to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,5 @@ ASALocalRun/
 .DS_Store
 
 *.nightingale
+
+html/


### PR DESCRIPTION
This automatically builds a `html` folder on push to the repository. Docs can also be build locally by running `doxygen Doxyfile`