### PR TITLE
Create observations when null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v3.2.0-preview4 - 2021-09-02
+
+* Fixed bug that causes error when calling data absent boolean setter methods
+
 ### v3.2.0-preview3 - 2021-09-01
 
 * Add methods for getting and setting AgeAtDeathAbsentReason and BirthRecordIdentifierAbsentReason. A boolean getter and setter returning whether a reason has been set has also been provided.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>3.2.0-preview3</Version>
+        <Version>3.2.0-preview4</Version>
         <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
         <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This repository includes .NET (C#) code for
 <tr>
 <td style="text-align: center;">STU2 Ballot</td>
 <td style="text-align: center;">R4</td>
-<td style="text-align: center;">V3.2.0-preview3</td>
-<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR/3.2.0-preview3">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/v3.2.0-preview3"> github</a></td>
-<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR.Messaging/3.2.0-preview3">nuget</a> <a href="https://github.com/nightingaleproject/vital_records_fhir_messaging/releases/download/v3.1.0/fhir_messaging_for_nvss.pdf"> github</a></td>
+<td style="text-align: center;">V3.2.0-preview4</td>
+<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR/3.2.0-preview4">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/v3.2.0-preview4"> github</a></td>
+<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR.Messaging/3.2.0-preview4">nuget</a> <a href="https://github.com/nightingaleproject/vital_records_fhir_messaging/releases/download/v3.1.0/fhir_messaging_for_nvss.pdf"> github</a></td>
 </tr>
 </tbody>
 </table>
@@ -65,7 +65,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR" Version="3.2.0-preview3" />
+  <PackageReference Include="VRDR" Version="3.2.0-preview4" />
   ...
 </ItemGroup>
 ```
@@ -230,7 +230,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR.Messaging" Version="3.2.0-preview3" />
+  <PackageReference Include="VRDR.Messaging" Version="3.2.0-preview4" />
   ...
 </ItemGroup>
 ```

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -4200,13 +4200,13 @@ namespace VRDR
             }
         }
 
-        /// <summary>Decedent's Age At Death Data Absent Boolean.</summary>
+        /// <summary>Birth Record Identifier Data Absent Boolean.</summary>
         /// <value>True if the data absent reason field is present</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.AgeAtDeathAbsentBoolean = true;</para>
+        /// <para>ExampleDeathRecord.BirthRecordIdentifierDataAbsentBoolean = true;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"AgeAtDeathDataAbsentBoolean: {ExampleDeathRecord.AgeAtDeathDataAbsentReason}");</para>
+        /// <para>Console.WriteLine($"BirthRecordIdentifierDataAbsentBoolean: {ExampleDeathRecord.BirthRecordIdentifierDataAbsentReason}");</para>
         /// </example>
         [Property("Birth Record Identifier Data Absent (Boolean)", Property.Types.Bool, "Decedent Demographics", "Birth Record Identifier Data Absent Reason.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-BirthRecordIdentifier.html", false, 17)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='30525-0').dataAbsentReason", "")]
@@ -4226,6 +4226,11 @@ namespace VRDR
                 }
                 else
                 {
+                    if (BirthRecordIdentifier == null)
+                    {
+                        CreateBirthRecordIdentifier();
+
+                    }
                     // If there already is a data absent reason do not overwrite it with the default
                     if(BirthRecordIdentifier.DataAbsentReason == null) {
                         BirthRecordIdentifierDataAbsentReason = new Dictionary<string, string>() {
@@ -6180,6 +6185,10 @@ namespace VRDR
                 }
                 else
                 {
+                    if (AgeAtDeathObs == null)
+                    {
+                        CreateAgeAtDeathObs();
+                    }
                     // If there already is a data absent reason do not overwrite it with the default
                     if(AgeAtDeathObs.DataAbsentReason == null) {
                         AgeAtDeathDataAbsentReason = new Dictionary<string, string>() {

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1365,13 +1365,13 @@
             </example>
         </member>
         <member name="P:VRDR.DeathRecord.BirthRecordIdentifierDataAbsentBoolean">
-            <summary>Decedent's Age At Death Data Absent Boolean.</summary>
+            <summary>Birth Record Identifier Data Absent Boolean.</summary>
             <value>True if the data absent reason field is present</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleDeathRecord.AgeAtDeathAbsentBoolean = true;</para>
+            <para>ExampleDeathRecord.BirthRecordIdentifierDataAbsentBoolean = true;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"AgeAtDeathDataAbsentBoolean: {ExampleDeathRecord.AgeAtDeathDataAbsentReason}");</para>
+            <para>Console.WriteLine($"BirthRecordIdentifierDataAbsentBoolean: {ExampleDeathRecord.BirthRecordIdentifierDataAbsentReason}");</para>
             </example>
         </member>
         <member name="P:VRDR.DeathRecord.BirthRecordState">


### PR DESCRIPTION
Pete found - Setting BirthRecordIdentifierDataAbsentBoolean or AgeAtDeathDataAbsentBoolean to true on a blank record causes an error because they both assume the presence of an object, and some incorrect header comments