### PR TITLE
Deathdate date part absent

### DIFF
--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -24,7 +24,7 @@
     <None Update="fixtures/json/CauseOfDeathCodingMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/CodingUpdateMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathLocationType.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="fixtures/json/DeathRecordBirthDateDataAbsent.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthAndDeathDateDataAbsent.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordBirthRecordDataAbsent.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordSubmission.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordSubmissionNoIdentifiers.json" CopyToOutputDirectory="PreserveNewest" />

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1249,7 +1249,7 @@ namespace VRDR.Tests
         [Fact]
         public void Get_BirthDate_Partial_Date()
         {
-            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecordBirthDateDataAbsent.json")));
+            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
             Assert.Equal(Tuple.Create("year-absent-reason", "asked-unknown"), (dr.DateOfBirthDatePartAbsent[0]));
             Assert.Equal(Tuple.Create("date-month", "2"), (dr.DateOfBirthDatePartAbsent[1]));
             Assert.Equal(Tuple.Create("date-day", "24"), (dr.DateOfBirthDatePartAbsent[2]));
@@ -1260,7 +1260,7 @@ namespace VRDR.Tests
         [Fact]
         public void Get_BirthDate_Partial_Date_Roundtrip()
         {
-            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecordBirthDateDataAbsent.json")));
+            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
             IJEMortality ije1 = new IJEMortality(dr); 
             Assert.Equal("9999", ije1.DOB_YR);
             Assert.Equal("02", ije1.DOB_MO);
@@ -2474,6 +2474,36 @@ namespace VRDR.Tests
         {
             Assert.Equal("2018-02-19T16:48:06-05:00", ((DeathRecord)JSONRecords[0]).DateOfDeath);
             Assert.Equal("2018-02-19T16:48:06-05:00", ((DeathRecord)XMLRecords[0]).DateOfDeath);
+        }
+
+        [Fact]
+        public void Set_DateOfDeath_Partial_Date()
+        {
+            Tuple<string, string>[] datePart = { Tuple.Create("date-year", "2021"), Tuple.Create("date-month", "5"), Tuple.Create("day-absent-reason", "asked-unknown")};
+            SetterDeathRecord.DateOfDeathDatePartAbsent = datePart;
+            Assert.Equal(datePart[0], SetterDeathRecord.DateOfDeathDatePartAbsent[0]);
+            Assert.Equal(datePart[1], SetterDeathRecord.DateOfDeathDatePartAbsent[1]);
+            Assert.Equal(datePart[2], SetterDeathRecord.DateOfDeathDatePartAbsent[2]);
+        }
+
+        [Fact]
+        public void Get_DateOfDeath_Partial_Date()
+        {
+            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
+            Assert.Equal(Tuple.Create("date-year", "2021"), (dr.DateOfDeathDatePartAbsent[0]));
+            Assert.Equal(Tuple.Create("date-month", "2"), (dr.DateOfDeathDatePartAbsent[1]));
+            Assert.Equal(Tuple.Create("day-absent-reason", "asked-unknown"), (dr.DateOfDeathDatePartAbsent[2]));
+
+        }
+
+        [Fact]
+        public void Get_DateOfDeath_Partial_Date_Roundtrip()
+        {
+            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
+            IJEMortality ije1 = new IJEMortality(dr); 
+            Assert.Equal("2021", ije1.DOD_YR);
+            Assert.Equal("02", ije1.DOD_MO);
+            Assert.Equal("99", ije1.DOD_DY);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2477,6 +2477,18 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void Get_DateOfDeath_Roundtrip()
+        {
+            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecord1.json")));
+            IJEMortality ije1 = new IJEMortality(dr); 
+            Assert.Equal("2018", ije1.DOD_YR);
+            Assert.Equal("02", ije1.DOD_MO);
+            Assert.Equal("19", ije1.DOD_DY);
+            DeathRecord dr2 = ije1.ToDeathRecord();
+            Assert.Equal("2018-02-19T16:48:06-05:00", dr2.DateOfDeath);
+        }
+
+        [Fact]
         public void Set_DateOfDeath_Partial_Date()
         {
             Tuple<string, string>[] datePart = { Tuple.Create("date-year", "2021"), Tuple.Create("date-month", "5"), Tuple.Create("day-absent-reason", "asked-unknown")};

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1621,7 +1621,27 @@
             "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
           }
         ],
-        "valueDateTime": "2018-02-19T16:48:06-05:00",
+        "_valueDateTime": {
+          "extension": [
+            {
+              "url":"http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason",
+              "extension" : [
+                {
+                  "url" : "date-year",
+                  "valueInteger" : 2021
+                },
+                {
+                  "url" : "date-month",
+                  "valueInteger" : 2
+                },
+                {
+                  "url" : "day-absent-reason",
+                  "valueCode" : "asked-unknown"
+                }
+              ]
+            }
+          ]
+        },
         "component": [
           {
             "code": {

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5483,7 +5483,10 @@ namespace VRDR
                     }
                     LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
                 }
-                DeathDateObs.Value = DeathDateObs.Effective = new FhirDateTime(value);
+                
+                DeathDateObs.Value = new FhirDateTime(value);
+                DeathDateObs.Effective = new FhirDateTime(value);
+
                 UpdateBundleIdentifier();
             }
         }
@@ -5537,6 +5540,10 @@ namespace VRDR
                         DeathDateObs.Value = new FhirDateTime();
                     }
                     DeathDateObs.Value.Extension.Add(datePart);
+                    // set effective date to some arbitrary date since it is a required field
+                    // TODO the IG should be updated to put the extension on the Effective Date instead of value
+                    // since effective date is the required field
+                    DeathDateObs.Effective = new FhirDateTime("2021-01-01T00:00:00-00:00");
                     
                 }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -168,6 +168,19 @@ namespace VRDR
             Bundle.AddResourceEntry(AgeAtDeathObs, "urn:uuid:" + AgeAtDeathObs.Id);
         }
 
+        private void CreateDeathDateObs() {
+            DeathDateObs = new Observation();
+            DeathDateObs.Id = Guid.NewGuid().ToString();
+            DeathDateObs.Meta = new Meta();
+            string[] deathdate_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date" };
+            DeathDateObs.Meta.Profile = deathdate_profile;
+            DeathDateObs.Status = ObservationStatus.Final;
+            DeathDateObs.Code = new CodeableConcept(CodeSystems.LOINC, "81956-5", "Date and time of death", null);
+            DeathDateObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+            AddReferenceToComposition(DeathDateObs.Id);
+            Bundle.AddResourceEntry(DeathDateObs, "urn:uuid:" + DeathDateObs.Id);
+        }
+
         /// <summary>Decedent Pregnancy Status.</summary>
         private Observation PregnancyObs;
 
@@ -5463,29 +5476,72 @@ namespace VRDR
             {
                 if (DeathDateObs == null)
                 {
-                    DeathDateObs = new Observation();
-                    DeathDateObs.Id = Guid.NewGuid().ToString();
-                    DeathDateObs.Meta = new Meta();
-                    string[] deathdate_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date" };
-                    DeathDateObs.Meta.Profile = deathdate_profile;
-                    DeathDateObs.Status = ObservationStatus.Final;
-                    DeathDateObs.Code = new CodeableConcept(CodeSystems.LOINC, "81956-5", "Date and time of death", null);
-                    DeathDateObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    CreateDeathDateObs();
                     if (Pronouncer != null)
                     {
                         DeathDateObs.Performer.Add(new ResourceReference("urn:uuid:" + Pronouncer.Id));
                     }
-                    DeathDateObs.Value = DeathDateObs.Effective = new FhirDateTime(value);
                     LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
-                    AddReferenceToComposition(DeathDateObs.Id);
-                    Bundle.AddResourceEntry(DeathDateObs, "urn:uuid:" + DeathDateObs.Id);
                 }
-                else
-                {
-                    DeathDateObs.Value = DeathDateObs.Effective = new FhirDateTime(value);
-                }
+                DeathDateObs.Value = DeathDateObs.Effective = new FhirDateTime(value);
                 UpdateBundleIdentifier();
             }
+        }
+
+        /// <summary>Decedent's Date of Death Date Part Absent Extension.</summary>
+        /// <value>the decedent's date of death date part absent reason</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.DateOfDeathDatePartReason = "2021-02-19";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Date of Death Date Part Reason: {ExampleDeathRecord.DateOfDeathDatePartAbsent}");</para>
+        /// </example>
+        [Property("Date Of Death Date Part Absent", Property.Types.TupleArr, "Death Investigation", "Decedent's Date of Birth Date Part.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Date.html", true, 14)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')._valueDateTime.extension.where(url='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason')", "_valueDateTime")]
+        public Tuple<string,string>[] DateOfDeathDatePartAbsent
+        {
+            get
+            {     
+                if (DeathDateObs != null && DeathDateObs.Value != null){
+                    Extension datePartAbsent = DeathDateObs.Value.Extension.Where(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason").FirstOrDefault();
+                    return DatePartsToArray(datePartAbsent);
+                }
+                return null;
+            }
+            set
+            {
+                if (DeathDateObs == null)
+                {
+                    CreateDeathDateObs();
+                }
+                if (value != null && value.Length > 0) 
+                {     
+                    if (DeathDateObs.Value != null)
+                    {
+                        DeathDateObs.Value.Extension.RemoveAll(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason");           
+                    }
+                    Extension datePart = new Extension();
+                    datePart.Url = "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason";
+                    foreach (Tuple<string, string> element in value)
+                    {
+                        if (element != null)
+                        {                        
+                            Extension datePartDetails = new Extension();
+                            datePartDetails.Url = element.Item1;
+                            datePartDetails.Value = new FhirString(element.Item2);
+                            datePart.Extension.Add(datePartDetails);
+                        }
+
+                    }
+                    if (DeathDateObs.Value == null){
+                        DeathDateObs.Value = new FhirDateTime();
+                    }
+                    DeathDateObs.Value.Extension.Add(datePart);
+                    
+                }
+
+            }
+                
         }
 
         /// <summary>Decedent's Date/Time of Death Pronouncement.</summary>
@@ -5516,21 +5572,12 @@ namespace VRDR
             {
                 if (DeathDateObs == null)
                 {
-                    DeathDateObs = new Observation();
-                    DeathDateObs.Id = Guid.NewGuid().ToString();
-                    DeathDateObs.Meta = new Meta();
-                    string[] deathdate_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date" };
-                    DeathDateObs.Meta.Profile = deathdate_profile;
-                    DeathDateObs.Status = ObservationStatus.Final;
-                    DeathDateObs.Code = new CodeableConcept(CodeSystems.LOINC, "81956-5", "Date and time of death", null);
-                    DeathDateObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    CreateDeathDateObs();
                     DeathDateObs.Performer.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "80616-6", "Date and time pronounced dead [US Standard Certificate of Death]", null);
                     component.Value = new FhirDateTime(value);
                     DeathDateObs.Component.Add(component);
-                    AddReferenceToComposition(DeathDateObs.Id);
-                    Bundle.AddResourceEntry(DeathDateObs, "urn:uuid:" + DeathDateObs.Id);
                 }
                 else
                 {

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1701,6 +1701,16 @@
             <para>Console.WriteLine($"Decedent Date of Death: {ExampleDeathRecord.DateOfDeath}");</para>
             </example>
         </member>
+        <member name="P:VRDR.DeathRecord.DateOfDeathDatePartAbsent">
+            <summary>Decedent's Date of Death Date Part Absent Extension.</summary>
+            <value>the decedent's date of death date part absent reason</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleDeathRecord.DateOfDeathDatePartReason = "2021-02-19";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Decedent Date of Death Date Part Reason: {ExampleDeathRecord.DateOfDeathDatePartAbsent}");</para>
+            </example>
+        </member>
         <member name="P:VRDR.DeathRecord.DateOfDeathPronouncement">
             <summary>Decedent's Date/Time of Death Pronouncement.</summary>
             <value>the decedent's date and time of death pronouncement</value>
@@ -2321,6 +2331,9 @@
         </member>
         <member name="M:VRDR.IJEMortality.BirthDate_Part_Absent_Get(System.String,System.String,System.String)">
             <summary>Get the date part value from DateOfBirthDatePartAbsent if it's populated</summary>
+        </member>
+        <member name="M:VRDR.IJEMortality.DeathDate_Part_Absent_Get(System.String,System.String,System.String)">
+            <summary>Get the date part value from DateOfDeathDatePartAbsent if it's populated</summary>
         </member>
         <member name="M:VRDR.IJEMortality.DateTime_Set(System.String,System.String,System.String,System.String,System.Boolean,System.Boolean)">
             <summary>Set a value on the DeathRecord whose type is some part of a DateTime.</summary>


### PR DESCRIPTION
Ticket [208](NVSS-208)  
IG Death Date field [here](http://hl7.org/fhir/us/vrdr/2021Sep/StructureDefinition-VRDR-Death-Date.html) 
Added the date part absent extension to the Death of Death field. There was an issue with the effective date and value date. They were previously set to be equivalent, but now there is an extension only on the value date field. This means in a roundtrip where there are absent date parts, the required effective date field must be assigned an arbitrary date. The IG should likely be updated to put the extension on the required field.

Added several tests for the Date of Death Date Part Absent field