### PR TITLE
Add support for passing Bundles directly to BaseMessage

### DIFF
--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -357,6 +357,24 @@ namespace VRDR
         }
 
         /// <summary>
+        /// Construct the appropriate subclass of BaseMessage based on a FHIR Bundle.
+        /// The new object is checked to ensure it the same or a subtype of the type parameter.
+        /// </summary>
+        /// <typeparam name="T">the expected message type</typeparam>
+        /// <param name="bundle">A FHIR Bundle</param>
+        /// <returns>The message object of the appropriate message type</returns>
+        /// <exception cref="MessageParseException">Thrown when source does not represent the same or a subtype of the type parameter.</exception>
+        public static T Parse<T>(Bundle bundle) where T: BaseMessage
+        {
+            BaseMessage typedMessage = Parse(bundle);
+            if (!typeof(T).IsInstanceOfType(typedMessage))
+            {
+                throw new MessageParseException($"The supplied message was of type {typedMessage.GetType()}, expected {typeof(T)} or a subclass", typedMessage);
+            }
+            return (T)typedMessage;
+        }
+
+        /// <summary>
         /// Parse an XML or JSON serialization of a FHIR Bundle and construct the appropriate subclass of
         /// BaseMessage. The new object is checked to ensure it the same or a subtype of the type parameter.
         /// </summary>
@@ -398,6 +416,17 @@ namespace VRDR
                 throw new System.ArgumentException("The given input does not appear to be a valid XML or JSON FHIR message.");
             }
 
+            return Parse(bundle);
+        }
+
+        /// <summary>
+        /// Construct the appropriate subclass of BaseMessage based on a FHIR Bundle.
+        /// Clients can use the typeof operator to determine the type of message object returned.
+        /// </summary>
+        /// <param name="bundle">A FHIR Bundle</param>
+        /// <returns>The message object of the appropriate message type</returns>
+        public static BaseMessage Parse(Bundle bundle)
+        {
             BaseMessage message = new BaseMessage(bundle, true, false);
             switch (message.MessageType)
             {

--- a/VRDR.Messaging/VRDRMessaging.xml
+++ b/VRDR.Messaging/VRDRMessaging.xml
@@ -144,6 +144,16 @@
             <returns>The deserialized message object</returns>
             <exception cref="T:VRDR.MessageParseException">Thrown when source does not represent the same or a subtype of the type parameter.</exception>
         </member>
+        <member name="M:VRDR.BaseMessage.Parse``1(Hl7.Fhir.Model.Bundle)">
+            <summary>
+            Construct the appropriate subclass of BaseMessage based on a FHIR Bundle.
+            The new object is checked to ensure it the same or a subtype of the type parameter.
+            </summary>
+            <typeparam name="T">the expected message type</typeparam>
+            <param name="bundle">A FHIR Bundle</param>
+            <returns>The message object of the appropriate message type</returns>
+            <exception cref="T:VRDR.MessageParseException">Thrown when source does not represent the same or a subtype of the type parameter.</exception>
+        </member>
         <member name="M:VRDR.BaseMessage.Parse``1(System.String,System.Boolean)">
             <summary>
             Parse an XML or JSON serialization of a FHIR Bundle and construct the appropriate subclass of
@@ -163,6 +173,14 @@
             <param name="source">the XML or JSON serialization of a FHIR Bundle</param>
             <param name="permissive">if the parser should be permissive when parsing the given string</param>
             <returns>The deserialized message object</returns>
+        </member>
+        <member name="M:VRDR.BaseMessage.Parse(Hl7.Fhir.Model.Bundle)">
+            <summary>
+            Construct the appropriate subclass of BaseMessage based on a FHIR Bundle.
+            Clients can use the typeof operator to determine the type of message object returned.
+            </summary>
+            <param name="bundle">A FHIR Bundle</param>
+            <returns>The message object of the appropriate message type</returns>
         </member>
         <member name="M:VRDR.BaseMessage.Parse(System.IO.StreamReader,System.Boolean)">
             <summary>

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -114,6 +114,23 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void CreateSubmissionFromBundle()
+        {
+            DeathRecordSubmission submission = new DeathRecordSubmission();
+            submission.DeathRecord = new DeathRecord();
+            submission.CertificateNumber = 42;
+            submission.StateAuxiliaryIdentifier = "identifier";
+            Bundle submissionBundle = (Bundle)submission;
+
+            DeathRecordSubmission parsed = BaseMessage.Parse<DeathRecordSubmission>(submissionBundle);
+            Assert.Equal(submission.DeathRecord.ToJson(), parsed.DeathRecord.ToJson());
+            Assert.Equal(submission.MessageType, parsed.MessageType);
+            Assert.Equal(submission.CertificateNumber, parsed.CertificateNumber);
+            Assert.Equal(submission.StateAuxiliaryIdentifier, parsed.StateAuxiliaryIdentifier);
+            Assert.Equal(submission.NCHSIdentifier, parsed.NCHSIdentifier);
+        }
+
+        [Fact]
         public void CreateUpdate()
         {
             DeathRecordUpdate submission = new DeathRecordUpdate();
@@ -169,6 +186,23 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void CreatUpdateFromBundle()
+        {
+            DeathRecordUpdate update = new DeathRecordUpdate();
+            update.DeathRecord = new DeathRecord();
+            update.CertificateNumber = 42;
+            update.StateAuxiliaryIdentifier = "identifier";
+            Bundle updateBundle = (Bundle)update;
+
+            DeathRecordUpdate parsed = BaseMessage.Parse<DeathRecordUpdate>(updateBundle);
+            Assert.Equal(update.DeathRecord.ToJson(), parsed.DeathRecord.ToJson());
+            Assert.Equal(update.MessageType, parsed.MessageType);
+            Assert.Equal(update.CertificateNumber, parsed.CertificateNumber);
+            Assert.Equal(update.StateAuxiliaryIdentifier, parsed.StateAuxiliaryIdentifier);
+            Assert.Equal(update.NCHSIdentifier, parsed.NCHSIdentifier);
+        }
+
+        [Fact]
         public void CreateAckForMessage()
         {
             DeathRecordSubmission submission = BaseMessage.Parse<DeathRecordSubmission>(FixtureStream("fixtures/json/DeathRecordSubmission.json"));
@@ -220,6 +254,20 @@ namespace VRDR.Tests
         {
             AckMessage ack = BaseMessage.Parse<AckMessage>(FixtureStream("fixtures/xml/AckMessage.xml"));
             Assert.Equal("http://nchs.cdc.gov/vrdr_acknowledgement", ack.MessageType);
+            Assert.Equal("a9d66d2e-2480-4e8d-bab3-4e4c761da1b7", ack.AckedMessageId);
+            Assert.Equal("nightingale", ack.MessageDestination);
+            Assert.Equal("2018MA000001", ack.NCHSIdentifier);
+            Assert.Equal((uint)1, ack.CertificateNumber);
+            Assert.Equal((uint)2018, ack.DeathYear);
+            Assert.Equal("42", ack.StateAuxiliaryIdentifier);
+        }
+
+        [Fact]
+        public void CreateAckFromBundle()
+        {
+            AckMessage ackFixture = BaseMessage.Parse<AckMessage>(FixtureStream("fixtures/json/AckMessage.json"));
+            Bundle ackBundle = (Bundle)ackFixture;
+            AckMessage ack = BaseMessage.Parse<AckMessage>(ackBundle);
             Assert.Equal("a9d66d2e-2480-4e8d-bab3-4e4c761da1b7", ack.AckedMessageId);
             Assert.Equal("nightingale", ack.MessageDestination);
             Assert.Equal("2018MA000001", ack.NCHSIdentifier);


### PR DESCRIPTION
This better supports the use case where a user receives a Bundle of Messages, parses the Bundle directly using the HL7 FHIR library, and then needs to work with the individual messages.