### PR TITLE
Fix FHIRPath and data types for date absent extension support

### DIFF
--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -319,7 +319,7 @@ namespace VRDR.Tests
             DeathRecord dr1 = ije1.ToDeathRecord();
             Assert.True(dr1.DateOfBirthDatePartAbsent != null);
 
-            Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "unknown"), Tuple.Create("date-month", "01"), Tuple.Create("date-day", "01")};
+            Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "unknown"), Tuple.Create("date-month", "1"), Tuple.Create("date-day", "1")};
             Assert.Equal(datePart[0], dr1.DateOfBirthDatePartAbsent[0]);
             Assert.Equal(datePart[1], dr1.DateOfBirthDatePartAbsent[1]);
             Assert.Equal(datePart[2], dr1.DateOfBirthDatePartAbsent[2]);

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -3025,7 +3025,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Decedent Date of Birth Date Part Reason: {ExampleDeathRecord.DateOfBirthDatePartAbsent}");</para>
         /// </example>
         [Property("Date Of Birth Date Part Absent", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Date of Birth Date Part.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)._birthDate.extension.where(url='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason')", "_birthDate")]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "_birthDate")]
         public Tuple<string,string>[] DateOfBirthDatePartAbsent
         {
             get
@@ -3049,7 +3049,14 @@ namespace VRDR
                         {
                             Extension datePartDetails = new Extension();
                             datePartDetails.Url = element.Item1;
-                            datePartDetails.Value = new FhirString(element.Item2);
+                            if (datePartDetails.Url == "date-year" || datePartDetails.Url == "date-month" || datePartDetails.Url == "date-day")
+                            {
+                                datePartDetails.Value = new Integer(Int32.Parse(element.Item2));
+                            }
+                            else
+                            {
+                                datePartDetails.Value = new Code(element.Item2);
+                            }
                             datePart.Extension.Add(datePartDetails);
                         }
 
@@ -5604,7 +5611,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Decedent Date of Death Date Part Reason: {ExampleDeathRecord.DateOfDeathDatePartAbsent}");</para>
         /// </example>
         [Property("Date Of Death Date Part Absent", Property.Types.TupleArr, "Death Investigation", "Decedent's Date of Birth Date Part.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Date.html", true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')._valueDateTime.extension.where(url='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason')", "_valueDateTime")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "_valueDateTime")]
         public Tuple<string,string>[] DateOfDeathDatePartAbsent
         {
             get
@@ -5635,7 +5642,14 @@ namespace VRDR
                         {
                             Extension datePartDetails = new Extension();
                             datePartDetails.Url = element.Item1;
-                            datePartDetails.Value = new FhirString(element.Item2);
+                            if (datePartDetails.Url == "date-year" || datePartDetails.Url == "date-month" || datePartDetails.Url == "date-day")
+                            {
+                                datePartDetails.Value = new Integer(Int32.Parse(element.Item2));
+                            }
+                            else
+                            {
+                                datePartDetails.Value = new Code(element.Item2);
+                            }
                             datePart.Extension.Add(datePartDetails);
                         }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -3049,14 +3049,7 @@ namespace VRDR
                         {
                             Extension datePartDetails = new Extension();
                             datePartDetails.Url = element.Item1;
-                            if (datePartDetails.Url == "date-year" || datePartDetails.Url == "date-month" || datePartDetails.Url == "date-day")
-                            {
-                                datePartDetails.Value = new Integer(Int32.Parse(element.Item2));
-                            }
-                            else
-                            {
-                                datePartDetails.Value = new Code(element.Item2);
-                            }
+                            datePartDetails.Value = DatePartToIntegerOrCode(element);
                             datePart.Extension.Add(datePartDetails);
                         }
 
@@ -5642,14 +5635,7 @@ namespace VRDR
                         {
                             Extension datePartDetails = new Extension();
                             datePartDetails.Url = element.Item1;
-                            if (datePartDetails.Url == "date-year" || datePartDetails.Url == "date-month" || datePartDetails.Url == "date-day")
-                            {
-                                datePartDetails.Value = new Integer(Int32.Parse(element.Item2));
-                            }
-                            else
-                            {
-                                datePartDetails.Value = new Code(element.Item2);
-                            }
+                            datePartDetails.Value = DatePartToIntegerOrCode(element);
                             datePart.Extension.Add(datePartDetails);
                         }
 
@@ -7631,6 +7617,20 @@ namespace VRDR
                 }
             }
             return dateParts.ToArray();
+        }
+
+        /// <summary>Convert an element to an integer or code depending on if the input element is a date part.</summary>
+        /// <param name="pair">A key value pair, the key will be used to identify whether the element is a date part.</param>
+        private Element DatePartToIntegerOrCode(Tuple<string, string> pair)
+        {
+            if (pair.Item1 == "date-year" || pair.Item1 == "date-month" || pair.Item1 == "date-day")
+            {
+                return new Integer(Int32.Parse(pair.Item2));
+            }
+            else
+            {
+                return new Code(pair.Item2);
+            }
         }
 
         /// <summary>Convert a FHIR Address to an "address" Dictionary.</summary>

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -2190,6 +2190,10 @@
             <param name="datePartAbsent">a Date Part Extension.</param>
             <returns>the corresponding array representation of the date parts.</returns>
         </member>
+        <member name="M:VRDR.DeathRecord.TupleToIntegerOrCode(System.Tuple{System.String,System.String})">
+            <summary>Convert an element to an integer or code depending on if the input element is a date part.</summary>
+            <param name="pair">A key value pair, the key will be used to identify whether the element is a date part.</param>
+        </member>
         <member name="M:VRDR.DeathRecord.AddressToDict(Hl7.Fhir.Model.Address)">
             <summary>Convert a FHIR Address to an "address" Dictionary.</summary>
             <param name="addr">a FHIR Address.</param>


### PR DESCRIPTION
This pull request

- Updates our use of date absent extensions (for both birth date and death date) to correctly use valueCode or valueInteger datatypes instead of the valueString type we were using
- Updates the FHIRPath for these extensions so that Canary can correctly display these fields