### PR TITLE
254 invalid jurisdiction ext

### DIFF
--- a/VRDR.CLI/1.json
+++ b/VRDR.CLI/1.json
@@ -1511,6 +1511,20 @@
             "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
           ]
         },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                "system": "2.16.840.1.113883.6.92",
+                "code": "25",
+                "display": "MA"
+                }
+              ]
+            }
+          }
+        ],
         "name": "Example Death Location Name",
         "description": "Example Death Location Description",
         "address": {

--- a/VRDR.CLI/1.xml
+++ b/VRDR.CLI/1.xml
@@ -1233,6 +1233,15 @@
         <meta>
           <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" />
         </meta>
+        <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id">
+          <valueCodeableConcept>
+            <coding>
+              <system value="2.16.840.1.113883.6.92"/>
+              <code value="25"/>
+              <display value="MA"/>
+            </coding>
+          </valueCodeableConcept>
+        </extension>
         <name value="Example Death Location Name" />
         <description value="Example Death Location Description" />
         <address>

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -22,6 +22,7 @@ namespace VRDR.HTTP
             Dictionary<string, string> values = new Dictionary<string, string>();
 
             SetStringValueDictionary(values, "certificateNumber", record.Identifier);
+            SetStringValueDictionary(values, "deathLocationJurisdiction", record.DeathLocationJurisdiction);
 
             SetYesNoValueDictionary(values, "armedForcesService.armedForcesService", record, "MilitaryService");
             SetYesNoValueDictionary(values, "autopsyPerformed.autopsyPerformed", record, "AutopsyPerformedIndicator");
@@ -249,6 +250,8 @@ namespace VRDR.HTTP
             DeathRecord deathRecord = new DeathRecord();
 
             SetStringValueDeathRecordString(deathRecord, "Identifier", GetValue(values, "certificateNumber"));
+            SetStringValueDeathRecordString(deathRecord, "DeathLocationJurisdiction", GetValue(values, "deathLocationJurisdiction"));
+
 
             SetYesNoValueDeathRecordCode(deathRecord, "MilitaryService", GetValue(values, "armedForcesService.armedForcesService"));
             SetYesNoValueDeathRecordCode(deathRecord, "AutopsyPerformedIndicator", GetValue(values, "autopsyPerformed.autopsyPerformed"));

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <None Update="fixtures/json/DeathRecord1.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordNoIdentifiers.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/DeathRecordNoIdentifiersExceptJurisdictionId.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/AckMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BadConditions.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/CauseOfDeathCodingMessage.json" CopyToOutputDirectory="PreserveNewest" />

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -34,6 +34,7 @@
     <None Update="fixtures/json/EmptyMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/EmptySubmission.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/ExtractionErrorMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/InvalidJurisdictionId.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/InvalidMessageType.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/MissingArray.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/MissingAge.json" CopyToOutputDirectory="PreserveNewest" />

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -103,6 +103,17 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void FailOnInvalidDeathLocationJurisdiction()
+        {
+            // In input file's http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id extension uses an old format from version 3.0.0 RC5 
+            // if the input is invalid, an error is thrown
+            DeathRecord deathRecord = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/InvalidJurisdictionId.json")));
+            String deathJurisdiction;
+            Exception ex = Assert.Throws<System.ArgumentException>(() => deathJurisdiction = deathRecord.DeathLocationJurisdiction);
+            Assert.Equal("Death Location Jurisdiction is required, but not found. Check the extension is formatted correctly. (Parameter 'http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id')", ex.Message);
+        }
+
+        [Fact]
         public void EmptyRecordToDescription()
         {
             DeathRecord deathRecord = new DeathRecord();
@@ -167,16 +178,6 @@ namespace VRDR.Tests
         {
             DeathRecord deathRecord = new DeathRecord();
             IJEMortality ije = new IJEMortality(deathRecord);
-            Assert.Equal("  ", ije.DSTATE);
-        }
-
-    [Fact]
-        public void InvalidDeathLocationJurisdictionJsontoIJE()
-        {
-            // In input file's http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id extension uses an old format from version 3.0.0 RC5 
-            // if the input is invalid, it will interpret the value as missing, no error is thrown
-            DeathRecord djson = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/InvalidJurisdictionId.json")));
-            IJEMortality ije = new IJEMortality(djson);
             Assert.Equal("  ", ije.DSTATE);
         }
 
@@ -2437,6 +2438,7 @@ namespace VRDR.Tests
             dtladdress.Add("addressState", "MA");
             dtladdress.Add("addressZip", "01730");
             dtladdress.Add("addressCountry", "US");
+            SetterDeathRecord.DeathLocationJurisdiction = "MA";
             SetterDeathRecord.DeathLocationAddress = dtladdress;
             Assert.Equal("671 Example Street", SetterDeathRecord.DeathLocationAddress["addressLine1"]);
             Assert.Equal("Line 2", SetterDeathRecord.DeathLocationAddress["addressLine2"]);

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -110,7 +110,7 @@ namespace VRDR.Tests
             DeathRecord deathRecord = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/InvalidJurisdictionId.json")));
             String deathJurisdiction;
             Exception ex = Assert.Throws<System.ArgumentException>(() => deathJurisdiction = deathRecord.DeathLocationJurisdiction);
-            Assert.Matches("^Death Location Jurisdiction is required, but not found. Check the extension is formatted correctly", ex.Message);
+            Assert.Matches("^Death Location Jurisdiction is required, but not found. Check that the extension is formatted correctly", ex.Message);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -163,6 +163,24 @@ namespace VRDR.Tests
         }
 
       [Fact]
+        public void NoDeathLocationJurisdictionJsontoIJE()
+        {
+            DeathRecord deathRecord = new DeathRecord();
+            IJEMortality ije = new IJEMortality(deathRecord);
+            Assert.Equal("  ", ije.DSTATE);
+        }
+
+    [Fact]
+        public void InvalidDeathLocationJurisdictionJsontoIJE()
+        {
+            // In input file's http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id extension uses an old format from version 3.0.0 RC5 
+            // if the input is invalid, it will interpret the value as missing, no error is thrown
+            DeathRecord djson = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/InvalidJurisdictionId.json")));
+            IJEMortality ije = new IJEMortality(djson);
+            Assert.Equal("  ", ije.DSTATE);
+        }
+
+        [Fact]
         public void ParseDeathLocationTypeIJEtoJson()
         {
             DeathRecord djson = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathLocationType.json")));
@@ -2571,6 +2589,5 @@ namespace VRDR.Tests
                 return Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
             }
         }
-
     }
 }

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -110,7 +110,7 @@ namespace VRDR.Tests
             DeathRecord deathRecord = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/InvalidJurisdictionId.json")));
             String deathJurisdiction;
             Exception ex = Assert.Throws<System.ArgumentException>(() => deathJurisdiction = deathRecord.DeathLocationJurisdiction);
-            Assert.Equal("Death Location Jurisdiction is required, but not found. Check the extension is formatted correctly. (Parameter 'http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id')", ex.Message);
+            Assert.Matches("^Death Location Jurisdiction is required, but not found. Check the extension is formatted correctly", ex.Message);
         }
 
         [Fact]

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -20,6 +20,7 @@ namespace VRDR.Tests
             JSONRecords = new ArrayList();
             JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecord1.json"))));
             JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecordNoIdentifiers.json"))));
+            JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecordNoIdentifiersExceptJurisdictionId.json"))));
         }
 
         [Fact]
@@ -69,7 +70,10 @@ namespace VRDR.Tests
             Assert.Null(submission.StateAuxiliaryIdentifier);
             Assert.Null(submission.NCHSIdentifier);
 
-            record = (DeathRecord)JSONRecords[1]; // no ids in this record
+            record = (DeathRecord)JSONRecords[1]; // no ids in this record, should error on missing jurisdiction id
+            Assert.Throws<System.ArgumentException>(() => new DeathRecordSubmission(record));
+
+            record = (DeathRecord)JSONRecords[2];
             submission = new DeathRecordSubmission(record);
             Assert.NotNull(submission.DeathRecord);
             Assert.Equal("2018-02-20T16:48:06-05:00", submission.DeathRecord.DateOfDeathPronouncement);
@@ -140,7 +144,7 @@ namespace VRDR.Tests
             Assert.Equal("42", update.StateAuxiliaryIdentifier);
             Assert.Equal("2018MA000001", update.NCHSIdentifier);
 
-            update = new DeathRecordUpdate((DeathRecord)JSONRecords[1]); // no ids in this death record
+            update = new DeathRecordUpdate((DeathRecord)JSONRecords[2]); // no ids in this death record (except jurisdiction id which is required)
             Assert.NotNull(update.DeathRecord);
             Assert.Equal("2018-02-20T16:48:06-05:00", update.DeathRecord.DateOfDeathPronouncement);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission_update", update.MessageType);

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiersExceptJurisdictionId.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiersExceptJurisdictionId.json
@@ -1,0 +1,1520 @@
+{
+  "resourceType": "Bundle",
+  "id": "27c1f73d-59a7-4c52-bb20-7073c1778535",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document"
+    ]
+  },
+  "type": "document",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:590aa717-4e8d-413f-a62b-89ceb143539d",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "590aa717-4e8d-413f-a62b-89ceb143539d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate"
+          ]
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "64297-5",
+              "display": "Death certificate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "date": "2019-02-01T16:47:04-05:00",
+        "attester": [
+          {
+            "mode": "legal",
+            "time": "2019-01-29T16:48:06-05:00",
+            "party": {
+              "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+            }
+          }
+        ],
+        "event": [
+          {
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "103693007",
+                    "display": "Diagnostic procedure (procedure)"
+                  }
+                ]
+              }
+            ],
+            "detail": [
+              {
+                "reference": "urn:uuid:2d71d05b-7f52-4c13-bd19-68a251e3544d"
+              }
+            ]
+          }
+        ],
+        "section": [
+          {
+            "entry": [
+              {
+                "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+              },
+              {
+                "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+              },
+              {
+                "reference": "urn:uuid:84452aa0-fc31-4f4c-848f-b8f1e5bba1c0"
+              },
+              {
+                "reference": "urn:uuid:2d71d05b-7f52-4c13-bd19-68a251e3544d"
+              },
+              {
+                "reference": "urn:uuid:17e6d6c8-deea-464b-a009-d077ceb30af1"
+              },
+              {
+                "reference": "urn:uuid:cffcc6e0-7324-4898-b876-9107d275eafa"
+              },
+              {
+                "reference": "urn:uuid:c834ea74-e93d-4a51-bc02-60466b9e4f14"
+              },
+              {
+                "reference": "urn:uuid:4cbea811-716f-4bd4-85e0-a0cdeccfa795"
+              },
+              {
+                "reference": "urn:uuid:fe696fc7-7683-4268-92d8-b3a7c88b1587"
+              },
+              {
+                "reference": "urn:uuid:64551ae3-51ac-48e6-8d8a-41fd3ad29916"
+              },
+              {
+                "reference": "urn:uuid:fc27b07f-99c9-48f8-a229-6eb5d8b598f0"
+              },
+              {
+                "reference": "urn:uuid:b66d97ea-56b1-4397-8de3-fb989007485b"
+              },
+              {
+                "reference": "urn:uuid:8b7a9ca6-1276-402f-a521-35155234af14"
+              },
+              {
+                "reference": "urn:uuid:bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f"
+              },
+              {
+                "reference": "urn:uuid:223eaadb-5909-458c-bbe5-604c120c3ce9"
+              },
+              {
+                "reference": "urn:uuid:097c0d70-6807-48c0-9710-7d4e96726234"
+              },
+              {
+                "reference": "urn:uuid:0113aba7-3a33-48f3-a1f9-a76f050d37f1"
+              },
+              {
+                "reference": "urn:uuid:db1ec90f-038a-4ebc-b714-3b92c76b5fb8"
+              },
+              {
+                "reference": "urn:uuid:79c8753a-bb2b-4e99-800c-cabfe9b97b57"
+              },
+              {
+                "reference": "urn:uuid:327874e2-3e59-4c0d-9fb2-a5a9f9cc7f6c"
+              },
+              {
+                "reference": "urn:uuid:fee9f666-7099-4259-9a6c-25cf57f75654"
+              },
+              {
+                "reference": "urn:uuid:fc9de024-0fae-4bda-bfbb-04c08c083a43"
+              },
+              {
+                "reference": "urn:uuid:b0e1c9fd-8ec1-4d61-bf29-1ef39d1d4229"
+              },
+              {
+                "reference": "urn:uuid:b9a24c57-3f44-4091-b690-2eb4f6748919"
+              },
+              {
+                "reference": "urn:uuid:19cb645f-c8f9-44fc-9137-6f33b009d355"
+              },
+              {
+                "reference": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f"
+              },
+              {
+                "reference": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d"
+              },
+              {
+                "reference": "urn:uuid:d15a4ea5-ee1b-4760-b177-fea17fa75c09"
+              },
+              {
+                "reference": "urn:uuid:3c1f5202-68de-47e8-813f-43a3f7f29129"
+              },
+              {
+                "reference": "urn:uuid:38070a6e-d934-4a56-ac57-bbba133d6df0"
+              },
+              {
+                "reference": "urn:uuid:4678efc2-2529-4a7e-8266-fdc907d89e00"
+              },
+              {
+                "reference": "urn:uuid:81899bd9-0441-45f0-9b89-9d91daa08983"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "949354d3-9dcf-4c96-8ec4-6be27dd4c65f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "F"
+          },
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2135-2",
+                  "display": "Hispanic or Latino"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2180-8",
+                  "display": "Puerto Rican"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Hispanic or Latino, Puerto Rican"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+          },
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2106-3",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2076-8",
+                  "display": "Native Hawaiian or Other Pacific Islander"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2079-2",
+                  "display": "Native Hawaiian"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "White, Native Hawaiian or Other Pacific Islander, Native Hawaiian"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+            "valueAddress": {
+              "line": [
+                "1011 Example Street",
+                "Line 2"
+              ],
+              "city": "Bedford",
+              "district": "Middlesex",
+              "state": "MA",
+              "postalCode": "01730",
+              "country": "US"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "code": "SB",
+                  "display": "Social Beneficiary Identifier"
+                }
+              ]
+            },
+            "system": "http://hl7.org/fhir/sid/us-ssn",
+            "value": "123456789"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Last",
+            "given": [
+              "Example",
+              "Something",
+              "Middle"
+            ],
+            "suffix": [
+              "Jr."
+            ]
+          },
+          {
+            "use": "nickname",
+            "family": "LastNameAlias",
+            "given": [
+              "FirstNameAlias",
+              "MiddleAlias"
+            ],
+            "suffix": [
+              "Jr."
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1940-02-19",
+        "address": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator",
+                "valueCoding": {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                  "code": "N",
+                  "display": "No"
+                }
+              }
+            ],
+            "line": [
+              "101 Example Street",
+              "Line 2"
+            ],
+            "city": "Bedford",
+            "district": "Middlesex",
+            "state": "MA",
+            "postalCode": "01730",
+            "country": "US"
+          }
+        ],
+        "maritalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              "code": "S",
+              "display": "Never Married"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "0402b9de-2347-4580-a9bf-b984c161ed2d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier"
+          ]
+        },
+        "name": [
+          {
+            "use": "official",
+            "family": "Last",
+            "given": [
+              "Doctor",
+              "Middle"
+            ],
+            "suffix": [
+              "Jr."
+            ]
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "11 Example Street",
+              "Line 2"
+            ],
+            "city": "Bedford",
+            "district": "Middlesex",
+            "state": "MA",
+            "postalCode": "01730",
+            "country": "US"
+          }
+        ],
+        "qualification": [
+          {
+            "identifier": [
+              {
+                "value": "789123456"
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "urn:oid:2.16.840.1.114222.4.11.7186",
+                  "code": "3060",
+                  "display": "Physicians and surgeons"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:84452aa0-fc31-4f4c-848f-b8f1e5bba1c0",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "84452aa0-fc31-4f4c-848f-b8f1e5bba1c0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician"
+          ]
+        },
+        "name": [
+          {
+            "use": "official",
+            "family": "Last",
+            "given": [
+              "FD",
+              "Middle"
+            ],
+            "suffix": [
+              "Jr."
+            ]
+          }
+        ],
+        "qualification": [
+          {
+            "identifier": [
+              {
+                "value": "9876543210"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:2d71d05b-7f52-4c13-bd19-68a251e3544d",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "2d71d05b-7f52-4c13-bd19-68a251e3544d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification"
+          ]
+        },
+        "status": "completed",
+        "category": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "103693007",
+              "display": "Diagnostic procedure"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "308646001",
+              "display": "Death certification"
+            }
+          ]
+        },
+        "performedDateTime": "2019-01-29T16:48:06-05:00",
+        "performer": [
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "434641000124105",
+                  "display": "Physician"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:17e6d6c8-deea-464b-a009-d077ceb30af1",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "17e6d6c8-deea-464b-a009-d077ceb30af1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party"
+          ]
+        },
+        "identifier": [
+          {
+            "value": "1010101"
+          }
+        ],
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                "code": "prov",
+                "display": "Healthcare Provider"
+              }
+            ]
+          }
+        ],
+        "name": "Example Hospital",
+        "address": [
+          {
+            "line": [
+              "10 Example Street",
+              "Line 2"
+            ],
+            "city": "Bedford",
+            "district": "Middlesex",
+            "state": "MA",
+            "postalCode": "01730",
+            "country": "US"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:cffcc6e0-7324-4898-b876-9107d275eafa",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "cffcc6e0-7324-4898-b876-9107d275eafa",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
+          ]
+        },
+        "type": [
+          {
+            "coding": [
+              {
+                "code": "bus",
+                "display": "Non-Healthcare Business or Corporation"
+              }
+            ]
+          }
+        ],
+        "name": "Smith Funeral Home",
+        "address": [
+          {
+            "line": [
+              "1011010 Example Street",
+              "Line 2"
+            ],
+            "city": "Bedford",
+            "district": "Middlesex",
+            "state": "MA",
+            "postalCode": "01730",
+            "country": "US"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c834ea74-e93d-4a51-bc02-60466b9e4f14",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "c834ea74-e93d-4a51-bc02-60466b9e4f14",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Service-Licensee"
+          ]
+        },
+        "practitioner": {
+          "reference": "urn:uuid:84452aa0-fc31-4f4c-848f-b8f1e5bba1c0"
+        },
+        "organization": {
+          "reference": "urn:uuid:cffcc6e0-7324-4898-b876-9107d275eafa"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4cbea811-716f-4bd4-85e0-a0cdeccfa795",
+      "resource": {
+        "resourceType": "List",
+        "id": "4cbea811-716f-4bd4-85e0-a0cdeccfa795",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "source": {
+          "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        },
+        "orderedBy": {
+          "coding": [
+            {
+              "code": "priority"
+            }
+          ]
+        },
+        "entry": [
+          {
+            "item": {
+              "reference": "urn:uuid:b66d97ea-56b1-4397-8de3-fb989007485b"
+            }
+          },
+          {
+            "item": {
+              "reference": "urn:uuid:8b7a9ca6-1276-402f-a521-35155234af14"
+            }
+          },
+          {
+            "item": {
+              "reference": "urn:uuid:bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f"
+            }
+          },
+          {
+            "item": {
+              "reference": "urn:uuid:223eaadb-5909-458c-bbe5-604c120c3ce9"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "fe696fc7-7683-4268-92d8-b3a7c88b1587",
+      "resource": {
+        "resourceType": "Location",
+        "id": "fe696fc7-7683-4268-92d8-b3a7c88b1587",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location"
+          ]
+        },
+        "name": "Bedford Cemetery",
+        "address": {
+          "line": [
+            "603 Example Street",
+            "Line 2"
+          ],
+          "city": "Bedford",
+          "district": "Middlesex",
+          "state": "MA",
+          "postalCode": "01730",
+          "country": "US"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:64551ae3-51ac-48e6-8d8a-41fd3ad29916",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "64551ae3-51ac-48e6-8d8a-41fd3ad29916",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69449-7",
+              "display": "Manner of death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "performer": [
+          {
+            "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "code": "7878000",
+              "display": "Accident"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fc27b07f-99c9-48f8-a229-6eb5d8b598f0",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "fc27b07f-99c9-48f8-a229-6eb5d8b598f0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
+          ]
+        },
+        "code": {
+          "text": "Example Contributing Conditions"
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "asserter": {
+          "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b66d97ea-56b1-4397-8de3-fb989007485b",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "b66d97ea-56b1-4397-8de3-fb989007485b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10",
+              "code": "I21.0",
+              "display": "Acute transmural myocardial infarction of anterior wall"
+            }
+          ],
+          "text": "Rupture of myocardium"
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "onsetString": "minutes",
+        "asserter": {
+          "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8b7a9ca6-1276-402f-a521-35155234af14",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "8b7a9ca6-1276-402f-a521-35155234af14",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10",
+              "code": "I21.9",
+              "display": "Acute myocardial infarction, unspecified"
+            }
+          ],
+          "text": "Acute myocardial infarction"
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "onsetString": "6 days",
+        "asserter": {
+          "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+          ]
+        },
+        "code": {
+          "text": "Coronary artery thrombosis"
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "onsetString": "5 years",
+        "asserter": {
+          "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:223eaadb-5909-458c-bbe5-604c120c3ce9",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "223eaadb-5909-458c-bbe5-604c120c3ce9",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+          ]
+        },
+        "code": {
+          "text": "Atherosclerotic coronary artery disease"
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "onsetString": "7 years",
+        "asserter": {
+          "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:097c0d70-6807-48c0-9710-7d4e96726234",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "097c0d70-6807-48c0-9710-7d4e96726234",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Father"
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "relationship": [{
+          "coding": [
+            {
+              "code": "FTH"
+            }
+          ]
+        }],
+        "name": [
+          {
+            "family": "Last",
+            "given": [
+              "Father",
+              "Middle"
+            ],
+            "suffix": [
+              "Sr."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:0113aba7-3a33-48f3-a1f9-a76f050d37f1",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "0113aba7-3a33-48f3-a1f9-a76f050d37f1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Mother"
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "relationship": [{
+          "coding": [
+            {
+              "code": "MTH"
+            }
+          ]
+        }],
+        "name": [
+          {
+            "family": "Maiden",
+            "given": [
+              "Mother",
+              "Middle"
+            ],
+            "suffix": [
+              "Dr."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:db1ec90f-038a-4ebc-b714-3b92c76b5fb8",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "db1ec90f-038a-4ebc-b714-3b92c76b5fb8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Spouse"
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "relationship": [{
+          "coding": [
+            {
+              "code": "SPS"
+            }
+          ]
+        }],
+        "name": [
+          {
+            "family": "Last",
+            "given": [
+              "Spouse",
+              "Middle"
+            ],
+            "suffix": [
+              "Ph.D."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:79c8753a-bb2b-4e99-800c-cabfe9b97b57",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "79c8753a-bb2b-4e99-800c-cabfe9b97b57",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Education-Level"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "80913-7",
+              "display": "Highest level of education [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-EducationLevel",
+              "code": "BD",
+              "display": "College or baccalaureate degree complete"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:327874e2-3e59-4c0d-9fb2-a5a9f9cc7f6c",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "327874e2-3e59-4c0d-9fb2-a5a9f9cc7f6c",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Birth-Record-Identifier"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "BR"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueString": "4242123",
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "21842-0",
+                  "display": "Birthplace"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "urn:iso:std:iso:3166:-2",
+                  "code": "MA",
+                  "display": "Massachusetts"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "21112-8",
+                  "display": "Birth date"
+                }
+              ]
+            },
+            "valueDateTime": "1940"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fee9f666-7099-4259-9a6c-25cf57f75654",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "fee9f666-7099-4259-9a6c-25cf57f75654",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Usual-Work"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21843-8",
+              "display": "History of usual occupation"
+            }
+          ]
+        },
+        "effectivePeriod" : {
+          "start" : "1965-01-01",
+          "end" : "2010-01-01"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "display": "secretary"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "21844-6",
+                  "display": "Usual industry"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "display": "State agency"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:e9b3c71b-fe74-4046-a47d-c085b8f76c63",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "e9b3c71b-fe74-4046-a47d-c085b8f76c63",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Military-Service"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "55280-2",
+              "display": "Military service"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+              "code": "Y",
+              "display": "Yes"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fc9de024-0fae-4bda-bfbb-04c08c083a43",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "fc9de024-0fae-4bda-bfbb-04c08c083a43",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location",
+            "valueReference": {
+              "reference": "urn:uuid:fe696fc7-7683-4268-92d8-b3a7c88b1587"
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "80905-3",
+              "display": "Body disposition method"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "performer": [
+          {
+            "reference": "urn:uuid:84452aa0-fc31-4f4c-848f-b8f1e5bba1c0"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "449971000124106",
+              "display": "Burial"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b0e1c9fd-8ec1-4d61-bf29-1ef39d1d4229",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "b0e1c9fd-8ec1-4d61-bf29-1ef39d1d4229",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85699-7",
+              "display": "Autopsy was performed"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+              "code": "Y",
+              "display": "Yes"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69436-4",
+                  "display": "Autopsy results available"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                  "code": "Y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:b9a24c57-3f44-4091-b690-2eb4f6748919",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "b9a24c57-3f44-4091-b690-2eb4f6748919",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Age"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "30525-0",
+              "display": "Age"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueQuantity": {
+          "value": 79,
+          "unit": "a"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:19cb645f-c8f9-44fc-9137-6f33b009d355",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "19cb645f-c8f9-44fc-9137-6f33b009d355",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69442-2",
+              "display": "Timing of recent pregnancy in relation to death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+              "code": "NA",
+              "display": "not applicable"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69451-3",
+              "display": "Transportation role of decedent"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "257500003",
+              "display": "Passenger"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "74497-9",
+              "display": "Medical examiner or coroner was contacted [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+              "code": "N",
+              "display": "No"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d15a4ea5-ee1b-4760-b177-fea17fa75c09",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "d15a4ea5-ee1b-4760-b177-fea17fa75c09",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69443-0",
+              "display": "Did tobacco use contribute to death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373066001",
+              "display": "Yes"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:3c1f5202-68de-47e8-813f-43a3f7f29129",
+      "resource": {
+        "resourceType": "Location",
+        "id": "3c1f5202-68de-47e8-813f-43a3f7f29129",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
+          ]
+        },
+        "name": "Example Injury Location Name",
+        "description": "Example Injury Location Description",
+        "address": {
+          "line": [
+            "781 Example Street",
+            "Line 2"
+          ],
+          "city": "Bedford",
+          "district": "Middlesex",
+          "state": "MA",
+          "postalCode": "01730",
+          "country": "US"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:38070a6e-d934-4a56-ac57-bbba133d6df0",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "38070a6e-d934-4a56-ac57-bbba133d6df0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-InjuryIncident"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "11374-6",
+              "display": "Injury incident description Narrative"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "effectiveDateTime": "2018-02-19T16:48:06-05:00",
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69444-8",
+                  "display": "Did death result from injury at work"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                  "code": "N",
+                  "display": "No"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69450-5",
+                  "display": "Place of injury Facility"
+                }
+              ]
+            },
+            "valueString": "home"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4678efc2-2529-4a7e-8266-fdc907d89e00",
+      "resource": {
+        "resourceType": "Location",
+        "id": "4678efc2-2529-4a7e-8266-fdc907d89e00",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                "system": "2.16.840.1.113883.6.92",
+                "code": "25",
+                "display": "MA"
+                }
+              ]
+            }
+          }
+        ],
+        "name": "Example Death Location Name",
+        "description": "Example Death Location Description",
+        "address": {
+          "line": [
+            "671 Example Street",
+            "Line 2"
+          ],
+          "city": "Bedford",
+          "district": "Middlesex",
+          "state": "MA",
+          "postalCode": "01730",
+          "country": "US"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:81899bd9-0441-45f0-9b89-9d91daa08983",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "81899bd9-0441-45f0-9b89-9d91daa08983",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "81956-5",
+              "display": "Date and time of death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
+        },
+        "effectiveDateTime": "2018-02-19T16:48:06-05:00",
+        "valueDateTime": "2018-02-19T16:48:06-05:00",
+        "performer": [
+          {
+            "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "80616-6",
+                  "display": "Date and time pronounced dead"
+                }
+              ]
+            },
+            "valueDateTime": "2018-02-20T16:48:06-05:00"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/VRDR.Tests/fixtures/json/InvalidJurisdictionId.json
+++ b/VRDR.Tests/fixtures/json/InvalidJurisdictionId.json
@@ -1,0 +1,1349 @@
+{
+  "resourceType": "Bundle",
+  "id": "f9cac9a7-4b18-46b2-bfa4-06dd755739dc",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document"
+    ]
+  },
+  "identifier": {
+    "system": "http://nchs.cdc.gov/vrdr_id",
+    "value": "0000XX000000"
+  },
+  "type": "document",
+  "timestamp": "2021-09-07T10:17:10.5423619-04:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:e8227815-e338-4843-bc1d-d29e1f54c3f5",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "e8227815-e338-4843-bc1d-d29e1f54c3f5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate"
+          ]
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "64297-5",
+              "display": "Death certificate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "author": [
+          {
+            "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+          }
+        ],
+        "title": "Death Certificate",
+        "attester": [
+          {
+            "mode": "legal",
+            "party": {
+              "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+            }
+          }
+        ],
+        "event": [
+          {
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "103693007",
+                    "display": "Diagnostic procedure (procedure)"
+                  }
+                ]
+              }
+            ],
+            "detail": [
+              {
+                "reference": "urn:uuid:6124a28e-29fa-4eb6-af89-e4bfcba191c4"
+              }
+            ]
+          }
+        ],
+        "section": [
+          {
+            "entry": [
+              {
+                "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+              },
+              {
+                "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+              },
+              {
+                "reference": "urn:uuid:112cad8d-427e-4193-96b9-02fd8609df4a"
+              },
+              {
+                "reference": "urn:uuid:403209aa-ca0d-4a6d-b59b-847242752423"
+              },
+              {
+                "reference": "urn:uuid:6124a28e-29fa-4eb6-af89-e4bfcba191c4"
+              },
+              {
+                "reference": "urn:uuid:d245db17-b97f-4319-a977-d7a3cbe3cf83"
+              },
+              {
+                "reference": "urn:uuid:9a5fe3bb-c244-4183-9dd4-80efaf4433ac"
+              },
+              {
+                "reference": "urn:uuid:c359e27a-162a-4a92-b609-dfaf4ea69ce7"
+              },
+              {
+                "reference": "urn:uuid:da2b2b42-93bb-4c72-a220-36e0cbcf48f7"
+              },
+              {
+                "reference": "urn:uuid:fff9f38d-2c8f-47c7-bcfd-b479decb92db"
+              },
+              {
+                "reference": "urn:uuid:ae53611a-3de4-43cb-bc10-194b483a95a3"
+              },
+              {
+                "reference": "urn:uuid:2d65578f-a4bc-49bd-b182-2d06d0be8fe6"
+              },
+              {
+                "reference": "urn:uuid:1a01a4f9-e416-4639-a2b7-141e70fe1944"
+              },
+              {
+                "reference": "urn:uuid:91e65e78-6865-4050-a618-c779d3284f8a"
+              },
+              {
+                "reference": "urn:uuid:98d262e2-bfcb-4d5c-a7ae-2dda009fb0b0"
+              },
+              {
+                "reference": "urn:uuid:af5f2397-e125-4f56-b021-9d03eb590946"
+              },
+              {
+                "reference": "urn:uuid:2dd979be-5887-46a0-8bfd-d121135e7fbd"
+              },
+              {
+                "reference": "urn:uuid:ede01f81-fd0d-498d-843c-1630bd517bd0"
+              },
+              {
+                "reference": "urn:uuid:c886820b-7a81-4221-bbc1-b76970e46e95"
+              },
+              {
+                "reference": "urn:uuid:8c978843-7024-4411-bea4-b1f65a3a051d"
+              },
+              {
+                "reference": "urn:uuid:055e3a75-2613-494a-b65a-a39a15abb8f3"
+              },
+              {
+                "reference": "urn:uuid:1b12e1b8-ed10-4e68-a1ab-0165d56fe5d8"
+              },
+              {
+                "reference": "urn:uuid:ba1cdba2-7aa9-46c2-b334-9d35c06900fa"
+              },
+              {
+                "reference": "urn:uuid:6e576d41-27b7-4546-afbd-2bdf0c274d04"
+              },
+              {
+                "reference": "urn:uuid:9e8c4835-2558-4a26-8ebe-eabf250d8aa1"
+              },
+              {
+                "reference": "urn:uuid:bfecdeea-eaf6-457d-89b1-06b0a46ff809"
+              },
+              {
+                "reference": "urn:uuid:fbec82ee-f14c-4c5c-bbaa-107a8302544b"
+              },
+              {
+                "reference": "urn:uuid:30aeecb1-a0aa-4c0b-9eed-010c4358a624"
+              },
+              {
+                "reference": "urn:uuid:47e67939-fcc6-48a2-803c-3a51b273b1e3"
+              },
+              {
+                "reference": "urn:uuid:3041b25a-9b37-4f8c-84f5-6e0169b9a24f"
+              },
+              {
+                "reference": "urn:uuid:63ef0c18-eaa7-4e2b-a4e4-208443ef98ad"
+              },
+              {
+                "reference": "urn:uuid:01b05fec-8113-440a-8941-3c53d659de82"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "8d18bab2-bf31-428f-a13c-7a1a962977e9",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "M"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+            "valueAddress": {
+              "line": [
+                "1601 Hibiscus"
+              ],
+              "city": "Marcory, Groupement Foncier",
+              "state": "UNK",
+              "country": "CA"
+            }
+          },
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2186-5",
+                  "display": "Non Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Non Hispanic or Latino"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+          },
+          {
+            "extension": [
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "UNK",
+                  "display": "Unknown"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Unknown"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+          }
+        ],
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SB",
+                  "display": "Social Beneficiary Identifier"
+                }
+              ]
+            },
+            "system": "http://hl7.org/fhir/sid/us-ssn",
+            "value": "657876543"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Dramane",
+            "given": [
+              "Allassane"
+            ],
+            "suffix": [
+              "Jr."
+            ]
+          },
+          {
+            "use": "nickname",
+            "given": [
+              "Cheryl"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1941-01-01",
+        "address": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator",
+                "valueCoding": {
+                  "system": "Y",
+                  "code": "PHVS_YesNoUnknown_CDC",
+                  "display": "Yes"
+                }
+              }
+            ],
+            "line": [
+              "2706 Snowbird Terrace unit 5"
+            ],
+            "district": "MD",
+            "state": "MD",
+            "postalCode": "20906",
+            "country": "USA"
+          }
+        ],
+        "maritalStatus": {
+          "coding": [
+            {
+              "system": "PHVS_MaritalStatus_NCHS",
+              "code": "M",
+              "display": "Married"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "51aa0769-6c6d-4ece-ad93-9cf5fd8711e8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "989079"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Murphy",
+            "given": [
+              "sherry"
+            ]
+          }
+        ],
+        "qualification": [
+          {
+            "identifier": [
+              {
+                "value": "348584"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:112cad8d-427e-4193-96b9-02fd8609df4a",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "112cad8d-427e-4193-96b9-02fd8609df4a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Pronouncement-Performer"
+          ]
+        },
+        "name": [
+          {
+            "use": "official"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:403209aa-ca0d-4a6d-b59b-847242752423",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "403209aa-ca0d-4a6d-b59b-847242752423",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician"
+          ]
+        },
+        "name": [
+          {
+            "use": "official"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6124a28e-29fa-4eb6-af89-e4bfcba191c4",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "6124a28e-29fa-4eb6-af89-e4bfcba191c4",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification"
+          ]
+        },
+        "identifier": [
+          {
+            "value": "12"
+          }
+        ],
+        "status": "completed",
+        "category": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "103693007",
+              "display": "Diagnostic procedure"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "308646001",
+              "display": "Death certification"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "performer": [
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "434641000124105",
+                  "display": "Death certification and verification by physician"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:d245db17-b97f-4319-a977-d7a3cbe3cf83",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "d245db17-b97f-4319-a977-d7a3cbe3cf83",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "993727"
+          }
+        ],
+        "active": true,
+        "name": "Lingala Bailey LLC",
+        "address": [
+          {
+            "line": [
+              "2634 Coolidge rd"
+            ],
+            "city": "silver spring",
+            "district": "Montgomery",
+            "state": "MD",
+            "postalCode": "2876",
+            "country": "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9a5fe3bb-c244-4183-9dd4-80efaf4433ac",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "9a5fe3bb-c244-4183-9dd4-80efaf4433ac",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
+          ]
+        },
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                "code": "bus",
+                "display": "Non-Healthcare Business or Corporation"
+              }
+            ]
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "3311 Toledo Road"
+            ],
+            "district": "Montgomery",
+            "state": "MD",
+            "postalCode": "2876",
+            "country": "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c359e27a-162a-4a92-b609-dfaf4ea69ce7",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "c359e27a-162a-4a92-b609-dfaf4ea69ce7",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Service-Licensee"
+          ]
+        },
+        "practitioner": {
+          "reference": "urn:uuid:403209aa-ca0d-4a6d-b59b-847242752423"
+        },
+        "organization": {
+          "reference": "urn:uuid:9a5fe3bb-c244-4183-9dd4-80efaf4433ac"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:da2b2b42-93bb-4c72-a220-36e0cbcf48f7",
+      "resource": {
+        "resourceType": "List",
+        "id": "da2b2b42-93bb-4c72-a220-36e0cbcf48f7",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway"
+          ]
+        },
+        "status": "current",
+        "mode": "snapshot",
+        "source": {
+          "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+        },
+        "orderedBy": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/list-order",
+              "code": "priority",
+              "display": "Sorted by Priority"
+            }
+          ]
+        },
+        "entry": [
+          {
+            "item": {
+              "reference": "urn:uuid:63ef0c18-eaa7-4e2b-a4e4-208443ef98ad"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fff9f38d-2c8f-47c7-bcfd-b479decb92db",
+      "resource": {
+        "resourceType": "Location",
+        "id": "fff9f38d-2c8f-47c7-bcfd-b479decb92db",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location"
+          ]
+        },
+        "name": "Burial",
+        "address": {
+          "line": [
+            "2706 Apple Pie Terrace"
+          ],
+          "district": "Prince Georges",
+          "state": "MD",
+          "postalCode": "27865",
+          "country": "USA"
+        },
+        "physicalType": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code": "si",
+              "display": "Site"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ae53611a-3de4-43cb-bc10-194b483a95a3",
+      "resource": {
+        "resourceType": "DocumentReference",
+        "id": "ae53611a-3de4-43cb-bc10-194b483a95a3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Reference"
+          ]
+        },
+        "identifier": [
+          {
+            "value": "MD"
+          }
+        ],
+        "status": "current",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "64297-5",
+              "display": "Death certificate"
+            }
+          ]
+        },
+        "date": "2021-09-07T10:17:10.5882501-04:00",
+        "author": [
+          {
+            "reference": "urn:uuid:d245db17-b97f-4319-a977-d7a3cbe3cf83"
+          }
+        ],
+        "content": [
+          {
+            "attachment": {
+              "url": "urn:uuid:f9cac9a7-4b18-46b2-bfa4-06dd755739dc"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:2d65578f-a4bc-49bd-b182-2d06d0be8fe6",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "2d65578f-a4bc-49bd-b182-2d06d0be8fe6",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-BirthRecordIdentifier"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "BR",
+              "display": "Birth registry number"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "21842-0",
+                  "display": "Birthplace"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "CA"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "80904-6",
+                  "display": "Birth year"
+                }
+              ]
+            },
+            "valueDateTime": "1941"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1a01a4f9-e416-4639-a2b7-141e70fe1944",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "1a01a4f9-e416-4639-a2b7-141e70fe1944",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Military-Service"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "55280-2",
+              "display": "Military service Narrative"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "55280-2",
+              "code": "http://loinc.org",
+              "display": "Military service Narrative"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:91e65e78-6865-4050-a618-c779d3284f8a",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "91e65e78-6865-4050-a618-c779d3284f8a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Spouse"
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "relationship": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "SPS",
+                "display": "spouse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:98d262e2-bfcb-4d5c-a7ae-2dda009fb0b0",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "98d262e2-bfcb-4d5c-a7ae-2dda009fb0b0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Father"
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "relationship": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "FTH",
+                "display": "father"
+              }
+            ]
+          }
+        ],
+        "name": [
+          {
+            "family": "Ouattara",
+            "given": [
+              "Kabore"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:af5f2397-e125-4f56-b021-9d03eb590946",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "af5f2397-e125-4f56-b021-9d03eb590946",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Mother"
+          ]
+        },
+        "patient": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "relationship": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "MTH",
+                "display": "mother"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:2dd979be-5887-46a0-8bfd-d121135e7fbd",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "2dd979be-5887-46a0-8bfd-d121135e7fbd",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Education-Level"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "80913-7",
+              "display": "Highest level of education [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "PHVS_DecedentEducationLevel_NCHS",
+              "code": "8",
+              "display": "Doctorate Degree or Professional Degree"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ede01f81-fd0d-498d-843c-1630bd517bd0",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ede01f81-fd0d-498d-843c-1630bd517bd0",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Usual-Work"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21843-8",
+              "display": "History of Usual occupation"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueCodeableConcept": {
+          "text": "Computer Programmer"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c886820b-7a81-4221-bbc1-b76970e46e95",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c886820b-7a81-4221-bbc1-b76970e46e95",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Observation-Location",
+            "valueReference": {
+              "reference": "urn:uuid:fff9f38d-2c8f-47c7-bcfd-b479decb92db"
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "80905-3",
+              "display": "Body disposition method"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "performer": [
+          {
+            "reference": "urn:uuid:403209aa-ca0d-4a6d-b59b-847242752423"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "B",
+              "display": "Burial"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:8c978843-7024-4411-bea4-b1f65a3a051d",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8c978843-7024-4411-bea4-b1f65a3a051d",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Age"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "30525-0",
+              "display": "Age"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueQuantity": {
+          "value": 89,
+          "unit": "a"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:055e3a75-2613-494a-b65a-a39a15abb8f3",
+      "resource": {
+        "resourceType": "Location",
+        "id": "055e3a75-2613-494a-b65a-a39a15abb8f3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
+            "valueCodeableConcept": {
+              "text": "MD"
+            }
+          }
+        ],
+        "name": "West Somerville Hospital",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "PHVS_PlaceOfDeath_NCHS",
+                "code": "5",
+                "display": "Hospice  Facility"
+              }
+            ]
+          }
+        ],
+        "address": {
+          "line": [
+            "1234 Doc Berlin"
+          ],
+          "city": "aspen hill",
+          "district": "Montgomery",
+          "state": "MD",
+          "postalCode": "25654"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:1b12e1b8-ed10-4e68-a1ab-0165d56fe5d8",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "1b12e1b8-ed10-4e68-a1ab-0165d56fe5d8",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "81956-5",
+              "display": "Date+time of death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "effectiveDateTime": "2021-09-06T04:15:00.0000000-04:00",
+        "performer": [
+          {
+            "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+          }
+        ],
+        "valueDateTime": "2021-09-06T04:15:00.0000000-04:00",
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "80616-6",
+                  "display": "Date and time pronounced dead [US Standard Certificate of Death]"
+                }
+              ]
+            },
+            "valueDateTime": "2021-09-06T04:15:00.0000000-04:00"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:ba1cdba2-7aa9-46c2-b334-9d35c06900fa",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "ba1cdba2-7aa9-46c2-b334-9d35c06900fa",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "74497-9",
+              "display": "Medical examiner or coroner was contacted [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6e576d41-27b7-4546-afbd-2bdf0c274d04",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6e576d41-27b7-4546-afbd-2bdf0c274d04",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85699-7",
+              "display": "Autopsy was performed"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "Yes No Not Applicable (NCHS)",
+              "code": "Y",
+              "display": "Yes"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69436-4",
+                  "display": "Autopsy results available"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:9e8c4835-2558-4a26-8ebe-eabf250d8aa1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "9e8c4835-2558-4a26-8ebe-eabf250d8aa1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69443-0",
+              "display": "Did tobacco use contribute to death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "SNOMED-CT",
+              "code": "373066001",
+              "display": "Yes"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:bfecdeea-eaf6-457d-89b1-06b0a46ff809",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "bfecdeea-eaf6-457d-89b1-06b0a46ff809",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69442-2",
+              "display": "Timing of recent pregnancy in relation to death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "1",
+              "code": "PHC1260",
+              "display": "Not pregnant within the past year"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:fbec82ee-f14c-4c5c-bbaa-107a8302544b",
+      "resource": {
+        "resourceType": "Location",
+        "id": "fbec82ee-f14c-4c5c-bbaa-107a8302544b",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:30aeecb1-a0aa-4c0b-9eed-010c4358a624",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "30aeecb1-a0aa-4c0b-9eed-010c4358a624",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-InjuryIncident"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Observation-Location",
+            "valueReference": {
+              "reference": "urn:uuid:fbec82ee-f14c-4c5c-bbaa-107a8302544b"
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "11374-6",
+              "display": "Injury incident description Narrative"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69450-5",
+                  "display": "Place of injury Facility"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69444-8",
+                  "display": "Did death result from injury at work"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69448-9",
+                  "display": "Injury leading to death associated with transportation event"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:47e67939-fcc6-48a2-803c-3a51b273b1e3",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "47e67939-fcc6-48a2-803c-3a51b273b1e3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69451-3",
+              "display": "Transportation role of decedent"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:3041b25a-9b37-4f8c-84f5-6e0169b9a24f",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "3041b25a-9b37-4f8c-84f5-6e0169b9a24f",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69449-7",
+              "display": "Manner of death"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "performer": [
+          {
+            "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning",
+              "code": "normal",
+              "display": "Normal Range"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:63ef0c18-eaa7-4e2b-a4e4-208443ef98ad",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "63ef0c18-eaa7-4e2b-a4e4-208443ef98ad",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+          ]
+        },
+        "code": {
+          "text": "lung cancer"
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "onsetString": "5 years",
+        "asserter": {
+          "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:01b05fec-8113-440a-8941-3c53d659de82",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "01b05fec-8113-440a-8941-3c53d659de82",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
+          ]
+        },
+        "code": {
+          "text": "COVID-19"
+        },
+        "subject": {
+          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
+        },
+        "asserter": {
+          "reference": "urn:uuid:51aa0769-6c6d-4ece-ad93-9cf5fd8711e8"
+        }
+      }
+    }
+  ]
+}

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5813,65 +5813,6 @@ namespace VRDR
             }
         }
 
-        /// <summary>Location of Death.</summary>
-        /// <value>location of death. A Dictionary representing an address, containing the following key/value pairs:
-        /// <para>"addressLine1" - address, line one</para>
-        /// <para>"addressLine2" - address, line two</para>
-        /// <para>"addressCity" - address, city</para>
-        /// <para>"addressCounty" - address, county</para>
-        /// <para>"addressState" - address, state</para>
-        /// <para>"addressZip" - address, zip</para>
-        /// <para>"addressCountry" - address, country</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; address = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>address.Add("addressLine1", "123456789 Test Street");</para>
-        /// <para>address.Add("addressLine2", "Unit 3");</para>
-        /// <para>address.Add("addressCity", "Boston");</para>
-        /// <para>address.Add("addressCounty", "Suffolk");</para>
-        /// <para>address.Add("addressState", "MA");</para>
-        /// <para>address.Add("addressZip", "12345");</para>
-        /// <para>address.Add("addressCountry", "US");</para>
-        /// <para>ExampleDeathRecord.DeathLocationAddress = address;</para>
-        /// <para>// Getter:</para>
-        /// <para>foreach(var pair in ExampleDeathRecord.DeathLocationAddress)</para>
-        /// <para>{</para>
-        /// <para>  Console.WriteLine($"\DeathLocationAddress key: {pair.Key}: value: {pair.Value}");</para>
-        /// <para>};</para>
-        /// </example>
-        [Property("Death Location Address", Property.Types.Dictionary, "Death Investigation", "Location of Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Location.html", true, 15)]
-        [PropertyParam("addressLine1", "address, line one")]
-        [PropertyParam("addressLine2", "address, line two")]
-        [PropertyParam("addressCity", "address, city")]
-        [PropertyParam("addressCounty", "address, county")]
-        [PropertyParam("addressState", "address, state")]
-        [PropertyParam("addressZip", "address, zip")]
-        [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location')", "address")]
-        public Dictionary<string, string> DeathLocationAddress
-        {
-            get
-            {
-            if (DeathLocationLoc != null)
-                {
-                    return AddressToDict(DeathLocationLoc.Address);
-                }
-                return EmptyAddrDict();
-            }
-            set
-            {
-                if (DeathLocationLoc == null)
-                {
-                    CreateDeathLocation();
-                }
-
-                DeathLocationLoc.Address = DictToAddress(value);
-
-                UpdateBundleIdentifier();
-            }
-        }
-
         /// <summary>Death Location Jurisdiction.</summary>
         /// <value>the vital record jurisdiction identifier.</value>
         /// <example>
@@ -5935,6 +5876,65 @@ namespace VRDR
                     DeathLocationLoc.Extension.Add(extension);
                     UpdateBundleIdentifier();
                 }
+            }
+        }
+
+        /// <summary>Location of Death.</summary>
+        /// <value>location of death. A Dictionary representing an address, containing the following key/value pairs:
+        /// <para>"addressLine1" - address, line one</para>
+        /// <para>"addressLine2" - address, line two</para>
+        /// <para>"addressCity" - address, city</para>
+        /// <para>"addressCounty" - address, county</para>
+        /// <para>"addressState" - address, state</para>
+        /// <para>"addressZip" - address, zip</para>
+        /// <para>"addressCountry" - address, country</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; address = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>address.Add("addressLine1", "123456789 Test Street");</para>
+        /// <para>address.Add("addressLine2", "Unit 3");</para>
+        /// <para>address.Add("addressCity", "Boston");</para>
+        /// <para>address.Add("addressCounty", "Suffolk");</para>
+        /// <para>address.Add("addressState", "MA");</para>
+        /// <para>address.Add("addressZip", "12345");</para>
+        /// <para>address.Add("addressCountry", "US");</para>
+        /// <para>ExampleDeathRecord.DeathLocationAddress = address;</para>
+        /// <para>// Getter:</para>
+        /// <para>foreach(var pair in ExampleDeathRecord.DeathLocationAddress)</para>
+        /// <para>{</para>
+        /// <para>  Console.WriteLine($"\DeathLocationAddress key: {pair.Key}: value: {pair.Value}");</para>
+        /// <para>};</para>
+        /// </example>
+        [Property("Death Location Address", Property.Types.Dictionary, "Death Investigation", "Location of Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Location.html", true, 15)]
+        [PropertyParam("addressLine1", "address, line one")]
+        [PropertyParam("addressLine2", "address, line two")]
+        [PropertyParam("addressCity", "address, city")]
+        [PropertyParam("addressCounty", "address, county")]
+        [PropertyParam("addressState", "address, state")]
+        [PropertyParam("addressZip", "address, zip")]
+        [PropertyParam("addressCountry", "address, country")]
+        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location')", "address")]
+        public Dictionary<string, string> DeathLocationAddress
+        {
+            get
+            {
+            if (DeathLocationLoc != null)
+                {
+                    return AddressToDict(DeathLocationLoc.Address);
+                }
+                return EmptyAddrDict();
+            }
+            set
+            {
+                if (DeathLocationLoc == null)
+                {
+                    CreateDeathLocation();
+                }
+
+                DeathLocationLoc.Address = DictToAddress(value);
+
+                UpdateBundleIdentifier();
             }
         }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5851,7 +5851,7 @@ namespace VRDR
                 catch (Exception ex)
                 {
                     // Jurisdiction is a required field. If it is not found, return a useful error so the user can address the missing field.
-                    throw new ArgumentException("Death Location Jurisdiction is required, but not found. Check the extension is formatted correctly.", locationJurisdictionExtPath, ex);
+                    throw new ArgumentException("Death Location Jurisdiction is required, but not found. Check that the extension is formatted correctly.", locationJurisdictionExtPath, ex);
                 }
   
             }
@@ -5860,7 +5860,9 @@ namespace VRDR
                 if (DeathLocationLoc == null)
                 {
                     CreateDeathLocation();
-                }else{
+                }
+                else
+                {
                     DeathLocationLoc.Extension.RemoveAll(ext => ext.Url == locationJurisdictionExtPath);
                 }
                 if (!String.IsNullOrWhiteSpace(value)) // If a jurisdiction is provided, create and add the extension

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5892,7 +5892,10 @@ namespace VRDR
                     if (jurisdiction != null && jurisdiction.Value != null &&  jurisdiction.Value.GetType() == typeof(CodeableConcept))
                     {
                         CodeableConcept cc = (CodeableConcept)jurisdiction.Value;
-                        return MortalityData.JurisdictionCodeToJurisdictionName(cc.Coding[0].Code);
+                        if (cc.Coding.Count > 0) {
+                            return MortalityData.JurisdictionCodeToJurisdictionName(cc.Coding[0].Code);
+                        }
+                        
                     }
                 }
                 return null;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -539,17 +539,26 @@ namespace VRDR
                     UInt32.TryParse(this.DateOfDeath.Substring(0,4), out deathYear);
                 }
             }
-            var jurisdictionId = this.DeathLocationJurisdiction; // this.DeathLocationAddress?["addressState"];
-            if (jurisdictionId == null || jurisdictionId.Trim().Length < 2)
+            try
             {
-                jurisdictionId = "XX";
-            }
-            else
+                // DeathLocationJurisdiction will throw an error if it is not set
+                var jurisdictionId = this.DeathLocationJurisdiction; // this.DeathLocationAddress?["addressState"];
+                if (jurisdictionId == null || jurisdictionId.Trim().Length < 2)
+                {
+                    jurisdictionId = "XX";
+                }
+                else
+                {
+                    jurisdictionId = jurisdictionId.Trim().Substring(0, 2).ToUpper();
+                }
+                this.BundleIdentifier = $"{deathYear.ToString("D4")}{jurisdictionId}{certificateNumber.ToString("D6")}";
+            } 
+            catch (Exception ex)
             {
-                jurisdictionId = jurisdictionId.Trim().Substring(0, 2).ToUpper();
+                throw new Exception("Death Location Jurisdiction must be set before updating the Bundle Identifier.", ex);
             }
-            this.BundleIdentifier = $"{deathYear.ToString("D4")}{jurisdictionId}{certificateNumber.ToString("D6")}";
-            // Console.WriteLine("UpdateBundleIdentifier -- new identifer = " + this.BundleIdentifier);
+
+            
         }
 
         /// <summary>Death Record Bundle Identifier, NCHS identifier.</summary>

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1792,6 +1792,16 @@
             <para>Console.WriteLine($"Autopsy Results Available: {ExampleDeathRecord.AutopsyResultsAvailableBoolean}");</para>
             </example>
         </member>
+        <member name="P:VRDR.DeathRecord.DeathLocationJurisdiction">
+            <summary>Death Location Jurisdiction.</summary>
+            <value>the vital record jurisdiction identifier.</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleDeathRecord.DeathLocationJurisdiction = "MA";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Death Location Jurisdiction: {ExampleDeathRecord.DeathLocationJurisdiction}");</para>
+            </example>
+        </member>
         <member name="P:VRDR.DeathRecord.DeathLocationAddress">
             <summary>Location of Death.</summary>
             <value>location of death. A Dictionary representing an address, containing the following key/value pairs:
@@ -1819,16 +1829,6 @@
             <para>{</para>
             <para>  Console.WriteLine($"\DeathLocationAddress key: {pair.Key}: value: {pair.Value}");</para>
             <para>};</para>
-            </example>
-        </member>
-        <member name="P:VRDR.DeathRecord.DeathLocationJurisdiction">
-            <summary>Death Location Jurisdiction.</summary>
-            <value>the vital record jurisdiction identifier.</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleDeathRecord.DeathLocationJurisdiction = "MA";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Death Location Jurisdiction: {ExampleDeathRecord.DeathLocationJurisdiction}");</para>
             </example>
         </member>
         <member name="P:VRDR.DeathRecord.DeathLocationName">


### PR DESCRIPTION
Jurisdiction Id is a required field and the library should throw an error if it is missing. I added a try, catch block to catch errors in the get_DeathLocationJurisdiction function and throw a more descriptive error message. I also updated the test cases affected by the change. I considered throwing an error if The DeathLocationLoc field was null (line 5887) but when I tried that, any time we initialized an empty DeathRecord() it threw an error. The error should only be thrown if the VRDR-Death-Location resource is present or initialized, but the extension is missing or incorrectly formatted.