### PR TITLE
Include CLI and HTTP projects in the solution.

### DIFF
--- a/vrdr-dotnet.sln
+++ b/vrdr-dotnet.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VRDR", "VRDR\DeathRecord.csproj", "{A147015F-AFB9-4D4A-BE7A-DCBC535990B9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeathRecord", "VRDR\DeathRecord.csproj", "{A147015F-AFB9-4D4A-BE7A-DCBC535990B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBD}") = "VRDR.Tests", "VRDR.Tests\DeathRecord.Tests.csproj", "{370E27B1-3387-485E-AB76-C908353AC06C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeathRecord.Tests", "VRDR.Tests\DeathRecord.Tests.csproj", "{370E27B1-3387-485E-AB76-C908353AC06C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VRDRMessaging", "VRDR.Messaging\VRDRMessaging.csproj", "{54ED1D6F-DDCE-43BA-B077-B40824801C27}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VRDRMessaging", "VRDR.Messaging\VRDRMessaging.csproj", "{54ED1D6F-DDCE-43BA-B077-B40824801C27}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeathRecord.CLI", "VRDR.CLI\DeathRecord.CLI.csproj", "{40E9509A-189F-42F2-820A-692CF39CA36D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FhirDeathRecord.HTTP", "VRDR.HTTP\FhirDeathRecord.HTTP.csproj", "{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A147015F-AFB9-4D4A-BE7A-DCBC535990B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -58,5 +59,35 @@ Global
 		{54ED1D6F-DDCE-43BA-B077-B40824801C27}.Release|x64.Build.0 = Release|Any CPU
 		{54ED1D6F-DDCE-43BA-B077-B40824801C27}.Release|x86.ActiveCfg = Release|Any CPU
 		{54ED1D6F-DDCE-43BA-B077-B40824801C27}.Release|x86.Build.0 = Release|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Debug|x64.Build.0 = Debug|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Debug|x86.Build.0 = Debug|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Release|x64.ActiveCfg = Release|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Release|x64.Build.0 = Release|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Release|x86.ActiveCfg = Release|Any CPU
+		{40E9509A-189F-42F2-820A-692CF39CA36D}.Release|x86.Build.0 = Release|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Debug|x64.Build.0 = Debug|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Debug|x86.Build.0 = Debug|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x64.ActiveCfg = Release|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x64.Build.0 = Release|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x86.ActiveCfg = Release|Any CPU
+		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2C662FB1-9016-4454-BA20-B926FA549595}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This causes `dotnet build` (and/or `dotnet test`) to include them, and catches compile-time errors sooner (rather than waiting for the additional test cases in the github workflow).

This should only affect `dotnet build` and `dotnet test` without arguments from the root of the project. Specifying projects to build/test should still work as expected.

The publishing workflow appears to explicitly name the projects to be built and packaged, so that should not be affected by this change.