### PR TITLE
Broaden the check for empty dictionaries to address a canary bug

### DIFF
--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -7472,21 +7472,12 @@ namespace VRDR
             return codeableConcept;
         }
 
-        /// <summary>Check if a dictionary is empty or one of our</summary>
+        /// <summary>Check if a dictionary is empty or a default empty dictionary (all values are null or empty strings)</summary>
         /// <param name="dict">represents a code.</param>
         /// <returns>A boolean identifying whether the provided dictionary is empty or default.</returns>
         private bool IsDictEmptyOrDefault(Dictionary<string, string> dict)
         {
-            return dict.Count == 0 || DictCompare(EmptyCodeableDict(), dict) || DictCompare(EmptyCodeDict(), dict);
-        }
-
-        /// <summary>Check if two dictionaries are equal</summary>
-        /// <param name="dict1">the first dictionary.</param>
-        /// <param name="dict2">the dictionary to compare the first against.</param>
-        /// <returns>A boolean identifying whether the provided dictionaries match</returns>
-        private bool DictCompare(Dictionary<string, string> dict1, Dictionary<string, string> dict2)
-        {
-            return dict1.Count == dict2.Count && !dict1.Except(dict2).Any();
+            return dict.Count == 0 || dict.Values.All(v => v == null || v == "");
         }
 
         /// <summary>Convert a FHIR Coding to a "code" Dictionary</summary>

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -2166,15 +2166,9 @@
             <returns>the corresponding CodeableConcept representation of the code.</returns>
         </member>
         <member name="M:VRDR.DeathRecord.IsDictEmptyOrDefault(System.Collections.Generic.Dictionary{System.String,System.String})">
-            <summary>Check if a dictionary is empty or one of our</summary>
+            <summary>Check if a dictionary is empty or a default empty dictionary (all values are null or empty strings)</summary>
             <param name="dict">represents a code.</param>
             <returns>A boolean identifying whether the provided dictionary is empty or default.</returns>
-        </member>
-        <member name="M:VRDR.DeathRecord.DictCompare(System.Collections.Generic.Dictionary{System.String,System.String},System.Collections.Generic.Dictionary{System.String,System.String})">
-            <summary>Check if two dictionaries are equal</summary>
-            <param name="dict1">the first dictionary.</param>
-            <param name="dict2">the dictionary to compare the first against.</param>
-            <returns>A boolean identifying whether the provided dictionaries match</returns>
         </member>
         <member name="M:VRDR.DeathRecord.CodingToDict(Hl7.Fhir.Model.Coding)">
             <summary>Convert a FHIR Coding to a "code" Dictionary</summary>


### PR DESCRIPTION
Canary first converts records to "dictionary" mode and then converts them back when doing comparisons. For some (as yet undetermined) reason, the conversion in canary causes some fields to be rendered in "dictionary" mode as nulls rather than empty strings. These nulls, when present in the new DataAbsent fields (e.g. `AgeAtDeathDataAbsentReason`) cause the values in the related data fields to be unset because nulls were not considered "empty". This pull request tweaks `IsDictEmptyOrDefault` to accept a broader definition of nulls.

This addresses NVSS-262 (once Canary uses a version of the .NET libraries that includes this pull request).