### PR TITLE
Move the client library functions into vrdr-dotnet, update README with examples

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.408
+    - name: Setup .NET Core 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.0
     - name: .net Side by Side
       run: |
         rsync -a ${DOTNET_ROOT/3.1.408/2.1.815}/* $DOTNET_ROOT/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET Core 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.0
+        dotnet-version: 6.0.100
     - name: .net Side by Side
       run: |
         rsync -a ${DOTNET_ROOT/3.1.408/2.1.815}/* $DOTNET_ROOT/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v3.3.0 - 2022-04-05
+
+* Added a client library (VDRD.Client) for interacting with the [NVSS FHIR API](https://github.com/nightingaleproject/Reference-NCHS-API)
+* Added helper methods for setting field values that use value sets
+* Fixed bug in unknown DOB IJE to FHIR conversion
+
 ### v3.2.1 - 2021-10-05
 
 * Return null rather than an error when jurisdiction id is missing from VRDR record

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>3.2.1</Version>
+        <Version>3.3.0</Version>
         <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
         <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -303,6 +303,58 @@ dotnet run --project VRDR.CLI checkJson VRDR.CLI/1.json
 # Read in and parse an IJE death record and print out the values for every (supported) field
 dotnet run --project VRDR.CLI ije VRDR.CLI/1.MOR
 ```
+### VRDR.Client
+This directory contains classes and functions to connect to the [NVSS API server](https://github.com/nightingaleproject/Reference-NCHS-API), authenticate, manage authentication tokens, post records, and retrieve responses. For a full implementation of a client service that uses this library, see the [Reference Client Implementation](https://github.com/nightingaleproject/Reference-Client-API). 
+
+*This package is not yet published on NuGet.*
+
+Note that the VRDR.Client package automatically includes the VRDR package and the VRDR Messaging package, a project file should not reference both.
+
+You can include a locally downloaded copy of the library instead of the NuGet version by referencing `VRDRClient.csproj` in your project configuration, for example:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  ...
+  <ItemGroup>
+    <ProjectReference Include="..\VRDR.Client\VRDRClient.csproj" />
+    ...
+  </ItemGroup>
+</Project>
+```
+
+#### Example Usage
+Authenticate to the NVSS API Server
+```
+  // Example SAMS credentials
+  string authUrl = "https://<authServerUrl>.gov/auth/oauth/v2/token";
+  string clientId = "Client-id-from-sams";
+  string clientSecret = "Client-secret-from-sams";
+  string username = "your-sams-username";
+  string pass = "your-sams-password";
+
+  // ... Create the credentials and client intance
+  Credentials credentials = new Credentials(authUrl, clientId, clientSecret, username, pass);
+  string apiUrl = "https://<thenvssapiserverurl>.gov/OSELS/NCHS/NVSSFHIRAPI/<Jurisidction-Id>/Bundles";
+  Boolean localDev = false; // false when testing against the NVSS API Server
+  client = new Client(apiUrl, localDev, credentials);
+```
+
+POST a FHIR Message to the NVSS API Server with your authenticated client
+```
+  // ... Create a FHIR Message
+  BaseMessage msg = new BaseMessage();
+  Boolean success = client.PostMessageAsync(msg);
+  // ... handle success or failure
+```
+
+GET record responses from the NVSS API Server with your authenticated client
+```
+  // lastUpdated is a timestamp of the last GET request
+  lastUpdatedStr = lastUpdated.ToString("yyyy-MM-ddTHH:mm:ss.fffffff");
+  var content = client.GetMessageResponsesAsync(lastUpdatedStr);
+  
+  // ...parse the Bundle of Bundles in the content response
+```
 
 ### VRDR.HTTP
 This directory contains a deployable microservice that exposes endpoints for conversion of IJE flat files to DeathRecord JSON or XML, and vice versa.

--- a/VRDR.Client/Client.cs
+++ b/VRDR.Client/Client.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Newtonsoft.Json.Linq;
+using VRDR;
+using RestSharp;
+
+namespace nvssclient.lib;
+public class Client
+{
+    /// <summary>The API url</summary>
+    public String Url { get; }
+    /// <summary>Whether the client is running locally</summary>
+    public bool LocalTesting { get; }
+    /// <summary>The credentials to access the API server</summary>
+    public Credentials Credentials { get; }
+    /// <summary>The token to access the API server</summary>
+    public string Token { get; set; }
+    /// <summary>Constructor</summary>
+    public Client() { }
+    /// <summary>Constructor</summary>
+    private HttpClient client = new HttpClient();
+    public Client(String url, bool local, Credentials credentials)
+    {
+        this.Url = url;
+        this.LocalTesting = local;
+        this.Credentials = credentials;
+    }
+    // GetMessageResponsesAsync makes a GET request to the NVSS FHIR API server for new messages
+    // responses since the provided timestamp
+    public String GetMessageResponsesAsync(String lastUpdated)
+    {
+        var address = this.Url;
+        Console.WriteLine($">>> Get messages since: {lastUpdated}");
+
+        // if testing against the NVSS FHIR API server, add the authentication token
+        if (!this.LocalTesting){
+            if (String.IsNullOrEmpty(this.Token))
+            {
+                this.Token = this.Credentials.GetAuthorizeToken();
+            }
+            string authorization = this.Token;
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authorization);
+        }
+
+        if (lastUpdated != null){
+            address = this.Url + "?lastUpdated=" + lastUpdated;
+        }
+        var response = client.GetAsync(address).Result;
+        
+        if (response.IsSuccessStatusCode)
+        {
+            var content = response.Content.ReadAsStringAsync().Result;
+            Console.WriteLine(content);
+            return content;
+        }
+        else
+        {
+            Console.WriteLine(response.StatusCode);
+            return "";
+        }
+
+    }
+
+    // PostMessageAsync POSTS a single message to the NVSS FHIR API server for processing
+    public Boolean PostMessageAsync(BaseMessage message)
+    {
+
+        var json = message.ToJSON();
+        var data = new StringContent(json, Encoding.UTF8, "application/json");
+        //using var client = new HttpClient();
+
+        // if testing against the NVSS FHIR API server, add the authentication token
+        if (!this.LocalTesting){
+            if (String.IsNullOrEmpty(this.Token))
+            {
+                this.Token = this.Credentials.GetAuthorizeToken();
+            }
+            string authorization = this.Token;
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authorization);
+        }
+
+        var response = client.PostAsync(this.Url, data).Result;
+        if (response.IsSuccessStatusCode)
+        {
+            Console.WriteLine($">>> Successfully submitted {message.MessageId} of type {message.GetType().Name}");
+            return true;
+        }
+        else if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            // unauthorized, refresh token
+            Console.WriteLine($">>> Unauthorized error submitting {message.MessageId}, status: {response.StatusCode}");
+            return false;
+        }
+        else
+        {
+            Console.WriteLine($">>> Error submitting {message.MessageId}, status: {response.StatusCode}");
+            return false;
+        }
+    }
+}

--- a/VRDR.Client/Client.cs
+++ b/VRDR.Client/Client.cs
@@ -47,7 +47,7 @@ public class Client
         }
 
         if (lastUpdated != null){
-            address = this.Url + "?lastUpdated=" + lastUpdated;
+            address = this.Url + "?_since=" + lastUpdated;
         }
         var response = client.GetAsync(address).Result;
         

--- a/VRDR.Client/Client.cs
+++ b/VRDR.Client/Client.cs
@@ -20,8 +20,6 @@ public class Client
     /// <summary>The token to access the API server</summary>
     public string Token { get; set; }
     /// <summary>Constructor</summary>
-    public Client() { }
-    /// <summary>Constructor</summary>
     private HttpClient client = new HttpClient();
     public Client(String url, bool local, Credentials credentials)
     {
@@ -117,6 +115,7 @@ public class Client
                 JObject json = JObject.Parse(content);
                 if (json["access_token"] != null)
                 {
+                    this.Token = json["access_token"].ToString();
                     string authorization = this.Token;
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authorization);
                 }

--- a/VRDR.Client/Client.cs
+++ b/VRDR.Client/Client.cs
@@ -18,7 +18,7 @@ public class Client
     /// <summary>The credentials to access the API server</summary>
     public Credentials Credentials { get; }
     /// <summary>The token to access the API server</summary>
-    public string Token { get; set; }
+    public string? Token { get; set; }
     /// <summary>Constructor</summary>
     private HttpClient client = new HttpClient();
     public Client(String url, bool local, Credentials credentials)
@@ -108,7 +108,7 @@ public class Client
         HttpResponseMessage response = GetAuthorizeToken();
         if (response.IsSuccessStatusCode)
         {
-            String content = response.Content.ToString();
+            String? content = response.Content.ToString();
             // parse the response to get the access token
             if (!String.IsNullOrEmpty(content))
             {

--- a/VRDR.Client/Credentials.cs
+++ b/VRDR.Client/Credentials.cs
@@ -1,0 +1,58 @@
+using VRDR;
+using RestSharp;
+using Newtonsoft.Json.Linq;
+
+namespace nvssclient.lib;
+// The Credentials class includes the values required to authenticate to the API Gateway
+public class Credentials
+{
+    /// <summary>The oauth authentication url</summary>
+    public String Url { get; }
+    /// <summary>The client ID provided by SAMS</summary>
+    public String ClientId { get; }
+    /// <summary>The client secret provided by SAMS</summary>
+    public String ClientSecret { get; }
+    /// <summary>The username provided by SAMS</summary>
+    public String Username { get; }
+    /// <summary>The password provided by SAMS</summary>
+    public String Pass { get; }
+    /// <summary>Constructor</summary>
+    public Credentials() { }
+    /// <summary>Constructor</summary>
+    public Credentials(String url, String clientID, String clientSecret, String username, String pass)
+    {
+        this.Url = url;
+        this.ClientId = clientID;
+        this.ClientSecret = clientSecret;
+        this.Username = username;
+        this.Pass = pass;
+    }
+    /// <summary>Returns the token for the provided credientials</summary>
+    public String GetAuthorizeToken()
+    {
+        var rclient = new RestClient(this.Url);
+        var request = new RestRequest(Method.POST);
+
+        // add credentials to the request
+        String paramString = String.Format("grant_type=password&client_id={0}&client_secret={1}&username={2}&password={3}", this.ClientId, this.ClientSecret, this.Username, this.Pass);
+        request.AddHeader("content-type", "application/x-www-form-urlencoded");
+        request.AddParameter("application/x-www-form-urlencoded", paramString, ParameterType.RequestBody);
+        
+        IRestResponse response = rclient.Execute(request);
+        string content = response.Content;
+
+        // parse the response to get the access token
+        if (!String.IsNullOrEmpty(content))
+        {
+            JObject json = JObject.Parse(content);
+            if (json["access_token"] != null)
+            {
+                String newtoken = json["access_token"].ToString();
+                return newtoken;
+            }
+            
+        }
+        return "";
+    }
+
+}

--- a/VRDR.Client/Credentials.cs
+++ b/VRDR.Client/Credentials.cs
@@ -27,32 +27,5 @@ public class Credentials
         this.Username = username;
         this.Pass = pass;
     }
-    /// <summary>Returns the token for the provided credientials</summary>
-    public String GetAuthorizeToken()
-    {
-        var rclient = new RestClient(this.Url);
-        var request = new RestRequest(Method.POST);
-
-        // add credentials to the request
-        String paramString = String.Format("grant_type=password&client_id={0}&client_secret={1}&username={2}&password={3}", this.ClientId, this.ClientSecret, this.Username, this.Pass);
-        request.AddHeader("content-type", "application/x-www-form-urlencoded");
-        request.AddParameter("application/x-www-form-urlencoded", paramString, ParameterType.RequestBody);
-        
-        IRestResponse response = rclient.Execute(request);
-        string content = response.Content;
-
-        // parse the response to get the access token
-        if (!String.IsNullOrEmpty(content))
-        {
-            JObject json = JObject.Parse(content);
-            if (json["access_token"] != null)
-            {
-                String newtoken = json["access_token"].ToString();
-                return newtoken;
-            }
-            
-        }
-        return "";
-    }
 
 }

--- a/VRDR.Client/Credentials.cs
+++ b/VRDR.Client/Credentials.cs
@@ -17,8 +17,6 @@ public class Credentials
     /// <summary>The password provided by SAMS</summary>
     public String Pass { get; }
     /// <summary>Constructor</summary>
-    public Credentials() { }
-    /// <summary>Constructor</summary>
     public Credentials(String url, String clientID, String clientSecret, String username, String pass)
     {
         this.Url = url;

--- a/VRDR.Client/VRDRClient.csproj
+++ b/VRDR.Client/VRDRClient.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="VRDR.Messaging" Version="3.2.1"/>
+  </ItemGroup>
+
+</Project>

--- a/vrdr-dotnet.sln
+++ b/vrdr-dotnet.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeathRecord.CLI", "VRDR.CLI
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FhirDeathRecord.HTTP", "VRDR.HTTP\FhirDeathRecord.HTTP.csproj", "{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VRDRClient", "VRDR.Client\VRDRClient.csproj", "{12518F30-0FCA-403A-A753-63D487D03A9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x64.Build.0 = Release|Any CPU
 		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x86.ActiveCfg = Release|Any CPU
 		{26E609D9-ECE5-4A9C-B12D-E5A74A775CC6}.Release|x86.Build.0 = Release|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Debug|x64.Build.0 = Debug|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Debug|x86.Build.0 = Debug|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Release|x64.ActiveCfg = Release|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Release|x64.Build.0 = Release|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Release|x86.ActiveCfg = Release|Any CPU
+		{12518F30-0FCA-403A-A753-63D487D03A9C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The client authentication, token handling, post requests, and get requests have been moved into the vrdr-dotnet library. This will make it easier for jurisdictions to reuse code without having to read through the entire client reference implementation.