### PR TITLE
Correct the FHIR path for the Death Location Jurisdiction

### DIFF
--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5881,7 +5881,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Death Location Jurisdiction: {ExampleDeathRecord.DeathLocationJurisdiction}");</para>
         /// </example>
         [Property("Death Location Jurisdiction", Property.Types.String, "Death Investigation", "Vital Records Jurisdiction of Death Location (two character jurisdiction code, e.g. CA).", true, locationJurisdictionExtPath, false, 16)]
-        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location')", "name")]
+        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location')", "extension")]
         public string DeathLocationJurisdiction
         {
             get


### PR DESCRIPTION
The FHIR page, which is used to display code snippets in Canary, was incorrect for the death location jurisdiction. This addresses NVSS-256.