### PR TITLE
Update README and the field description for jurisdiction id

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository includes .NET (C#) code for
 
-- Producing and consuming the Vital Records Death Reporting (VRDR) Health Level 7 (HL7) Fast Healthcare Interoperability Resources (FHIR) standard. [Click here to view the FHIR Implementation Guide](http://hl7.org/fhir/us/vrdr/).
+- Producing and consuming the Vital Records Death Reporting (VRDR) Health Level 7 (HL7) Fast Healthcare Interoperability Resources (FHIR) standard. [Click here to view the FHIR Implementation Guide STU2](http://hl7.org/fhir/us/vrdr/2021Sep/).
 - Producing and consuming FHIR messages for the exchange of VRDR documents.
 - Support for converting VRDR FHIR records to and from the Inter-Jurisdictional Exchange (IJE) Mortality format, as well as companion microservice for performing conversions.
 - This codebase covers the subset of the IJE fields listed in this [spreadsheet](VRDRdotNETLibraryCoverage.csv).
@@ -50,7 +50,10 @@ This repository includes .NET (C#) code for
 - You can also use .NET Core 2.1, see VRDR.CLI section below for instructions
 ### Library Usage
 - The VRDR or VRDR.Messaging libraries target .NET Standard 2.0
-- To check whether your .NET version supports a release, refer to (this)[https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support] .NET matrix. First, note whether you are using .NET Core or .NET Framework - see (here)[https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/september/net-standard-demystifying-net-core-and-net-standard] for distinctions between the .NET implementation option. Once you’ve determined your .NET implementation type and version, for example you are using .NET Framework 4.6.1, refer to the matrix to verify whether your .NET implementation supports the targeted .NET Standard version. By looking at the matrix, you can see the .NET Framework 4.6.1 supports .NET Standard 2.0 so the tool would be supported.
+- To check whether your .NET version supports a release, refer to [the .NET matrix](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support).
+  - Note whether you are using .NET Core or .NET Framework - see [here](https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/september/net-standard-demystifying-net-core-and-net-standard) for distinctions between the .NET implementation options. 
+  - Once you’ve determined your .NET implementation type and version, for example you are using .NET Framework 4.6.1, refer to the matrix to verify whether your .NET implementation supports the targeted .NET Standard version. 
+    - Ex. If you are using .NET Framework 4.6.1, you can look at the matrix and see the .NET Framework 4.6.1 supports .NET Standard 2.0 so the tool would be supported.
 
 ## Project Organization
 
@@ -113,9 +116,9 @@ deathRecord.CODE1A = exampleCode;
 
 // Add PregnancyStatus
 Dictionary<string, string> code = new Dictionary<string, string>();
-code.Add("code", "PHC1260");
-code.Add("system", "urn:oid:2.16.840.1.114222.4.5.274");
-code.Add("display", "Not pregnant within past year");
+code.Add("code", "PHC1261");
+code.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+code.Add("display", "Pregnant at the time of death");
 deathRecord.PregnancyStatus = code;
 
 // Add ExaminerContacted

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5880,7 +5880,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Jurisdiction: {ExampleDeathRecord.DeathLocationJurisdiction}");</para>
         /// </example>
-        [Property("Death Location Jurisdiction", Property.Types.String, "Death Investigation", "The Jurisdiction Name, the library will generate the codeable concept.", true, locationJurisdictionExtPath, false, 16)]
+        [Property("Death Location Jurisdiction", Property.Types.String, "Death Investigation", "Vital Records Jurisdiction of Death Location (two character jurisdiction code, e.g. CA).", true, locationJurisdictionExtPath, false, 16)]
         [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location')", "name")]
         public string DeathLocationJurisdiction
         {

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5880,7 +5880,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Jurisdiction: {ExampleDeathRecord.DeathLocationJurisdiction}");</para>
         /// </example>
-        [Property("Death Location Jurisdiction", Property.Types.String, "Death Investigation", "Vital Records Jurisdiction of Death Location.", true, locationJurisdictionExtPath, false, 16)]
+        [Property("Death Location Jurisdiction", Property.Types.String, "Death Investigation", "The Jurisdiction Name, the library will generate the codeable concept.", true, locationJurisdictionExtPath, false, 16)]
         [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location')", "name")]
         public string DeathLocationJurisdiction
         {


### PR DESCRIPTION
Changes for Connectathon Sep 2021

- For ticket 251, Update README.md
  - Updated the library README to link to the STU2 IG
  - Fixed the formatting for the links in the Library Usage section
  - Updated the pregnancy status example in the README
- For ticket 258, Canary doesn't allow user to enter codeable concept for jurisdiction id
  - This was intentional, the user should enter the jurisdiction name and the library will do the conversion
  - The field description was updated so the user knows what value they should enter, see screen shot below
![Screen Shot 2021-09-13 at 12 07 56 PM](https://user-images.githubusercontent.com/67597111/133123359-d394ea37-0216-434f-9eed-f341ce8b98fd.png)
