### PR TITLE
Nightingale conversion fixes and additional updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,25 +36,25 @@ jobs:
       run: |
           echo "* dotnet test VRDR.Tests/DeathRecord.Tests.csproj"
           dotnet test VRDR.Tests/DeathRecord.Tests.csproj
-          echo "* dotnet run -p VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json"
-          dotnet run -p VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json
-          echo "* dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml"
-          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml
-          echo "* dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml"
-          dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml
-          echo "* dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.json"
-          dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.json
-          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml"
-          ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml  
-          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json"
-          ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json  
-          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml"
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml  
-          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json"
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json   
-          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml"
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml  
-          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json"
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json  
+          echo "* dotnet run --project VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json"
+          dotnet run --project VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json
+          echo "* dotnet run --project VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml"
+          dotnet run --project VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml
+          echo "* dotnet run --project VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml"
+          dotnet run --project VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml
+          echo "* dotnet run --project VRDR.CLI description VRDR.CLI/1_wJurisdiction.json"
+          dotnet run --project VRDR.CLI description VRDR.CLI/1_wJurisdiction.json
+          echo "* ! dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1.xml"
+          ! dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1.xml  
+          echo "* ! dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1.json"
+          ! dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1.json  
+          echo "* dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml"
+          dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml  
+          echo "* dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json"
+          dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json   
+          echo "* dotnet run --project VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml"
+          dotnet run --project VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml  
+          echo "* dotnet run --project VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json"
+          dotnet run --project VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json  
           echo "* ./VRDR.Tests/test_translation_service.sh"
           ./VRDR.Tests/test_translation_service.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,26 +36,6 @@ jobs:
       run: |
           echo "* dotnet test VRDR.Tests/DeathRecord.Tests.csproj"
           dotnet test VRDR.Tests/DeathRecord.Tests.csproj
-          echo "* dotnet run -p VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1"
-          dotnet run -p VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1
-          echo "* dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1"
-          dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1
-          echo "* dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1"
-          dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1
-          echo "* dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1"
-          dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1
-          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml --framework netcoreapp2.1  "
-          ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml --framework netcoreapp2.1  
-          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json --framework netcoreapp2.1  "
-          ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json --framework netcoreapp2.1  
-          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1  " 
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1  
-          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1 "
-          dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1 
-          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1"
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml --framework netcoreapp2.1
-          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1"
-          dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json --framework netcoreapp2.1
           echo "* dotnet run -p VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json"
           dotnet run -p VRDR.CLI json2json VRDR.CLI/1_wJurisdiction.json
           echo "* dotnet run -p VRDR.CLI xml2xml VRDR.CLI/1_wJurisdiction.xml"
@@ -64,17 +44,17 @@ jobs:
           dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.xml
           echo "* dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.json"
           dotnet run -p VRDR.CLI description VRDR.CLI/1_wJurisdiction.json
-          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml  "
+          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml"
           ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.xml  
-          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json  "
+          echo "* ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json"
           ! dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1.json  
-          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml  "
+          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml"
           dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.xml  
-          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json   "
+          echo "* dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json"
           dotnet run -p VRDR.CLI roundtrip-ije VRDR.CLI/1_wJurisdiction.json   
-          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml  "
+          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml"
           dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.xml  
-          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json  "
+          echo "* dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json"
           dotnet run -p VRDR.CLI roundtrip-all VRDR.CLI/1_wJurisdiction.json  
           echo "* ./VRDR.Tests/test_translation_service.sh"
           ./VRDR.Tests/test_translation_service.sh

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ This repository includes .NET (C#) code for
 
 ### Development & CLI Requirements
 - This repository is built using .NET Core 3.1, download [here](https://dotnet.microsoft.com/download)
-- You can also use .NET Core 2.1, see VRDR.CLI section below for instructions
 ### Library Usage
 - The VRDR or VRDR.Messaging libraries target .NET Standard 2.0
 - To check whether your .NET version supports a release, refer to [the .NET matrix](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support).
@@ -265,8 +264,6 @@ dotnet test
 
 ### VRDR.CLI
 This directory contains a sample command line interface app that uses the VRDR library to do a few different things.
-
-NOTE: If you would like to run the CLI using .NET core 2.1, append `--framework netcoreapp2.1` to the end of all the example commands below
 
 #### Example Usages
 ```bash

--- a/README.md
+++ b/README.md
@@ -151,6 +151,41 @@ Console.WriteLine($"Cause of Death Part I Interval, Line a: {deathRecord.INTERVA
 Console.WriteLine($"Cause of Death Part I Code, Line a: {String.Join(", ", deathRecord.CODE1A.Select(x => x.Key + "=" + x.Value).ToArray())}");
 ```
 
+#### Helper Methods for Value Sets
+
+For fields that contain coded values it can involve some extra effort to provide the code, the code
+system, and the display text. The VRDR library includes some helper methods to make this easier. For
+example, here's how to specify the pregnancy status using the long form specifying each of the three
+necessary values:
+
+```
+// Add PregnancyStatus
+Dictionary<string, string> code = new Dictionary<string, string>();
+code.Add("code", "PHC1261");
+code.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+code.Add("display", "Pregnant at the time of death");
+deathRecord.PregnancyStatus = code;
+```
+
+Here's a simpler way to accomplish the same thing by using the `PregnancyStatusHelper`:
+
+```
+deathRecord.PregnancyStatusHelper = "PHC1261";
+```
+
+The helper automatically looks up the correct code system and display string. The following helpers
+are available to simplify setting coded values:
+
+* CertificationRoleHelper
+* MannerOfDeathTypeHelper
+* MaritalStatusHelper
+* EducationLevelHelper
+* DecedentDispositionMethodHelper
+* DeathLocationTypeHelper
+* PregnancyStatusHelper
+* InjuryPlaceHelper
+* TransportationRoleHelper
+
 #### FHIR VRDR record to/from IJE Mortality format
 An example of converting a VRDR FHIR Death Record to an IJE string:
 ```cs

--- a/VRDR.CLI/1_wJurisdiction.json
+++ b/VRDR.CLI/1_wJurisdiction.json
@@ -507,7 +507,7 @@
                 {
                   "system": "http://snomed.info/sct",
                   "code": "434641000124105",
-                  "display": "Physician"
+                  "display": "Physician certified and pronounced death certificate"
                 }
               ]
             },

--- a/VRDR.CLI/1_wJurisdiction.xml
+++ b/VRDR.CLI/1_wJurisdiction.xml
@@ -396,7 +396,7 @@
             <coding>
               <system value="http://snomed.info/sct" />
               <code value="434641000124105" />
-              <display value="Physician" />
+              <display value="Physician certified and pronounced death certificate" />
             </coding>
           </function>
           <actor>

--- a/VRDR.CLI/DeathRecord.CLI.csproj
+++ b/VRDR.CLI/DeathRecord.CLI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\VRDR\DeathRecord.csproj" />

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -473,6 +473,12 @@ namespace VRDR.CLI
                 //Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(Newtonsoft.Json.JsonConvert.DeserializeObject(deathRecord.ToJSON()), Newtonsoft.Json.Formatting.Indented) + "\n\n");
                 return 0;
             }
+            else if (args.Length == 4 && args[0] == "connectathon")
+            {
+                DeathRecord d = Connectathon.FromId(Int16.Parse(args[1]), Int16.Parse(args[2]), args[3]);
+                Console.WriteLine(d.ToJson());
+                return 0;
+            }
             else if (args.Length == 2 && args[0] == "description")
             {
                 DeathRecord d = new DeathRecord(File.ReadAllText(args[1]));

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -30,15 +30,15 @@ namespace VRDR.HTTP
             SetYesNoValueDictionary(values, "didTobaccoUseContributeToDeath.didTobaccoUseContributeToDeath", record, "TobaccoUse");
             SetYesNoValueDictionary(values, "meOrCoronerContacted.meOrCoronerContacted", record, "ExaminerContacted");
 
-            if (GetValueDict(record.CertificationRole, "code") == "434651000124107")
+            if (record.CertificationRoleHelper == "434651000124107")
             {
                 values["certifierType.certifierType"] = "Physician (Certifier)";
             }
-            else if (GetValueDict(record.CertificationRole, "code") == "434641000124105")
+            else if (record.CertificationRoleHelper == "434641000124105")
             {
                 values["certifierType.certifierType"] = "Physician (Pronouncer and Certifier)";
             }
-            else if (GetValueDict(record.CertificationRole, "code") == "455381000124109")
+            else if (record.CertificationRoleHelper == "455381000124109")
             {
                 values["certifierType.certifierType"] = "Medical Examiner";
             }
@@ -167,9 +167,9 @@ namespace VRDR.HTTP
 
             SetStringValueDictionary(values, "detailsOfInjury.detailsOfInjury", record.InjuryLocationDescription);
 
-            if (record.EducationLevel != null && record.EducationLevel.ContainsKey("code"))
+            if (record.EducationLevelHelper != null)
             {
-                switch (record.EducationLevel["code"])
+                switch (record.EducationLevelHelper)
                 {
                     case "PHC1448":
                         values["education.education"] = "8th grade or less";
@@ -198,9 +198,9 @@ namespace VRDR.HTTP
                 }
             }
 
-            if (record.MannerOfDeathType != null && record.MannerOfDeathType.ContainsKey("code"))
+            if (record.MannerOfDeathTypeHelper != null)
             {
-                switch (record.MannerOfDeathType["code"])
+                switch (record.MannerOfDeathTypeHelper)
                 {
                     case "38605008":
                         values["mannerOfDeath.mannerOfDeath"] = "Natural";
@@ -223,9 +223,9 @@ namespace VRDR.HTTP
                 }
             }
 
-            if (record.MaritalStatus != null && record.MaritalStatus.ContainsKey("code"))
+            if (record.MaritalStatusHelper != null)
             {
-                switch (record.MaritalStatus["code"])
+                switch (record.MaritalStatusHelper)
                 {
                     case "M":
                         values["maritalStatus.maritalStatus"] = "Married";
@@ -249,6 +249,42 @@ namespace VRDR.HTTP
             }
 
             SetStringValueDictionary(values, "usualOccupation.usualOccupation", record.UsualOccupation);
+
+            if (record.DeathLocationTypeHelper != null)
+            {
+                if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Hospital_Dead_On_Arrival)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Dead on arrival at hospital";
+                }
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Decedents_Home)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Death in home";
+                }
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Hospice)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Death in hospice";
+                }
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Hospital_Inpatient)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Death in hospital";
+                }
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Emergency_Room_Outpatient)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Death in hospital-based emergency department or outpatient department";
+                }
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Long_Term_Care_Facility)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Death in nursing home or long term care facility";
+                }
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Unknown)
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Unknown";
+                }
+                else
+                {
+                    values["placeOfDeath.placeOfDeath.option"] = "Other";
+                }
+            }
 
             if (record.BirthSex != null)
             {
@@ -301,27 +337,19 @@ namespace VRDR.HTTP
 
             if (GetValue(values, "certifierType.certifierType") == "Physician (Certifier)")
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434651000124107");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Physician");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
+                deathRecord.CertificationRoleHelper = "434651000124107";
             }
             else if (GetValue(values, "certifierType.certifierType") == "Physician (Pronouncer and Certifier)")
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434641000124105");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Physician (Pronouncer and Certifier)");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
+                deathRecord.CertificationRoleHelper = "434641000124105";
             }
             else if (GetValue(values, "certifierType.certifierType") == "Medical Examiner")
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "455381000124109");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Medical Examiner");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
+                deathRecord.CertificationRoleHelper = "455381000124109";
             }
             else
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "OTH");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Other");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
+                deathRecord.CertificationRoleHelper = "OTH";
             }
 
             SetStringValueDeathRecordString(deathRecord, "COD1A", GetValue(values, "cod.immediate"));
@@ -412,172 +440,107 @@ namespace VRDR.HTTP
             switch (GetValue(values, "education.education"))
             {
                 case "8th grade or less":
-                    Dictionary<string, string> edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1448");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "8th grade or less");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1448";
                     break;
                 case "9th through 12th grade; no diploma":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1449");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "9th through 12th grade; no diploma");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1449";
                     break;
                 case "High School Graduate or GED Completed":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1450");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "High School Graduate or GED Completed");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1450";
                     break;
                 case "Some college credit, but no degree":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1451");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "Some college credit, but no degree");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1451";
                     break;
                 case "Associate Degree":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1452");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "Associate Degree");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1452";
                     break;
                 case "Bachelor's Degree":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1453");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "Bachelor's Degree");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1453";
                     break;
                 case "Master's Degree":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1454");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "Master's Degree");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1454";
                     break;
                 case "Doctorate Degree or Professional Degree":
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "PHC1455");
-                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
-                    edu.Add("display", "Doctorate Degree or Professional Degree");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "PHC1455";
                     break;
                 default:
-                    edu = new Dictionary<string, string>();
-                    edu.Add("code", "UNK");
-                    edu.Add("system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
-                    edu.Add("display", "Unknown");
-                    deathRecord.EducationLevel = edu;
+                    deathRecord.EducationLevelHelper = "UNK";
                     break;
             }
 
             switch (GetValue(values, "mannerOfDeath.mannerOfDeath"))
             {
                 case "Natural":
-                    Dictionary<string, string> mod = new Dictionary<string, string>();
-                    mod.Add("code", "38605008");
-                    mod.Add("system", VRDR.CodeSystems.SCT);
-                    mod.Add("display", "Natural");
-                    deathRecord.MannerOfDeathType = mod;
+                    deathRecord.MannerOfDeathTypeHelper = "38605008";
                     break;
                 case "Accident":
-                    mod = new Dictionary<string, string>();
-                    mod.Add("code", "7878000");
-                    mod.Add("system", VRDR.CodeSystems.SCT);
-                    mod.Add("display", "Accident");
-                    deathRecord.MannerOfDeathType = mod;
+                    deathRecord.MannerOfDeathTypeHelper = "7878000";
                     break;
                 case "Suicide":
-                    mod = new Dictionary<string, string>();
-                    mod.Add("code", "44301001");
-                    mod.Add("system", VRDR.CodeSystems.SCT);
-                    mod.Add("display", "Suicide");
-                    deathRecord.MannerOfDeathType = mod;
+                    deathRecord.MannerOfDeathTypeHelper = "44301001";
                     break;
                 case "Homicide":
-                    mod = new Dictionary<string, string>();
-                    mod.Add("code", "27935005");
-                    mod.Add("system", VRDR.CodeSystems.SCT);
-                    mod.Add("display", "Homicide");
-                    deathRecord.MannerOfDeathType = mod;
+                    deathRecord.MannerOfDeathTypeHelper = "27935005";
                     break;
                 case "Pending Investigation":
-                    mod = new Dictionary<string, string>();
-                    mod.Add("code", "185973002");
-                    mod.Add("system", VRDR.CodeSystems.SCT);
-                    mod.Add("display", "Pending Investigation");
-                    deathRecord.MannerOfDeathType = mod;
+                    deathRecord.MannerOfDeathTypeHelper = "185973002";
                     break;
                 case "Could not be determined":
-                    mod = new Dictionary<string, string>();
-                    mod.Add("code", "65037004");
-                    mod.Add("system", VRDR.CodeSystems.SCT);
-                    mod.Add("display", "Could not be determined");
-                    deathRecord.MannerOfDeathType = mod;
+                    deathRecord.MannerOfDeathTypeHelper = "65037004";
                     break;
             }
 
             switch (GetValue(values, "maritalStatus.maritalStatus"))
             {
                 case "Married":
-                    Dictionary<string, string> mar = new Dictionary<string, string>();
-                    mar.Add("code", "M");
-                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
-                    mar.Add("display", "Married");
-                    deathRecord.MaritalStatus = mar;
+                    deathRecord.MaritalStatusHelper = "M";
                     break;
                 case "Legally Separated":
-                    mar = new Dictionary<string, string>();
-                    mar.Add("code", "L");
-                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
-                    mar.Add("display", "Legally Separated");
-                    deathRecord.MaritalStatus = mar;
+                    deathRecord.MaritalStatusHelper = "L";
                     break;
                 case "Widowed":
-                    mar = new Dictionary<string, string>();
-                    mar.Add("code", "W");
-                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
-                    mar.Add("display", "Widowed");
-                    deathRecord.MaritalStatus = mar;
+                    deathRecord.MaritalStatusHelper = "W";
                     break;
                 case "Divorced":
-                    mar = new Dictionary<string, string>();
-                    mar.Add("code", "D");
-                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
-                    mar.Add("display", "Divorced");
-                    deathRecord.MaritalStatus = mar;
+                    deathRecord.MaritalStatusHelper = "D";
                     break;
                 case "Never Married":
-                    mar = new Dictionary<string, string>();
-                    mar.Add("code", "S");
-                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
-                    mar.Add("display", "Never Married");
-                    deathRecord.MaritalStatus = mar;
+                    deathRecord.MaritalStatusHelper = "S";
                     break;
                 case "unknown":
-                    mar = new Dictionary<string, string>();
-                    mar.Add("code", "UNK");
-                    mar.Add("system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
-                    mar.Add("display", "unknown");
-                    deathRecord.MaritalStatus = mar;
+                    deathRecord.MaritalStatusHelper = "UNK";
                     break;
             }
 
             SetStringValueDeathRecordString(deathRecord, "UsualOccupation", GetValue(values, "usualOccupation.usualOccupation"));
 
-            // TODO: Add support for placeOfDeath.placeOfDeath.option
-            // Options: "Dead on arrival at hospital", "Death in home", "Death in hospice", "Death in hospital",
-            // "Death in hospital-based emergency department or outpatient department",
-            // "Death in nursing home or long term care facility", "Unknown", "Other"
-
-            // Idea: add helpers to DeathRecord.cs with "Code" suffixes that take a string code and 1) raise an error
-            // if it's not a valid code and 2) automatically assign the system and display; implement with a helper
-            // function that takes a hash of codes to system/display
+            switch (GetValue(values, "placeOfDeath.placeOfDeath.option"))
+            {
+                case "Dead on arrival at hospital":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Hospital_Dead_On_Arrival;
+                    break;
+                case "Death in home":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Decedents_Home;
+                    break;
+                case "Death in hospice":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Hospice;
+                    break;
+                case "Death in hospital":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Hospital_Inpatient;
+                    break;
+                case "Death in hospital-based emergency department or outpatient department":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Emergency_Room_Outpatient;
+                    break;
+                case "Death in nursing home or long term care facility":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Long_Term_Care_Facility;
+                    break;
+                case "Unknown":
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Unknown;
+                    break;
+                default:
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Other;
+                    break;
+            }
 
             if (GetValue(values, "sex.sex") == "Male")
             {

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -134,25 +134,28 @@ namespace VRDR.HTTP
             {
                 switch (record.EducationLevel["code"])
                 {
-                    case "SEC":
+                    case "PHC1448":
+                        values["education.education"] = "8th grade or less";
+                        break;
+                    case "PHC1449":
                         values["education.education"] = "9th through 12th grade; no diploma";
                         break;
-                    case "HS":
+                    case "PHC1450":
                         values["education.education"] = "High School Graduate or GED Completed";
                         break;
-                    case "PB":
+                    case "PHC1451":
                         values["education.education"] = "Some college credit, but no degree";
                         break;
-                    case "ASSOC":
+                    case "PHC1452":
                         values["education.education"] = "Associate Degree";
                         break;
-                    case "BD":
+                    case "PHC1453":
                         values["education.education"] = "Bachelor's Degree";
                         break;
-                    case "GD":
+                    case "PHC1454":
                         values["education.education"] = "Master's Degree";
                         break;
-                    case "POSTG":
+                    case "PHC1455":
                         values["education.education"] = "Doctorate Degree or Professional Degree";
                         break;
                 }
@@ -252,30 +255,30 @@ namespace VRDR.HTTP
             SetStringValueDeathRecordString(deathRecord, "Identifier", GetValue(values, "certificateNumber"));
             SetStringValueDeathRecordString(deathRecord, "DeathLocationJurisdiction", GetValue(values, "deathLocationJurisdiction"));
 
+            SetYesNoValueDeathRecordBoolean(deathRecord, "MilitaryServiceBoolean", GetValue(values, "armedForcesService.armedForcesService"));
+            SetYesNoValueDeathRecordBoolean(deathRecord, "AutopsyPerformedIndicatorBoolean", GetValue(values, "autopsyPerformed.autopsyPerformed"));
+            SetYesNoValueDeathRecordBoolean(deathRecord, "AutopsyResultsAvailableBoolean", GetValue(values, "autopsyAvailableToCompleteCauseOfDeath.autopsyAvailableToCompleteCauseOfDeath"));
+            SetYesNoValueDeathRecordBoolean(deathRecord, "ExaminerContactedBoolean", GetValue(values, "meOrCoronerContacted.meOrCoronerContacted"));
 
-            SetYesNoValueDeathRecordCode(deathRecord, "MilitaryService", GetValue(values, "armedForcesService.armedForcesService"));
-            SetYesNoValueDeathRecordCode(deathRecord, "AutopsyPerformedIndicator", GetValue(values, "autopsyPerformed.autopsyPerformed"));
-            SetYesNoValueDeathRecordCode(deathRecord, "AutopsyResultsAvailable", GetValue(values, "autopsyAvailableToCompleteCauseOfDeath.autopsyAvailableToCompleteCauseOfDeath"));
             SetYesNoValueDeathRecordCode(deathRecord, "TobaccoUse", GetValue(values, "didTobaccoUseContributeToDeath.didTobaccoUseContributeToDeath"));
-            SetYesNoValueDeathRecordCode(deathRecord, "ExaminerContacted", GetValue(values, "meOrCoronerContacted.meOrCoronerContacted"));
 
             if (GetValue(values, "certifierType.certifierType") == "Physician (Certifier)")
             {
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434641000124105");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Physician");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", "http://snomed.info/sct");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
             }
             else if (GetValue(values, "certifierType.certifierType") == "Physician (Pronouncer and Certifier)")
             {
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434651000124107");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Physician (Pronouncer and Certifier)");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", "http://snomed.info/sct");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
             }
             else if (GetValue(values, "certifierType.certifierType") == "Medical Examiner")
             {
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "440051000124108");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Medical Examiner");
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", "http://snomed.info/sct");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
             }
 
             SetStringValueDeathRecordString(deathRecord, "COD1A", GetValue(values, "cod.immediate"));
@@ -366,53 +369,66 @@ namespace VRDR.HTTP
             switch (GetValue(values, "education.education"))
             {
                 case "8th grade or less":
-                case "9th through 12th grade; no diploma":
                     Dictionary<string, string> edu = new Dictionary<string, string>();
-                    edu.Add("code", "SEC");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "Some secondary or high school education");
+                    edu.Add("code", "PHC1448");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "8th grade or less");
+                    deathRecord.EducationLevel = edu;
+                    break;
+                case "9th through 12th grade; no diploma":
+                    edu = new Dictionary<string, string>();
+                    edu.Add("code", "PHC1449");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "9th through 12th grade; no diploma");
                     deathRecord.EducationLevel = edu;
                     break;
                 case "High School Graduate or GED Completed":
                     edu = new Dictionary<string, string>();
-                    edu.Add("code", "HS");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "High School or secondary school degree complete");
+                    edu.Add("code", "PHC1450");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "High School Graduate or GED Completed");
                     deathRecord.EducationLevel = edu;
                     break;
                 case "Some college credit, but no degree":
                     edu = new Dictionary<string, string>();
-                    edu.Add("code", "PB");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "Some post-baccalaureate education");
+                    edu.Add("code", "PHC1451");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "Some college credit, but no degree");
                     deathRecord.EducationLevel = edu;
                     break;
                 case "Associate Degree":
                     edu = new Dictionary<string, string>();
-                    edu.Add("code", "ASSOC");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "Associate's or technical degree complete");
+                    edu.Add("code", "PHC1452");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "Associate Degree");
                     deathRecord.EducationLevel = edu;
                     break;
                 case "Bachelor's Degree":
                     edu = new Dictionary<string, string>();
-                    edu.Add("code", "BD");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "College or baccalaureate degree complete");
+                    edu.Add("code", "PHC1453");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "Bachelor's Degree");
                     deathRecord.EducationLevel = edu;
                     break;
                 case "Master's Degree":
                     edu = new Dictionary<string, string>();
-                    edu.Add("code", "GD");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "Graduate or professional Degree complete");
+                    edu.Add("code", "PHC1454");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "Master's Degree");
                     deathRecord.EducationLevel = edu;
                     break;
                 case "Doctorate Degree or Professional Degree":
                     edu = new Dictionary<string, string>();
-                    edu.Add("code", "POSTG");
-                    edu.Add("system", "http://terminology.hl7.org/CodeSystem/v3-EducationLevel");
-                    edu.Add("display", "Doctoral or post graduate education");
+                    edu.Add("code", "PHC1455");
+                    edu.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+                    edu.Add("display", "Doctorate Degree or Professional Degree");
+                    deathRecord.EducationLevel = edu;
+                    break;
+                default:
+                    edu = new Dictionary<string, string>();
+                    edu.Add("code", "UNK");
+                    edu.Add("system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
+                    edu.Add("display", "Unknown");
                     deathRecord.EducationLevel = edu;
                     break;
             }
@@ -424,36 +440,42 @@ namespace VRDR.HTTP
                 case "Natural":
                     Dictionary<string, string> mod = new Dictionary<string, string>();
                     mod.Add("code", "38605008");
+                    mod.Add("system", VRDR.CodeSystems.SCT);
                     mod.Add("display", "Natural");
                     deathRecord.MannerOfDeathType = mod;
                     break;
                 case "Accident":
                     mod = new Dictionary<string, string>();
                     mod.Add("code", "7878000");
+                    mod.Add("system", VRDR.CodeSystems.SCT);
                     mod.Add("display", "Accident");
                     deathRecord.MannerOfDeathType = mod;
                     break;
                 case "Suicide":
                     mod = new Dictionary<string, string>();
                     mod.Add("code", "44301001");
+                    mod.Add("system", VRDR.CodeSystems.SCT);
                     mod.Add("display", "Suicide");
                     deathRecord.MannerOfDeathType = mod;
                     break;
                 case "Homicide":
                     mod = new Dictionary<string, string>();
                     mod.Add("code", "27935005");
+                    mod.Add("system", VRDR.CodeSystems.SCT);
                     mod.Add("display", "Homicide");
                     deathRecord.MannerOfDeathType = mod;
                     break;
                 case "Pending Investigation":
                     mod = new Dictionary<string, string>();
                     mod.Add("code", "185973002");
+                    mod.Add("system", VRDR.CodeSystems.SCT);
                     mod.Add("display", "Pending Investigation");
                     deathRecord.MannerOfDeathType = mod;
                     break;
                 case "Could not be determined":
                     mod = new Dictionary<string, string>();
                     mod.Add("code", "65037004");
+                    mod.Add("system", VRDR.CodeSystems.SCT);
                     mod.Add("display", "Could not be determined");
                     deathRecord.MannerOfDeathType = mod;
                     break;
@@ -464,42 +486,42 @@ namespace VRDR.HTTP
                 case "Married":
                     Dictionary<string, string> mar = new Dictionary<string, string>();
                     mar.Add("code", "M");
-                    mar.Add("system", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus");
+                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
                     mar.Add("display", "Married");
                     deathRecord.MaritalStatus = mar;
                     break;
                 case "Legally Separated":
                     mar = new Dictionary<string, string>();
                     mar.Add("code", "L");
-                    mar.Add("system", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus");
+                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
                     mar.Add("display", "Legally Separated");
                     deathRecord.MaritalStatus = mar;
                     break;
                 case "Widowed":
                     mar = new Dictionary<string, string>();
                     mar.Add("code", "W");
-                    mar.Add("system", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus");
+                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
                     mar.Add("display", "Widowed");
                     deathRecord.MaritalStatus = mar;
                     break;
                 case "Divorced":
                     mar = new Dictionary<string, string>();
                     mar.Add("code", "D");
-                    mar.Add("system", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus");
+                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
                     mar.Add("display", "Divorced");
                     deathRecord.MaritalStatus = mar;
                     break;
                 case "Never Married":
                     mar = new Dictionary<string, string>();
                     mar.Add("code", "S");
-                    mar.Add("system", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus");
+                    mar.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
                     mar.Add("display", "Never Married");
                     deathRecord.MaritalStatus = mar;
                     break;
                 case "unknown":
                     mar = new Dictionary<string, string>();
                     mar.Add("code", "UNK");
-                    mar.Add("system", "http://terminology.hl7.org/CodeSystem/v3-NullFlavor");
+                    mar.Add("system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
                     mar.Add("display", "unknown");
                     deathRecord.MaritalStatus = mar;
                     break;
@@ -610,54 +632,60 @@ namespace VRDR.HTTP
             prop.SetValue(deathRecord, dict, null);
         }
 
-        /// <summary>Set a Yes/No (coded) value on a DeathRecord.</summary>
-        private static void SetYesNoValueDeathRecordCode(DeathRecord deathRecord, string property, string value)
+        /// <summary>Set a Yes/No (coded) value on a DeathRecord using Boolean helpers.</summary>
+        private static void SetYesNoValueDeathRecordBoolean(DeathRecord deathRecord, string property, string value)
         {
+            Type type = deathRecord.GetType();
+            PropertyInfo prop = type.GetProperty(property);
             if (String.IsNullOrWhiteSpace(value))
             {
-                return;
+                prop.SetValue(deathRecord, null);
             }
-            if (value.Trim().ToLower() == "yes")
+            else if (value.Trim().ToLower() == "yes")
             {
-                Dictionary<string, string> mserv = new Dictionary<string, string>();
-                mserv.Add("code", "Y");
-                mserv.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                mserv.Add("display", "Yes");
-                Type type = deathRecord.GetType();
-                PropertyInfo prop = type.GetProperty(property);
-                prop.SetValue(deathRecord, mserv, null);
+                prop.SetValue(deathRecord, true);
             }
             else if (value.Trim().ToLower() == "no")
             {
-                Dictionary<string, string> mserv = new Dictionary<string, string>();
-                mserv.Add("code", "N");
-                mserv.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                mserv.Add("display", "No");
-                Type type = deathRecord.GetType();
-                PropertyInfo prop = type.GetProperty(property);
-                prop.SetValue(deathRecord, mserv, null);
+                prop.SetValue(deathRecord, false);
+            }
+            else
+            {
+                prop.SetValue(deathRecord, null);
             }
         }
 
         /// <summary>Set a Yes/No (coded) value on a DeathRecord.</summary>
-        private static void SetYesNoValueDeathRecordBool(DeathRecord deathRecord, string property, string value)
+        private static void SetYesNoValueDeathRecordCode(DeathRecord deathRecord, string property, string value)
         {
+            Dictionary<string, string> coding = new Dictionary<string, string>();
             if (String.IsNullOrWhiteSpace(value))
             {
-                return;
+                coding.Add("code", "UNK");
+                coding.Add("system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
+                coding.Add("display", "Unknown");
             }
-            if (value.Trim().ToLower() == "yes")
+            else if (value.Trim().ToLower() == "yes")
             {
-                Type type = deathRecord.GetType();
-                PropertyInfo prop = type.GetProperty(property);
-                prop.SetValue(deathRecord, true, null);
+                coding.Add("code", "373066001");
+                coding.Add("system", CodeSystems.SCT);
+                coding.Add("display", "Yes");
             }
             else if (value.Trim().ToLower() == "no")
             {
-                Type type = deathRecord.GetType();
-                PropertyInfo prop = type.GetProperty(property);
-                prop.SetValue(deathRecord, false, null);
+                coding.Add("code", "373067005");
+                coding.Add("system", CodeSystems.SCT);
+                coding.Add("display", "No");
             }
+            else
+            {
+                coding.Add("code", "UNK");
+                coding.Add("system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
+                coding.Add("display", "Unknown");
+            }
+            Type type = deathRecord.GetType();
+            PropertyInfo prop = type.GetProperty(property);
+            prop.SetValue(deathRecord, coding);
         }
 
         /// <summary>Set a value in a Dictionary, but only if that value is not null or whitespace.</summary>

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -30,15 +30,15 @@ namespace VRDR.HTTP
             SetYesNoValueDictionary(values, "didTobaccoUseContributeToDeath.didTobaccoUseContributeToDeath", record, "TobaccoUse");
             SetYesNoValueDictionary(values, "meOrCoronerContacted.meOrCoronerContacted", record, "ExaminerContacted");
 
-            if (GetValueDict(record.CertificationRole, "code") == "434641000124105")
+            if (GetValueDict(record.CertificationRole, "code") == "434651000124107")
             {
                 values["certifierType.certifierType"] = "Physician (Certifier)";
             }
-            else if (GetValueDict(record.CertificationRole, "code") == "434651000124107")
+            else if (GetValueDict(record.CertificationRole, "code") == "434641000124105")
             {
                 values["certifierType.certifierType"] = "Physician (Pronouncer and Certifier)";
             }
-            else if (GetValueDict(record.CertificationRole, "code") == "440051000124108")
+            else if (GetValueDict(record.CertificationRole, "code") == "455381000124109")
             {
                 values["certifierType.certifierType"] = "Medical Examiner";
             }
@@ -264,21 +264,27 @@ namespace VRDR.HTTP
 
             if (GetValue(values, "certifierType.certifierType") == "Physician (Certifier)")
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434641000124105");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434651000124107");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Physician");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
             }
             else if (GetValue(values, "certifierType.certifierType") == "Physician (Pronouncer and Certifier)")
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434651000124107");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "434641000124105");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Physician (Pronouncer and Certifier)");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
             }
             else if (GetValue(values, "certifierType.certifierType") == "Medical Examiner")
             {
-                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "440051000124108");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "455381000124109");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Medical Examiner");
                 SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.SCT);
+            }
+            else
+            {
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "code", "OTH");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "display", "Other");
+                SetStringValueDeathRecordDictionary(deathRecord, "CertificationRole", "system", VRDR.CodeSystems.PH_NullFlavor_HL7_V3);
             }
 
             SetStringValueDeathRecordString(deathRecord, "COD1A", GetValue(values, "cod.immediate"));
@@ -526,6 +532,15 @@ namespace VRDR.HTTP
                     deathRecord.MaritalStatus = mar;
                     break;
             }
+
+            // TODO: Add support for placeOfDeath.placeOfDeath.option
+            // Options: "Dead on arrival at hospital", "Death in home", "Death in hospice", "Death in hospital",
+            // "Death in hospital-based emergency department or outpatient department",
+            // "Death in nursing home or long term care facility", "Unknown", "Other"
+
+            // Idea: add helpers to DeathRecord.cs with "Code" suffixes that take a string code and 1) raise an error
+            // if it's not a valid code and 2) automatically assign the system and display; implement with a helper
+            // function that takes a hash of codes to system/display
 
             if (GetValue(values, "sex.sex") == "Male")
             {

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -111,8 +111,46 @@ namespace VRDR.HTTP
                     values["decedentName.middleName"] = record.GivenNames[1];
                 }
             }
-
             SetStringValueDictionary(values, "decedentName.lastName", record.FamilyName);
+
+            if (record.SpouseGivenNames != null)
+            {
+                if (record.SpouseGivenNames.Count() > 0)
+                {
+                    values["spouseName.firstName"] = record.SpouseGivenNames[0];
+                }
+                if (record.SpouseGivenNames.Count() > 1)
+                {
+                    values["spouseName.middleName"] = record.SpouseGivenNames[1];
+                }
+            }
+            SetStringValueDictionary(values, "spouseName.lastName", record.SpouseFamilyName);
+
+            if (record.FatherGivenNames != null)
+            {
+                if (record.FatherGivenNames.Count() > 0)
+                {
+                    values["fatherName.firstName"] = record.FatherGivenNames[0];
+                }
+                if (record.FatherGivenNames.Count() > 1)
+                {
+                    values["fatherName.middleName"] = record.FatherGivenNames[1];
+                }
+            }
+            SetStringValueDictionary(values, "fatherName.lastName", record.FatherFamilyName);
+
+            if (record.MotherGivenNames != null)
+            {
+                if (record.MotherGivenNames.Count() > 0)
+                {
+                    values["motherName.firstName"] = record.MotherGivenNames[0];
+                }
+                if (record.MotherGivenNames.Count() > 1)
+                {
+                    values["motherName.middleName"] = record.MotherGivenNames[1];
+                }
+            }
+            SetStringValueDictionary(values, "motherName.lastName", record.MotherMaidenName);
 
             if (record.CertifierGivenNames != null)
             {
@@ -125,7 +163,6 @@ namespace VRDR.HTTP
                     values["personCompletingCauseOfDeathName.middleName"] = record.CertifierGivenNames[1];
                 }
             }
-
             SetStringValueDictionary(values, "personCompletingCauseOfDeathName.lastName", record.CertifierFamilyName);
 
             SetStringValueDictionary(values, "detailsOfInjury.detailsOfInjury", record.InjuryLocationDescription);
@@ -160,8 +197,6 @@ namespace VRDR.HTTP
                         break;
                 }
             }
-
-            SetStringValueDictionary(values, "motherName.lastName", record.MotherMaidenName);
 
             if (record.MannerOfDeathType != null && record.MannerOfDeathType.ContainsKey("code"))
             {
@@ -212,6 +247,8 @@ namespace VRDR.HTTP
                         break;
                 }
             }
+
+            SetStringValueDictionary(values, "usualOccupation.usualOccupation", record.UsualOccupation);
 
             if (record.BirthSex != null)
             {
@@ -345,30 +382,30 @@ namespace VRDR.HTTP
             SetStringValueDeathRecordDictionary(deathRecord, "DispositionLocationAddress", "addressState", GetValue(values, "placeOfDisposition.state"));
             SetStringValueDeathRecordDictionary(deathRecord, "DispositionLocationAddress", "addressCountry", GetValue(values, "placeOfDisposition.country"));
 
-            List<string> names = new List<string>();
-            if (!String.IsNullOrWhiteSpace(GetValue(values, "decedentName.firstName")))
-            {
-                names.Add(GetValue(values, "decedentName.firstName"));
-            }
-            if (!String.IsNullOrWhiteSpace(GetValue(values, "decedentName.middleName")))
-            {
-                names.Add(GetValue(values, "decedentName.middleName"));
-            }
-            deathRecord.GivenNames = names.ToArray();
-            SetStringValueDeathRecordString(deathRecord, "FamilyName", GetValue(values, "decedentName.lastName"));
+            SetNameValuesDeathRecordName(deathRecord, "GivenNames", "FamilyName",
+                                         GetValue(values, "decedentName.firstName"),
+                                         GetValue(values, "decedentName.middleName"),
+                                         GetValue(values, "decedentName.lastName"));
 
-            List<string> cnames = new List<string>();
-            if (!String.IsNullOrWhiteSpace(GetValue(values, "personCompletingCauseOfDeathName.firstName")))
-            {
-                cnames.Add(GetValue(values, "personCompletingCauseOfDeathName.firstName"));
-            }
-            if (!String.IsNullOrWhiteSpace(GetValue(values, "personCompletingCauseOfDeathName.middleName")))
-            {
-                cnames.Add(GetValue(values, "personCompletingCauseOfDeathName.middleName"));
-            }
-            deathRecord.CertifierGivenNames = cnames.ToArray();
+            SetNameValuesDeathRecordName(deathRecord, "SpouseGivenNames", "SpouseFamilyName",
+                                         GetValue(values, "spouseName.firstName"),
+                                         GetValue(values, "spouseName.middleName"),
+                                         GetValue(values, "spouseName.lastName"));
 
-            SetStringValueDeathRecordString(deathRecord, "CertifierFamilyName", GetValue(values, "personCompletingCauseOfDeathName.lastName"));
+            SetNameValuesDeathRecordName(deathRecord, "FatherGivenNames", "FatherFamilyName",
+                                         GetValue(values, "fatherName.firstName"),
+                                         GetValue(values, "fatherName.middleName"),
+                                         GetValue(values, "fatherName.lastName"));
+
+            SetNameValuesDeathRecordName(deathRecord, "MotherGivenNames", "MotherMaidenName",
+                                         GetValue(values, "motherName.firstName"),
+                                         GetValue(values, "motherName.middleName"),
+                                         GetValue(values, "motherName.lastName"));
+
+            SetNameValuesDeathRecordName(deathRecord, "CertifierGivenNames", "CertifierFamilyName",
+                                         GetValue(values, "personCompletingCauseOfDeathName.firstName"),
+                                         GetValue(values, "personCompletingCauseOfDeathName.middleName"),
+                                         GetValue(values, "personCompletingCauseOfDeathName.lastName"));
 
             SetStringValueDeathRecordString(deathRecord, "InjuryLocationDescription", GetValue(values, "detailsOfInjury.detailsOfInjury"));
 
@@ -438,8 +475,6 @@ namespace VRDR.HTTP
                     deathRecord.EducationLevel = edu;
                     break;
             }
-
-            SetStringValueDeathRecordString(deathRecord, "MotherMaidenName", GetValue(values, "motherName.lastName"));
 
             switch (GetValue(values, "mannerOfDeath.mannerOfDeath"))
             {
@@ -532,6 +567,8 @@ namespace VRDR.HTTP
                     deathRecord.MaritalStatus = mar;
                     break;
             }
+
+            SetStringValueDeathRecordString(deathRecord, "UsualOccupation", GetValue(values, "usualOccupation.usualOccupation"));
 
             // TODO: Add support for placeOfDeath.placeOfDeath.option
             // Options: "Dead on arrival at hospital", "Death in home", "Death in hospice", "Death in hospital",
@@ -629,7 +666,7 @@ namespace VRDR.HTTP
             prop.SetValue(deathRecord, value, null);
         }
 
-        /// <summary>Set a String value on a DeathRecord.</summary>
+        /// <summary>Set a String value on a DeathRecord within a dictionary.</summary>
         private static void SetStringValueDeathRecordDictionary(DeathRecord deathRecord, string property, string key, string value)
         {
             if (String.IsNullOrWhiteSpace(value))
@@ -701,6 +738,24 @@ namespace VRDR.HTTP
             Type type = deathRecord.GetType();
             PropertyInfo prop = type.GetProperty(property);
             prop.SetValue(deathRecord, coding);
+        }
+
+        /// <summary>Set a name value on a DeathRecord.</summary>
+        private static void SetNameValuesDeathRecordName(DeathRecord deathRecord, string givenNamesField, string familyNameField, string firstName, string middleName, string lastName)
+        {
+            List<string> names = new List<string>();
+            if (!String.IsNullOrWhiteSpace(firstName))
+            {
+                names.Add(firstName);
+            }
+            if (!String.IsNullOrWhiteSpace(middleName))
+            {
+                names.Add(middleName);
+            }
+            Type type = deathRecord.GetType();
+            PropertyInfo givenNames = type.GetProperty(givenNamesField);
+            givenNames.SetValue(deathRecord, names.ToArray());
+            SetStringValueDeathRecordString(deathRecord, familyNameField, lastName);
         }
 
         /// <summary>Set a value in a Dictionary, but only if that value is not null or whitespace.</summary>

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -21,8 +21,8 @@ namespace VRDR.HTTP
         {
             Dictionary<string, string> values = new Dictionary<string, string>();
 
-            SetStringValueDictionary(values, "certificateNumber", record.Identifier);
-            SetStringValueDictionary(values, "deathLocationJurisdiction", record.DeathLocationJurisdiction);
+            SetStringValueDictionary(values, "certificateNumber.certificateNumber", record.Identifier);
+            SetStringValueDictionary(values, "deathLocationJurisdiction.deathLocationJurisdiction", record.DeathLocationJurisdiction);
 
             SetYesNoValueDictionary(values, "armedForcesService.armedForcesService", record, "MilitaryService");
             SetYesNoValueDictionary(values, "autopsyPerformed.autopsyPerformed", record, "AutopsyPerformedIndicator");
@@ -325,8 +325,8 @@ namespace VRDR.HTTP
             // Start building the record
             DeathRecord deathRecord = new DeathRecord();
 
-            SetStringValueDeathRecordString(deathRecord, "Identifier", GetValue(values, "certificateNumber"));
-            SetStringValueDeathRecordString(deathRecord, "DeathLocationJurisdiction", GetValue(values, "deathLocationJurisdiction"));
+            SetStringValueDeathRecordString(deathRecord, "Identifier", GetValue(values, "certificateNumber.certificateNumber"));
+            SetStringValueDeathRecordString(deathRecord, "DeathLocationJurisdiction", GetValue(values, "deathLocationJurisdiction.deathLocationJurisdiction"));
 
             SetYesNoValueDeathRecordBoolean(deathRecord, "MilitaryServiceBoolean", GetValue(values, "armedForcesService.armedForcesService"));
             SetYesNoValueDeathRecordBoolean(deathRecord, "AutopsyPerformedIndicatorBoolean", GetValue(values, "autopsyPerformed.autopsyPerformed"));

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>VRDR.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -1,0 +1,897 @@
+using VRDR;
+using System;
+using System.Collections.Generic;
+
+namespace VRDR
+{
+    /// <summary>vrdr-dotnet versions of connectathon records.</summary>
+    public class Connectathon
+    {
+        public static string fhirVersion = "R4";    // used to generate files
+        public Connectathon() { }
+
+        public static DeathRecord FromId(int id, int? certificateNumber = null, string state = null)
+        {
+            DeathRecord record = null;
+            switch (id)
+            {
+                case 1:
+                    record = JanetPage();
+                    break;
+                case 2:
+                    record = MadelynPatel();
+                    break;
+                case 3:
+                    record = VivienneLeeWright();
+                    break;
+                case 4:
+                    record = JavierLuisPerez(partialRecord: false);
+                    break;
+                case 5:
+                    record = JavierLuisPerez(partialRecord: true);
+                    break;
+            }
+
+            if (record != null && state != null)
+            {
+                record.DeathLocationJurisdiction = state;
+            }
+
+            if (record != null && certificateNumber != null)
+            {
+                record.Identifier = certificateNumber.ToString();
+            }
+
+            return record;
+        }
+
+        public static DeathRecord JanetPage()
+        {
+            DeathRecord record = new DeathRecord();
+
+            record.Identifier = "000001";
+
+            record.RegisteredTime = "2022-01-09";
+
+            record.GivenNames = new string[] { "Janet" };
+
+            record.FamilyName = "Page";
+
+            record.Race = new Tuple<string, string>[] { Tuple.Create("White", "2106-3") };
+
+            record.Ethnicity = new Tuple<string, string>[] { Tuple.Create("Puerto Rican", "2180-8") };
+
+            record.BirthSex = "F";
+
+            record.SSN = "555111234";
+
+            Dictionary<string, string> age = new Dictionary<string, string>();
+            age.Add("value", "72");
+            age.Add("unit", "a");
+            record.AgeAtDeath = age;
+
+            record.DateOfBirth = "1949-01-15";
+
+            Dictionary<string, string> addressB = new Dictionary<string, string>();
+            addressB.Add("addressCity", "Atlanta");
+            addressB.Add("addressState", "GA");
+            addressB.Add("addressCountry", "US");
+            record.PlaceOfBirth = addressB;
+
+            record.BirthRecordId = "515151";
+            record.BirthRecordState = new Dictionary<string, string>() {
+                { "code", "US-GA" },
+                { "system", CodeSystems.ISO_3166_2 },
+                { "display", "US-GA" } };
+
+            record.MotherGivenNames = new String[] { "Linda" };
+            record.MotherMaidenName = "Shay";
+
+            record.FatherFamilyName = "Page";
+
+            Dictionary<string, string> code = new Dictionary<string, string>();
+            code.Add("code", "D");
+            code.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
+            code.Add("display", "Divorced");
+            record.MaritalStatus = code;
+
+            Dictionary<string, string> addressR = new Dictionary<string, string>();
+            addressR.Add("addressLine1", "25 Hope Street");
+            addressR.Add("addressCity", "Atlanta");
+            addressR.Add("addressCounty", "Fulton");
+            addressR.Add("addressState", "GA");
+            addressR.Add("addressCountry", "US");
+            record.Residence = addressR;
+            record.ResidenceWithinCityLimitsBoolean = true;
+
+            Dictionary<string, string> elevel = new Dictionary<string, string>();
+            elevel.Add("code", "PHC1455");
+            elevel.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+            elevel.Add("display", "Doctorate Degree or Professional Degree");
+            elevel.Add("text", "Doctorate");
+            record.EducationLevel = elevel;
+
+            Dictionary<string, string> uocc = new Dictionary<string, string>();
+            uocc.Add("code", "1010");
+            uocc.Add("system", VRDR.CodeSystems.PH_Occupation_CDC_Census2010);
+            uocc.Add("display", "Computer Programmers");
+            uocc.Add("text", "Programmer");
+            record.UsualOccupationCode = uocc;
+
+            Dictionary<string, string> uind = new Dictionary<string, string>();
+            uind.Add("code", "6990");
+            uind.Add("system", VRDR.CodeSystems.PH_Industry_CDC_Census2010);
+            uind.Add("display", "Insurance carriers and related activities");
+            uind.Add("text", "Health Insurance");
+            record.UsualIndustryCode = uind;
+
+            record.DateOfDeath = "2022-01-08T05:30:00";
+
+            Dictionary<string, string> deathLoc = new Dictionary<string, string>();
+            deathLoc.Add("addressCity", "Atlanta");
+            deathLoc.Add("addressCountry", "US");
+            record.DeathLocationAddress = deathLoc;
+
+            record.DeathLocationName = "Pecan Grove Nursing Home";
+            Dictionary<string, string> locType = new Dictionary<string, string>();
+            locType.Add("code", "450381000124100");
+            locType.Add("system", VRDR.CodeSystems.SCT);
+            locType.Add("display", "Nursing Home");
+            record.DeathLocationType = locType;
+            record.DeathLocationDescription = "nursing home";
+            record.DeathLocationJurisdiction = "GA";
+
+            Dictionary<string, string> role = new Dictionary<string, string>();
+            role.Add("code", "434641000124105");
+            role.Add("system", VRDR.CodeSystems.SCT);
+            role.Add("display", "Death certification and verification by physician");
+            record.CertificationRole = role;
+
+            record.CertifierGivenNames = new string[] { "Sam" };
+            record.CertifierFamilyName = "Jones";
+
+            Dictionary<string, string> address = new Dictionary<string, string>();
+            address.Add("addressLine1", "1 Main Street");
+            address.Add("addressCity", "Atlanta");
+            address.Add("addressState", "GA");
+            address.Add("addressZip", "30303");
+            address.Add("addressCountry", "US");
+            record.CertifierAddress = address;
+
+            record.CertifiedTime = "2022-01-08";
+
+            record.DateOfDeathPronouncement = "2022-01-08T05:30:00";
+            record.PronouncerGivenNames = new string[] { "Sam" };
+            record.PronouncerFamilyName = "Jones";
+
+            record.COD1A = "Congestive heart failure";
+            record.INTERVAL1A = "1 hour";
+
+            record.COD1B = "breast cancer";
+            record.INTERVAL1B = "20 years";
+
+            record.ExaminerContactedBoolean = false;
+
+            Dictionary<string, string> manner = new Dictionary<string, string>();
+            manner.Add("code", "38605008");
+            manner.Add("system", VRDR.CodeSystems.SCT);
+            manner.Add("display", "Natural death");
+            record.MannerOfDeathType = manner;
+
+            record.AutopsyPerformedIndicatorBoolean = false;
+
+            Dictionary<string, string> fdaddress = new Dictionary<string, string>();
+            fdaddress.Add("addressLine1", "15 Pecan Street");
+            fdaddress.Add("addressCity", "Atlanta");
+            fdaddress.Add("addressState", "GA");
+            fdaddress.Add("addressZip", " 30301");
+            fdaddress.Add("addressCountry", "US");
+            record.FuneralHomeAddress = fdaddress;
+            record.FuneralHomeName = "Pecan Street Funeral Home and Crematory";
+            // record.FuneralDirectorPhone = "000-000-0000";    // unknown property?????
+
+            Dictionary<string, string> morticianId = new Dictionary<string, string>();
+            morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+            morticianId.Add("value", "111111AB");
+            record.MorticianIdentifier = morticianId;
+
+            record.MorticianGivenNames = new string[] { "Maureen", "P" };
+            record.MorticianFamilyName = "Winston";
+
+            Dictionary<string, string> dladdress = new Dictionary<string, string>();
+            dladdress.Add("addressLine1", "15 Pecan Street");
+            dladdress.Add("addressCity", "Atlanta");
+            dladdress.Add("addressState", "GA");
+            dladdress.Add("addressZip", " 30301");
+            dladdress.Add("addressCountry", "US");
+            record.DispositionLocationAddress = dladdress;
+            record.DispositionLocationName = "Pecan Street Funeral Home and Crematory";
+
+            Dictionary<string, string> dmethod = new Dictionary<string, string>();
+            dmethod.Add("code", "449961000124104");
+            dmethod.Add("system", VRDR.CodeSystems.SCT);
+            dmethod.Add("display", "Patient status determination, deceased and cremated");
+            record.DecedentDispositionMethod = dmethod;
+
+            Dictionary<string, string> pregnancyStatus = new Dictionary<string, string>();
+            pregnancyStatus.Add("code", "NA");
+            pregnancyStatus.Add("system", CodeSystems.PH_NullFlavor_HL7_V3);
+            pregnancyStatus.Add("display", "not applicable");
+            record.PregnancyStatus = pregnancyStatus;
+
+            record.TobaccoUse = new Dictionary<string, string>() {
+                { "code", "UNK" },
+                { "system", CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "display", "unknown" } };
+
+            record.MilitaryService = new Dictionary<string, string>() {
+                { "code", "UNK" },
+                { "system", CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "display", "unknown" } };
+
+            // uncomment to generate file
+            // string filename = "1_janet_page_cancer_" + fhirVersion + ".xml";
+            // WriteRecordAsXml(record, filename);
+
+            return record;
+        }
+
+        public static DeathRecord MadelynPatel()
+        {
+            DeathRecord record = new DeathRecord();
+
+            record.Identifier = "000002";
+
+            record.RegisteredTime = "2022-01-11";
+
+            record.GivenNames = new string[] { "Madelyn" };
+
+            record.FamilyName = "Patel";
+
+            record.Race = new Tuple<string, string>[] { Tuple.Create("Asian Indian", "2029-7") };
+
+            record.Ethnicity = new Tuple<string, string>[] { Tuple.Create("Not Hispanic or Latino", "2186-5") };
+
+            record.BirthSex = "F";
+
+            record.SSN = "187654321";
+
+            Dictionary<string, string> age = new Dictionary<string, string>();
+            age.Add("value", "43");
+            age.Add("unit", "a");
+            record.AgeAtDeath = age;
+
+            record.DateOfBirth = "1978-03-12";
+
+            Dictionary<string, string> addressB = new Dictionary<string, string>();
+            addressB.Add("addressCity", "Roanoke");
+            addressB.Add("addressState", "VA");
+            addressB.Add("addressCountry", "US");
+            record.PlaceOfBirth = addressB;
+
+            record.BirthRecordId = "616161";
+            record.BirthRecordState = new Dictionary<string, string>() {
+                { "code", "US-VA" },
+                { "system", CodeSystems.ISO_3166_2 },
+                { "display", "US-VA" } };
+            record.MotherGivenNames = new String[] { "Jennifer" };
+            record.MotherMaidenName = "May";
+
+            record.FatherFamilyName = "Patel";
+
+            Dictionary<string, string> code = new Dictionary<string, string>();
+            code.Add("code", "S");
+            code.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
+            code.Add("display", "Never Married");
+            record.MaritalStatus = code;
+
+            Dictionary<string, string> addressR = new Dictionary<string, string>();
+            addressR.Add("addressLine1", "5590 Lockwood Drive");
+            addressR.Add("addressCity", "Danville");
+            addressR.Add("addressState", "NS");
+            addressR.Add("addressCountry", "CA");
+            record.Residence = addressR;
+            record.ResidenceWithinCityLimitsBoolean = null;
+
+            Dictionary<string, string> elevel = new Dictionary<string, string>();
+            elevel.Add("code", "PHC1452");
+            elevel.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+            elevel.Add("display", "Associate Degree");
+            record.EducationLevel = elevel;
+
+            Dictionary<string, string> uocc = new Dictionary<string, string>();
+            uocc.Add("code", "4030");
+            uocc.Add("system", VRDR.CodeSystems.PH_Occupation_CDC_Census2010);
+            uocc.Add("display", "Food preparation workers");
+            uocc.Add("text", "Food Prep");
+            record.UsualOccupationCode = uocc;
+
+            Dictionary<string, string> uind = new Dictionary<string, string>();
+            uind.Add("code", "8680");
+            uind.Add("system", VRDR.CodeSystems.PH_Industry_CDC_Census2010);
+            uind.Add("display", "Restaurants and other food services");
+            uind.Add("text", "Fast food");
+            record.UsualIndustryCode = uind;
+
+            record.DateOfDeath = "2022-01-05T14:04:00";
+
+            Dictionary<string, string> deathLoc = new Dictionary<string, string>();
+            deathLoc.Add("addressCity", "Danville");
+            deathLoc.Add("addressCountry", "US");
+            record.DeathLocationAddress = deathLoc;
+            record.DeathLocationJurisdiction = "VA";
+
+            record.DeathLocationName = "home";
+            Dictionary<string, string> locType = new Dictionary<string, string>();
+            locType.Add("code", "440081000124100");
+            locType.Add("system", VRDR.CodeSystems.SCT);
+            locType.Add("display", "Descedent's Home");
+            record.DeathLocationType = locType;
+            record.DeathLocationDescription = "home";
+
+            Dictionary<string, string> role = new Dictionary<string, string>();
+            role.Add("code", "440051000124108");
+            role.Add("system", VRDR.CodeSystems.SCT);
+            role.Add("display", "Medical Examiner");
+            record.CertificationRole = role;
+
+            record.CertifierGivenNames = new string[] { "Constance" };
+            record.CertifierFamilyName = "Green";
+
+            Dictionary<string, string> address = new Dictionary<string, string>();
+            address.Add("addressLine1", "123 12th St.");
+            address.Add("addressCity", "Danville");
+            address.Add("addressState", "VA");
+            address.Add("addressCountry", "US");
+            record.CertifierAddress = address;
+
+            record.CertifiedTime = "2022-01-05";
+
+            record.DateOfDeathPronouncement = "2022-01-05T15:30:00";
+            record.PronouncerGivenNames = new string[] { "Adam" };
+            record.PronouncerFamilyName = "Revel";
+
+            record.COD1A = "Cocaine toxicity";
+            record.INTERVAL1A = "1 hour";
+
+            record.ContributingConditions = "hypertensive heart disease";
+
+            record.ExaminerContactedBoolean = true;
+
+            Dictionary<string, string> manner = new Dictionary<string, string>();
+            manner.Add("code", "7878000");
+            manner.Add("system", VRDR.CodeSystems.SCT);
+            manner.Add("display", "Accidental death");
+            record.MannerOfDeathType = manner;
+
+            record.InjuryDate = "2022-01-05T13:00:00";
+            record.InjuryAtWorkBoolean = false;
+
+            // @check
+            Dictionary<string, string> injuryPlace = new Dictionary<string, string>();
+            injuryPlace.Add("code", "0");
+            injuryPlace.Add("system", VRDR.CodeSystems.PH_PlaceOfOccurrence_ICD_10_WHO);
+            injuryPlace.Add("display", "Home");
+            record.InjuryPlace = injuryPlace;
+
+            record.InjuryDescription = "drug toxicity";
+
+            record.InjuryLocationDescription = "5590 Lockwood Drive 20621 US";
+
+            record.AutopsyPerformedIndicatorBoolean = true;
+
+            record.AutopsyResultsAvailableBoolean = true;
+
+            Dictionary<string, string> fdaddress = new Dictionary<string, string>();
+            fdaddress.Add("addressLine1", "Lilly Lane");
+            fdaddress.Add("addressCity", "Danville");
+            fdaddress.Add("addressState", "VA");
+            fdaddress.Add("addressZip", " 24541");
+            fdaddress.Add("addressCountry", "US");
+            record.FuneralHomeAddress = fdaddress;
+            record.FuneralHomeName = "Rosewood Funeral Home";
+
+            Dictionary<string, string> morticianId = new Dictionary<string, string>();
+            morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+            morticianId.Add("value", "212222AB");
+            record.MorticianIdentifier = morticianId;
+
+            record.MorticianGivenNames = new string[] { "Ronald", "Q" };
+            record.MorticianFamilyName = "Smith";
+
+            Dictionary<string, string> dladdress = new Dictionary<string, string>();
+            dladdress.Add("addressLine1", "303 Rosewood Ave");
+            dladdress.Add("addressCity", "Danville");
+            dladdress.Add("addressState", "VA");
+            dladdress.Add("addressZip", " 24541");
+            dladdress.Add("addressCountry", "US");
+            record.DispositionLocationAddress = dladdress;
+            record.DispositionLocationName = "Rosewood Cemetary";
+
+            Dictionary<string, string> dmethod = new Dictionary<string, string>();
+            dmethod.Add("code", "449971000124106");
+            dmethod.Add("system", VRDR.CodeSystems.SCT);
+            dmethod.Add("display", "Patient status determination, deceased and buried");
+            record.DecedentDispositionMethod = dmethod;
+
+            Dictionary<string, string> pregnancyStatus = new Dictionary<string, string>();
+            pregnancyStatus.Add("code", "PHC1260");
+            pregnancyStatus.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+            pregnancyStatus.Add("display", "Not pregnant within the past year");
+            record.PregnancyStatus = pregnancyStatus;
+            record.TransportationEventBoolean = false;
+            record.TobaccoUse = new Dictionary<string, string>() {
+                { "code", "373067005" },
+                { "system", VRDR.CodeSystems.SCT },
+                { "display", "No" } };
+            record.MilitaryService = new Dictionary<string, string>() {
+                { "code", "Y" },
+                { "system", CodeSystems.PH_YesNo_HL7_2x },
+                { "display", "Yes" } };
+            // uncomment to generate file
+            // string filename = "2_madelyn_patel_opiod_" + fhirVersion + ".xml";
+            // WriteRecordAsXml(record, filename);
+
+            return record;
+        }
+
+        public static DeathRecord VivienneLeeWright()
+        {
+            DeathRecord record = new DeathRecord();
+
+            record.Identifier = "000003";
+
+            record.RegisteredTime = "2022-01-14";
+
+            record.GivenNames = new string[] { "Vivienne", "L" };
+
+            record.FamilyName = "Wright";
+
+            record.Race = new Tuple<string, string>[] { Tuple.Create("White", "2106-3"), Tuple.Create("American Indian or Alaska Native", "1002-5") };
+
+            record.Ethnicity = new Tuple<string, string>[] { Tuple.Create("Hispanic or Latino", "2135-2"), Tuple.Create("Salvadoran", "2161-8")};
+
+            record.BirthSex = "F";
+
+            record.SSN = "789456123";
+
+            Dictionary<string, string> age = new Dictionary<string, string>();
+            age.Add("value", "19");
+            age.Add("unit", "a");
+            record.AgeAtDeath = age;
+
+            record.DateOfBirth = "2001-04-11";
+
+            Dictionary<string, string> addressB = new Dictionary<string, string>();
+            addressB.Add("addressCity", "Hinsdale");
+            addressB.Add("addressState", "IL");
+            addressB.Add("addressCountry", "US");
+            record.PlaceOfBirth = addressB;
+
+            record.BirthRecordId = "717171";
+            record.BirthRecordState = new Dictionary<string, string>() {
+                { "code", "US-IL" },
+                { "system", CodeSystems.ISO_3166_2 },
+                { "display", "US-IL" } };
+            record.MotherGivenNames = new String[] { "Martha" };
+            record.MotherMaidenName = "White";
+
+            record.FatherFamilyName = "Wright";
+
+            Dictionary<string, string> code = new Dictionary<string, string>();
+            code.Add("code", "M");
+            code.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
+            code.Add("display", "Married");
+            record.MaritalStatus = code;
+
+            Dictionary<string, string> addressR = new Dictionary<string, string>();
+            addressR.Add("addressLine1", "101 Liberty Lane");
+            addressR.Add("addressCity", "Harrisburg ");
+            addressR.Add("addressState", "PA");
+            addressR.Add("addressCountry", "US");
+            record.Residence = addressR;
+            record.ResidenceWithinCityLimitsBoolean = true;
+
+            Dictionary<string, string> elevel = new Dictionary<string, string>();
+            elevel.Add("code", "PHC1449");
+            elevel.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+            elevel.Add("display", "9th through 12th grade; no diploma");
+            elevel.Add("text", "11th grade");
+            record.EducationLevel = elevel;
+
+            Dictionary<string, string> uocc = new Dictionary<string, string>();
+            uocc.Add("code", "5700");
+            uocc.Add("system", VRDR.CodeSystems.PH_Occupation_CDC_Census2010);
+            uocc.Add("display", "Secretaries and administrative assistants");
+            uocc.Add("text", "secretary");
+            record.UsualOccupationCode = uocc;
+
+            Dictionary<string, string> uind = new Dictionary<string, string>();
+            uind.Add("code", "9390");
+            uind.Add("system", VRDR.CodeSystems.PH_Industry_CDC_Census2010);
+            uind.Add("display", "Other general government and support");
+            uind.Add("text", "State agency");
+            record.UsualIndustryCode = uind;
+
+            record.DateOfDeath = "2022-01-13T21:00:00";
+
+            Dictionary<string, string> deathLoc = new Dictionary<string, string>();
+            deathLoc.Add("addressCity", "Lancaster");
+            deathLoc.Add("addressCounty", "Lancaster");
+            deathLoc.Add("addressCountry", "US");
+            record.DeathLocationAddress = deathLoc;
+            record.DeathLocationJurisdiction = "PA";
+
+            record.DeathLocationName = "Mt. Olive Hospital";
+            Dictionary<string, string> locType = new Dictionary<string, string>();
+            locType.Add("code", "450391000124102");
+            locType.Add("system", VRDR.CodeSystems.SCT);
+            locType.Add("display", "Death in emergency Room/Outpatient");
+            record.DeathLocationType = locType;
+            record.DeathLocationDescription = "Emergency room";
+
+            Dictionary<string, string> role = new Dictionary<string, string>();
+            role.Add("code", "310193003");
+            role.Add("system", VRDR.CodeSystems.SCT);
+            role.Add("display", "Coroner");
+            record.CertificationRole = role;
+
+            record.CertifierGivenNames = new string[] { "Jim" };
+            record.CertifierFamilyName = "Black";
+
+            Dictionary<string, string> address = new Dictionary<string, string>();
+            address.Add("addressLine1", "44 South Street");
+            address.Add("addressCity", "Bird in Hand");
+            address.Add("addressState", "PA");
+            address.Add("addressZip", "17505");
+            address.Add("addressCountry", "US");
+            record.CertifierAddress = address;
+
+            record.CertifiedTime = "2022-01-13";
+
+            record.DateOfDeathPronouncement = "2022-01-13T21:00:00";
+            record.PronouncerGivenNames = new string[] { "Jim" };
+            record.PronouncerFamilyName = "Black";
+
+            record.COD1A = "Cardiopulmonary arrest";
+            record.INTERVAL1A = "4 hours";
+
+            record.COD1B = "Eclampsia";
+            record.INTERVAL1B = "3 months";
+
+            record.ExaminerContactedBoolean = true;
+
+            Dictionary<string, string> manner = new Dictionary<string, string>();
+            manner.Add("code", "38605008");
+            manner.Add("system", VRDR.CodeSystems.SCT);
+            manner.Add("display", "Natural death");
+            record.MannerOfDeathType = manner;
+
+            record.AutopsyPerformedIndicatorBoolean = true;
+            record.AutopsyResultsAvailableBoolean = true;
+
+            Dictionary<string, string> morticianId = new Dictionary<string, string>();
+            morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+            morticianId.Add("value", "414444AB");
+            record.MorticianIdentifier = morticianId;
+
+            record.MorticianGivenNames = new string[] { "Joseph", "M" };
+            record.MorticianFamilyName = "Clark";
+
+            Dictionary<string, string> fdaddress = new Dictionary<string, string>();
+            fdaddress.Add("addressLine1", "211 High Street");
+            fdaddress.Add("addressCity", "Lancaster");
+            fdaddress.Add("addressState", "PA");
+            fdaddress.Add("addressZip", " 17573");
+            fdaddress.Add("addressCountry", "US");
+            record.FuneralHomeAddress = fdaddress;
+            record.FuneralHomeName = "Lancaster Funeral Home and Crematory";
+
+            Dictionary<string, string> dladdress = new Dictionary<string, string>();
+            dladdress.Add("addressLine1", "211 High Street");
+            dladdress.Add("addressCity", "Lancaster");
+            dladdress.Add("addressState", "PA");
+            dladdress.Add("addressZip", " 17573");
+            dladdress.Add("addressCountry", "US");
+            record.DispositionLocationAddress = dladdress;
+            record.DispositionLocationName = "Lancaster Funeral Home and Crematory";
+
+            Dictionary<string, string> dmethod = new Dictionary<string, string>();
+            dmethod.Add("code", "449961000124104");
+            dmethod.Add("system", VRDR.CodeSystems.SCT);
+            dmethod.Add("display", "Patient status determination, deceased and cremated");
+            record.DecedentDispositionMethod = dmethod;
+
+            Dictionary<string, string> pregnancyStatus = new Dictionary<string, string>();
+            pregnancyStatus.Add("code", "PHC1261");
+            pregnancyStatus.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+            pregnancyStatus.Add("display", "Pregnant at the time of death");
+            record.PregnancyStatus = pregnancyStatus;
+
+            record.TobaccoUse = new Dictionary<string, string>() {
+                { "code", "373066001" },
+                { "system", VRDR.CodeSystems.SCT },
+                { "display", "Yes" } };
+           record.MilitaryService = new Dictionary<string, string>() {
+                { "code", "N" },
+                { "system", CodeSystems.PH_YesNo_HL7_2x },
+                { "display", "No" } };
+
+            // uncomment to generate file
+            // string filename = "3_vivienne_wright_pregnant_" + fhirVersion + ".xml";
+            // WriteRecordAsXml(record, filename);
+
+            return record;
+        }
+
+        /** this can be used 2 ways, with partialRecord set to
+         *                                  false for a full record
+         *                               or true for a partial record
+         */
+        public static DeathRecord JavierLuisPerez(bool partialRecord = false)
+        {
+            bool fullRecord = !partialRecord;
+            DeathRecord record = new DeathRecord();
+
+            record.Identifier = "000004";
+
+            record.RegisteredTime = "2022-01-15";
+
+            record.GivenNames = new string[] { "Javier", "Luis" };
+
+            record.FamilyName = "Perez";
+            record.Suffix = "Jr.";
+
+            record.Race = new Tuple<string, string>[] { Tuple.Create("White", "2106-3"), Tuple.Create("Black", "2054-5") };
+
+            record.Ethnicity = new Tuple<string, string>[] { Tuple.Create("Cuban", "2182-4") };
+
+            record.BirthSex = "M";
+
+            record.SSN = "456123789";
+
+            Dictionary<string, string> age = new Dictionary<string, string>();
+
+
+            if (fullRecord)
+            {
+                age.Add("value", "57");
+                age.Add("unit", "a");
+                record.AgeAtDeath = age;
+                record.DateOfBirth = "1964-02-24";
+
+                Dictionary<string, string> addressB = new Dictionary<string, string>();
+                addressB.Add("addressCountry", "US");
+                addressB.Add("addressState", "TX");
+                record.PlaceOfBirth = addressB;
+
+                record.BirthRecordId = "818181";
+                record.BirthRecordState = new Dictionary<string, string>() {
+                { "code", "US-TX" },
+                { "system", CodeSystems.ISO_3166_2 },
+                { "display", "US-TX" } };
+            }
+            else
+            {
+                Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "asked-unknown"), Tuple.Create("date-month", "02"), Tuple.Create("date-day", "24")};
+                record.DateOfBirthDatePartAbsent = datePart;
+                Dictionary<string, string> addressB = new Dictionary<string, string>();
+                addressB.Add("addressCountry", "AS");  // This is an abomination
+                addressB.Add("addressState", "");
+                record.PlaceOfBirth = addressB;
+                record.BirthRecordIdentifierDataAbsentBoolean = true;
+                record.AgeAtDeathDataAbsentBoolean = true;
+            }
+
+            if (fullRecord)
+            {
+                record.MotherGivenNames = new String[] { "Liliana" };
+                record.MotherMaidenName = "Jones";
+            }
+
+            record.FatherFamilyName = "Perez";
+
+            Dictionary<string, string> code = new Dictionary<string, string>();
+            code.Add("code", "M");
+            code.Add("system", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x);
+            code.Add("display", "Married");
+            record.MaritalStatus = code;
+
+            Dictionary<string, string> addressR = new Dictionary<string, string>();
+            if (fullRecord)
+            {
+                addressR.Add("addressLine1", "143 Taylor Street");
+                addressR.Add("addressCountry", "US");
+            }else{
+                addressR.Add("addressCountry", "ZZ");
+            }
+            addressR.Add("addressCity", "Annapolis");
+            addressR.Add("addressCounty", "Anne Arundel");
+            addressR.Add("addressState", "MD");
+
+            record.Residence = addressR;
+            record.ResidenceWithinCityLimitsBoolean = false;
+
+            Dictionary<string, string> elevel = new Dictionary<string, string>();
+            elevel.Add("code", "PHC1454");
+            elevel.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
+            elevel.Add("display", "Master's Degree");
+            record.EducationLevel = elevel;
+
+            Dictionary<string, string> uocc = new Dictionary<string, string>();
+            uocc.Add("code", "6230");
+            uocc.Add("system", VRDR.CodeSystems.PH_Occupation_CDC_Census2010);
+            uocc.Add("display", "carpenters");
+            uocc.Add("text", "carpenter");
+            record.UsualOccupationCode = uocc;
+
+            Dictionary<string, string> uind = new Dictionary<string, string>();
+            uind.Add("code", "0770");
+            uind.Add("system", VRDR.CodeSystems.PH_Industry_CDC_Census2010);
+            uind.Add("display", "Construction");    // actual text is "Construction (the cleaning of buildings and dwellings is incidental during construction and immediately after construction)"
+            uind.Add("text", "construction");
+            record.UsualIndustryCode = uind;
+
+            record.DateOfDeath = "2022-01-14T11:25:00";
+
+            record.DeathLocationName = "County Hospital";
+            Dictionary<string, string> locType = new Dictionary<string, string>();
+            locType.Add("code", "63238001");
+            locType.Add("system", VRDR.CodeSystems.SCT);
+            locType.Add("display", "Hospital Dead on Arrival");
+            record.DeathLocationType = locType;
+
+            record.DeathLocationDescription = "Dead On Arrival";
+            record.DeathLocationJurisdiction = "DE";
+
+            Dictionary<string, string> role = new Dictionary<string, string>();
+            role.Add("code", "434641000124105");
+            role.Add("system", VRDR.CodeSystems.SCT);
+            role.Add("display", "Death certification and verification by physician");
+            record.CertificationRole = role;
+
+            record.CertifierGivenNames = new string[] { "Hope" };
+            record.CertifierFamilyName = "Lost";
+
+            Dictionary<string, string> address = new Dictionary<string, string>();
+            address.Add("addressLine1", "RR1");
+            address.Add("addressCity", "Dover");
+            address.Add("addressState", "DE");
+            address.Add("addressCountry", "US");
+            record.CertifierAddress = address;
+
+            record.CertifiedTime = "2022-01-14";
+
+            record.DateOfDeathPronouncement = "2022-01-14T11:35:00";
+
+            if (fullRecord)
+            {
+                record.PronouncerGivenNames = new string[] { "Hope" };
+                record.PronouncerFamilyName = "Lost";
+            }
+
+            record.COD1A = "Blunt head trauma";
+            record.COD1B = "Automobile accident";
+            record.ExaminerContactedBoolean = null; // use null to set to unknown
+            if (fullRecord)
+            {
+                record.INTERVAL1A = "30 min";
+                record.INTERVAL1B = "30 min";
+                record.COD1C = "Epilepsy";
+                record.INTERVAL1C = "20 years";
+                record.ExaminerContactedBoolean = true;
+                record.InjuryLocationDescription = "15 Industrial Drive 19901 US";
+            }
+
+
+            Dictionary<string, string> manner = new Dictionary<string, string>();
+            manner.Add("code", "7878000");
+            manner.Add("system", VRDR.CodeSystems.SCT);
+            manner.Add("display", "Accidental death");
+            record.MannerOfDeathType = manner;
+
+            record.InjuryDate = "2022-01-14T11:15:00";
+            record.InjuryAtWorkBoolean = true;
+
+            Dictionary<string, string> injuryPlace = new Dictionary<string, string>();
+            injuryPlace.Add("code", "4");
+            injuryPlace.Add("system", VRDR.CodeSystems.PH_PlaceOfOccurrence_ICD_10_WHO);
+            injuryPlace.Add("display", "street");
+            record.InjuryPlace = injuryPlace;
+
+            record.InjuryDescription = "unrestrained ejected driver in rollover motor vehicle accident";
+
+
+
+            Dictionary<string, string> codeT = new Dictionary<string, string>();
+            codeT.Add("code", "236320001");
+            codeT.Add("system", VRDR.CodeSystems.SCT);
+            codeT.Add("display", "Vehicle driver");
+            record.TransportationRole = codeT;
+            record.TransportationEventBoolean = true;
+            record.AutopsyPerformedIndicatorBoolean = false;
+            record.AutopsyResultsAvailableBoolean = false;
+            if (fullRecord)
+            {
+                Dictionary<string, string> fdaddress = new Dictionary<string, string>();
+                fdaddress.Add("addressLine1", "15 Furnace Drive");
+                fdaddress.Add("addressCity", "San Antonio");
+                fdaddress.Add("addressState", "TX");
+                fdaddress.Add("addressZip", " 78201");
+                fdaddress.Add("addressCountry", "US");
+                record.FuneralHomeAddress = fdaddress;
+                record.FuneralHomeName = "River Funeral Home";
+
+                Dictionary<string, string> morticianId = new Dictionary<string, string>();
+                morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+                morticianId.Add("value", "313333AB");
+                record.MorticianIdentifier = morticianId;
+
+                record.MorticianGivenNames = new string[] { "Pedro", "A" };
+                record.MorticianFamilyName = "Jimenez";
+
+                Dictionary<string, string> dladdress = new Dictionary<string, string>();
+                dladdress.Add("addressLine1", "15 Furnace Drive");
+                dladdress.Add("addressCity", "San Antonio");
+                dladdress.Add("addressState", "TX");
+                dladdress.Add("addressZip", " 78201");
+                dladdress.Add("addressCountry", "US");
+                record.DispositionLocationAddress = dladdress;
+                record.DispositionLocationName = "River Cemetary";
+            }
+
+            Dictionary<string, string> dmethod = new Dictionary<string, string>();
+            dmethod.Add("code", "449941000124103");
+            dmethod.Add("system", VRDR.CodeSystems.SCT);
+            dmethod.Add("display", "Patient status determination, deceased and removed from state");
+            record.DecedentDispositionMethod = dmethod;
+
+            Dictionary<string, string> pregnancyStatus = new Dictionary<string, string>();
+            pregnancyStatus.Add("code", "NA");
+            pregnancyStatus.Add("system", CodeSystems.PH_NullFlavor_HL7_V3);
+            pregnancyStatus.Add("display", "not applicable");
+            record.PregnancyStatus = pregnancyStatus;
+
+            if (fullRecord)
+            {
+                record.TobaccoUse = new Dictionary<string, string>() {
+                    { "code", "373067005" },
+                    { "system", VRDR.CodeSystems.SCT },
+                    { "display", "No" } };
+            }
+            record.MilitaryService = new Dictionary<string, string>() {
+                { "code", "N" },
+                { "system", CodeSystems.PH_YesNo_HL7_2x },
+                { "display", "No" } };
+            // uncomment to generate file
+            // string filename = "";
+            // if (fullRecord)
+            // {
+            //     filename += "4_javier_perez_accident_full_" + fhirVersion + ".xml";
+            // }
+            // else
+            // {
+            //     filename += "5_javier_perez_accident_partial_" + fhirVersion + ".xml";
+            // }
+            // WriteRecordAsXml(record, filename);
+
+            return record;
+        }
+
+
+        // Writes record to a file named filename in a subdirectory of the current working directory
+        //  Note that you do this with docker, you will have to set a bind mount on the container
+        public static string WriteRecordAsXml(DeathRecord record, string filename)
+        {
+            string parentPath = System.IO.Directory.GetCurrentDirectory() + "/connectathon_files";
+            System.IO.Directory.CreateDirectory(parentPath);  // in case the directory does not exist
+            string fullPath = parentPath + "/" + filename;
+            Console.WriteLine("writing record to " + fullPath + " as XML");
+            string xml = record.ToXml();
+            System.IO.File.WriteAllText(@fullPath, xml);
+            // Console.WriteLine(xml);
+            return xml;
+        }
+
+    }
+}

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 
 namespace VRDR
 {
-    /// <summary>vrdr-dotnet versions of connectathon records.</summary>
+    /// <summary>Class <c>Connectathon</c> provides static methods for generating records used in Connectathon testing, used in Canary and in the CLI tool</summary>
     public class Connectathon
     {
-        public static string fhirVersion = "R4";    // used to generate files
-        public Connectathon() { }
-
+        /// <summary>Generate a DeathRecord from one of 5 pre-set records, providing an optional certificate number and state</summary>
         public static DeathRecord FromId(int id, int? certificateNumber = null, string state = null)
         {
             DeathRecord record = null;
@@ -44,6 +42,7 @@ namespace VRDR
             return record;
         }
 
+        /// <summary>Generate the Janet Page example record</summary>
         public static DeathRecord JanetPage()
         {
             DeathRecord record = new DeathRecord();
@@ -228,13 +227,10 @@ namespace VRDR
                 { "system", CodeSystems.PH_NullFlavor_HL7_V3 },
                 { "display", "unknown" } };
 
-            // uncomment to generate file
-            // string filename = "1_janet_page_cancer_" + fhirVersion + ".xml";
-            // WriteRecordAsXml(record, filename);
-
             return record;
         }
 
+        /// <summary>Generate the Madelyn Patel example record</summary>
         public static DeathRecord MadelynPatel()
         {
             DeathRecord record = new DeathRecord();
@@ -427,13 +423,11 @@ namespace VRDR
                 { "code", "Y" },
                 { "system", CodeSystems.PH_YesNo_HL7_2x },
                 { "display", "Yes" } };
-            // uncomment to generate file
-            // string filename = "2_madelyn_patel_opiod_" + fhirVersion + ".xml";
-            // WriteRecordAsXml(record, filename);
 
             return record;
         }
 
+        /// <summary>Generate the Vivienne Lee Wright example record</summary>
         public static DeathRecord VivienneLeeWright()
         {
             DeathRecord record = new DeathRecord();
@@ -616,17 +610,10 @@ namespace VRDR
                 { "system", CodeSystems.PH_YesNo_HL7_2x },
                 { "display", "No" } };
 
-            // uncomment to generate file
-            // string filename = "3_vivienne_wright_pregnant_" + fhirVersion + ".xml";
-            // WriteRecordAsXml(record, filename);
-
             return record;
         }
 
-        /** this can be used 2 ways, with partialRecord set to
-         *                                  false for a full record
-         *                               or true for a partial record
-         */
+        /// <summary>Generate the Javier Luis Perez example record; this can be used to generate either a partial or full record</summary>
         public static DeathRecord JavierLuisPerez(bool partialRecord = false)
         {
             bool fullRecord = !partialRecord;
@@ -862,24 +849,13 @@ namespace VRDR
                 { "code", "N" },
                 { "system", CodeSystems.PH_YesNo_HL7_2x },
                 { "display", "No" } };
-            // uncomment to generate file
-            // string filename = "";
-            // if (fullRecord)
-            // {
-            //     filename += "4_javier_perez_accident_full_" + fhirVersion + ".xml";
-            // }
-            // else
-            // {
-            //     filename += "5_javier_perez_accident_partial_" + fhirVersion + ".xml";
-            // }
-            // WriteRecordAsXml(record, filename);
 
             return record;
         }
 
-
         // Writes record to a file named filename in a subdirectory of the current working directory
-        //  Note that you do this with docker, you will have to set a bind mount on the container
+        // Note that you do this with docker, you will have to set a bind mount on the container
+        /// <summary>Of historical interest for writing a record to a file</summary>
         public static string WriteRecordAsXml(DeathRecord record, string filename)
         {
             string parentPath = System.IO.Directory.GetCurrentDirectory() + "/connectathon_files";

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -1,4 +1,3 @@
-using VRDR;
 using System;
 using System.Collections.Generic;
 
@@ -51,7 +50,7 @@ namespace VRDR
 
             record.Identifier = "000001";
 
-            record.RegisteredTime = "2022-01-09";
+            record.RegisteredTime = "2021-02-09";
 
             record.GivenNames = new string[] { "Janet" };
 
@@ -125,7 +124,7 @@ namespace VRDR
             uind.Add("text", "Health Insurance");
             record.UsualIndustryCode = uind;
 
-            record.DateOfDeath = "2022-01-08T05:30:00";
+            record.DateOfDeath = "2021-02-08T05:30:00";
 
             Dictionary<string, string> deathLoc = new Dictionary<string, string>();
             deathLoc.Add("addressCity", "Atlanta");
@@ -158,9 +157,9 @@ namespace VRDR
             address.Add("addressCountry", "US");
             record.CertifierAddress = address;
 
-            record.CertifiedTime = "2022-01-08";
+            record.CertifiedTime = "2021-02-08";
 
-            record.DateOfDeathPronouncement = "2022-01-08T05:30:00";
+            record.DateOfDeathPronouncement = "2021-02-08T05:30:00";
             record.PronouncerGivenNames = new string[] { "Sam" };
             record.PronouncerFamilyName = "Jones";
 
@@ -242,7 +241,7 @@ namespace VRDR
 
             record.Identifier = "000002";
 
-            record.RegisteredTime = "2022-01-11";
+            record.RegisteredTime = "2021-06-11";
 
             record.GivenNames = new string[] { "Madelyn" };
 
@@ -313,7 +312,7 @@ namespace VRDR
             uind.Add("text", "Fast food");
             record.UsualIndustryCode = uind;
 
-            record.DateOfDeath = "2022-01-05T14:04:00";
+            record.DateOfDeath = "2021-06-05T14:04:00";
 
             Dictionary<string, string> deathLoc = new Dictionary<string, string>();
             deathLoc.Add("addressCity", "Danville");
@@ -345,9 +344,9 @@ namespace VRDR
             address.Add("addressCountry", "US");
             record.CertifierAddress = address;
 
-            record.CertifiedTime = "2022-01-05";
+            record.CertifiedTime = "2021-06-05";
 
-            record.DateOfDeathPronouncement = "2022-01-05T15:30:00";
+            record.DateOfDeathPronouncement = "2021-06-05T15:30:00";
             record.PronouncerGivenNames = new string[] { "Adam" };
             record.PronouncerFamilyName = "Revel";
 
@@ -364,7 +363,7 @@ namespace VRDR
             manner.Add("display", "Accidental death");
             record.MannerOfDeathType = manner;
 
-            record.InjuryDate = "2022-01-05T13:00:00";
+            record.InjuryDate = "2021-06-05T13:00:00";
             record.InjuryAtWorkBoolean = false;
 
             // @check
@@ -441,7 +440,7 @@ namespace VRDR
 
             record.Identifier = "000003";
 
-            record.RegisteredTime = "2022-01-14";
+            record.RegisteredTime = "2021-01-14";
 
             record.GivenNames = new string[] { "Vivienne", "L" };
 
@@ -513,7 +512,7 @@ namespace VRDR
             uind.Add("text", "State agency");
             record.UsualIndustryCode = uind;
 
-            record.DateOfDeath = "2022-01-13T21:00:00";
+            record.DateOfDeath = "2021-01-13T21:00:00";
 
             Dictionary<string, string> deathLoc = new Dictionary<string, string>();
             deathLoc.Add("addressCity", "Lancaster");
@@ -547,9 +546,9 @@ namespace VRDR
             address.Add("addressCountry", "US");
             record.CertifierAddress = address;
 
-            record.CertifiedTime = "2022-01-13";
+            record.CertifiedTime = "2021-01-13";
 
-            record.DateOfDeathPronouncement = "2022-01-13T21:00:00";
+            record.DateOfDeathPronouncement = "2021-01-13T21:00:00";
             record.PronouncerGivenNames = new string[] { "Jim" };
             record.PronouncerFamilyName = "Black";
 
@@ -635,7 +634,7 @@ namespace VRDR
 
             record.Identifier = "000004";
 
-            record.RegisteredTime = "2022-01-15";
+            record.RegisteredTime = "2021-03-15";
 
             record.GivenNames = new string[] { "Javier", "Luis" };
 
@@ -732,7 +731,7 @@ namespace VRDR
             uind.Add("text", "construction");
             record.UsualIndustryCode = uind;
 
-            record.DateOfDeath = "2022-01-14T11:25:00";
+            record.DateOfDeath = "2021-03-14T11:25:00";
 
             record.DeathLocationName = "County Hospital";
             Dictionary<string, string> locType = new Dictionary<string, string>();
@@ -760,9 +759,9 @@ namespace VRDR
             address.Add("addressCountry", "US");
             record.CertifierAddress = address;
 
-            record.CertifiedTime = "2022-01-14";
+            record.CertifiedTime = "2021-03-14";
 
-            record.DateOfDeathPronouncement = "2022-01-14T11:35:00";
+            record.DateOfDeathPronouncement = "2021-03-14T11:35:00";
 
             if (fullRecord)
             {
@@ -790,7 +789,7 @@ namespace VRDR
             manner.Add("display", "Accidental death");
             record.MannerOfDeathType = manner;
 
-            record.InjuryDate = "2022-01-14T11:15:00";
+            record.InjuryDate = "2021-03-14T11:15:00";
             record.InjuryAtWorkBoolean = true;
 
             Dictionary<string, string> injuryPlace = new Dictionary<string, string>();

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -799,6 +799,35 @@ namespace VRDR
             }
         }
 
+        /// <summary>Certification Role Helper.</summary>
+        /// <value>the role/qualification of the person who certified the death.
+        /// <para>"code" - the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.CertificationRoleHelper = ValueSets.CertificationRole.InfectiousDiseasesPhysician;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Certification Role: {ExampleDeathRecord.CertificationRoleHelper}");</para>
+        /// </example>
+        [Property("Certification Role", Property.Types.String, "Death Certification", "Certification Role.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Certification.html", true, 4)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Procedure).where(code.coding.code='308646001')", "performer")]
+        public string CertificationRoleHelper
+        {
+            get
+            {
+                if (CertificationRole.ContainsKey("code"))
+                {
+                    return CertificationRole["code"];
+                }
+                return null;
+            }
+            set
+            {
+                SetCodeValue("CertificationRole", value, VRDR.ValueSets.CertificationRole.Codes);
+            }
+        }
+
         /// <summary>Interested Party Identifier.</summary>
         /// <value>the interested party identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
         /// <para>"system" - the identifier system, e.g. US NPI</para>
@@ -6219,7 +6248,7 @@ namespace VRDR
         /// <summary>Type of Death Location Helper</summary>
         /// <value>type of death location code.</value>
         /// <example>
-    /// <para>// Setter:</para>
+        /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.DeathLocationTypeHelper = "16983000";</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Type: {ExampleDeathRecord.DeathLocationTypeHelper}");</para>

--- a/VRDR/ValueSets.cs
+++ b/VRDR/ValueSets.cs
@@ -231,14 +231,18 @@ namespace VRDR
                 { "434651000124107", "Physician certified death certificate", VRDR.CodeSystems.SCT },
                 { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
             };
-            /// <summary> Medical_Examiner_Coroner </summary>
+            /// <summary> Medical Examiner/Coroner </summary>
             public static string  Medical_Examiner_Coroner = "455381000124109";
-            /// <summary> Physician_Certified_And_Pronounced_Death_Certificate </summary>
+            /// <summary> Physician certified and pronounced death certificate </summary>
             public static string  Physician_Certified_And_Pronounced_Death_Certificate = "434641000124105";
-            /// <summary> Physician_Certified_Death_Certificate </summary>
+            /// <summary> Physician certified death certificate </summary>
             public static string  Physician_Certified_Death_Certificate = "434651000124107";
             /// <summary> Other </summary>
             public static string  Other = "OTH";
         };
-   }
+    }
 }
+
+
+
+

--- a/tools/convert_NCHS_DACEB_pilot_data_to_fhir.rb
+++ b/tools/convert_NCHS_DACEB_pilot_data_to_fhir.rb
@@ -1,0 +1,69 @@
+# coding: utf-8
+
+# Take an excel file from DACEB and convert it to FHIR records; we parse the excel file and extract the data
+# for each record, with the goal of a simple IJE mapping; we write one file per record
+
+filename = ARGV.shift
+raise "Please provide the Excel file name as an argument to this script" unless filename
+
+require 'creek'
+data = Creek::Book.new(filename)
+
+# Helper method: Given a sheet, the first row that has data, and the expected number of records, return an
+# array of all the IJE records from that sheet
+def extract_ije_records(sheet, first_data_row, record_count)
+
+  # Data starts on row N (0 based); each row contains position (offset), length (we use this to determine the
+  # amount of padding), description (ignored), IJE field name (ignored), data for N records (one column each)
+
+  rows = sheet.rows.to_a
+  row_number = first_data_row
+  ije_records = Array.new(record_count) { '' } # Array of strings
+  while row = rows[row_number] do
+    row_values = row.to_a.map(&:last) # Convert from hash of cell name to value
+    offset = row_values[0].to_i - 1 # Make offset 0 based
+    length = row_values[1].to_i
+    values = row_values[4, record_count]
+    # If there's a linefeed in a value, take everything before the linefeed
+    values.map! { |v| v.to_s.split("\n").first.to_s.strip }
+    # There appears to be a special character for blank
+    values.map! { |v| v == '␢' ? '' : v }
+    # puts "#{length} #{values.join(',')}"
+    record_count.times do |record_number|
+      # Append data, padded with correct amount of space before (based on offset) and after (based on length)
+      ije_records[record_number] += ' ' * (offset - ije_records[record_number].length)
+      ije_records[record_number] << "%-#{length}s" % values[record_number]
+    end
+    row_number += 1
+  end
+
+  # Pad each record to 5000 characters and return the result
+  ije_records.map { |record| record += ' ' * (5000 - record.length) }
+end
+
+# Helper method: write IJE and JSON records to files based on the certificate identifier information in the record
+def write_record(record, annotation)
+  filename = record[0,12] # First 12 bytes are the year, jurisdiction, and certificate number
+  filename << "_#{annotation}" if annotation # If we have an extra label add it to the filename
+  ije_filename = "#{filename}.ije"
+  json_filename = "#{filename}.json"
+  puts "Writing record to #{ije_filename}"
+  File.open(ije_filename, 'w') { |file| file.write(record) }
+  puts "Writing record to #{json_filename}"
+  cli_path = File.expand_path(File.join(__dir__, '..', 'VRDR.CLI'))
+  command = "dotnet run --project #{cli_path} ije2json #{ije_filename} > #{json_filename}"
+  puts command
+  system(command)
+end
+
+# Two sheets; sheet one is good records (10 total), sheet two is bad records (14 total)
+good_ije_records = extract_ije_records(data.sheets[0], 4, 10)
+bad_ije_records = extract_ije_records(data.sheets[1], 6, 14)
+
+10.times do |i|
+  write_record(good_ije_records[i], "good")
+end
+
+14.times do |i|
+  write_record(bad_ije_records[i], "bad")
+end

--- a/tools/generate_bulk_connectathon_records.rb
+++ b/tools/generate_bulk_connectathon_records.rb
@@ -1,0 +1,34 @@
+require 'parallel'
+
+# Generate quantities of connectathon records
+#
+# Usage: ruby generate_bulk_connectathon_records.rb <StartCertificateNumber> <Count> <Directory>
+#
+# Generates <Count> records, starting with the specified <StartCertificateNumber>, rotating
+# through the 4 distinct connectathon records, and writing them to the specified <Directory>
+#
+# Uses the parallel gem to run using all cores
+
+start_certificate_number = (ARGV.shift || 0).to_i
+count = (ARGV.shift || 0).to_i
+output_directory = ARGV.shift
+
+raise "Must supply a starting certificate number greater than 0" unless start_certificate_number > 0
+raise "Must supply a count greater than 0" unless count > 0
+raise "Must supply a valid output directory" unless output_directory && Dir.exists?(output_directory)
+
+# It's faster to run the built command line app than to repeatedly call dotnet run... make sure it's built
+cli_path = File.expand_path(File.join(__dir__, '..', 'VRDR.CLI'))
+current_path = Dir.pwd
+command = "cd #{cli_path} ; dotnet build --configuration Release ; cd #{current_path}"
+puts command
+system command
+
+Parallel.each(0...count) do |i|
+  certificate_number = start_certificate_number + i
+  record_selector = (i % 4) + 1
+  file_name = File.join(output_directory, "#{Time.now.year}MA#{'%06d' % certificate_number}.json")
+  command = "#{cli_path}/bin/Release/netcoreapp3.1/DeathRecord.CLI connectathon #{record_selector} #{certificate_number} MA | jq > #{file_name}"
+  puts command
+  system command
+end


### PR DESCRIPTION
This pull request makes a handful of not-necessarily-related changes:

1. Updates and adds to the code for converting from the Nightingale data format to FHIR
2. Adds the CertificationRoleHelper method
3. Documents the new helper methods in the README
4. Copies the Connectathon record generation code into VRDR from Canary so that it can be accessed from the VRDR.CLI; once this is merged the version of the file in Canary can be removed and Canary can refer to this version
5. Adds functionality to the VRDR.CLI application for generating Connectathon records from the command line
6. Adds a ruby script for generating a large quantity of FHIR records using the Connectathon records
7. Adds a ruby script for converting an Excel file with records in pseudo-IJE format into a set of FHIR records for testing
8. Removes support for the now-obsolete netcoreapp2.1
