### PR TITLE
Updated generate value set helpers along with generation code

### DIFF
--- a/VRDR.CLI/1.xml
+++ b/VRDR.CLI/1.xml
@@ -801,8 +801,8 @@
         </subject>
         <valueCodeableConcept>
           <coding>
-            <system value="urn:oid:2.16.840.1.114222.4.5.274" />
-            <code value="PHC1453" />
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0360" />
+            <code value="BA" />
             <display value="Bachelor's Degree" />
           </coding>
         </valueCodeableConcept>

--- a/VRDR.CLI/1_wJurisdiction.json
+++ b/VRDR.CLI/1_wJurisdiction.json
@@ -737,7 +737,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "7878000",
-              "display": "Accident"
+              "display": "Accidental death"
             }
           ]
         }
@@ -994,8 +994,8 @@
         "valueCodeableConcept": {
           "coding": [
             {
-              "system": "urn:oid:2.16.840.1.114222.4.5.274",
-              "code": "PHC1453",
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0360",
+              "code": "BA",
               "display": "Bachelor's Degree"
             }
           ]

--- a/VRDR.CLI/1_wJurisdiction.xml
+++ b/VRDR.CLI/1_wJurisdiction.xml
@@ -585,7 +585,7 @@
           <coding>
             <system value="http://snomed.info/sct" />
             <code value="7878000" />
-            <display value="Accident" />
+            <display value="Accidental death" />
           </coding>
         </valueCodeableConcept>
       </Observation>
@@ -801,8 +801,8 @@
         </subject>
         <valueCodeableConcept>
           <coding>
-            <system value="urn:oid:2.16.840.1.114222.4.5.274" />
-            <code value="PHC1453" />
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0360" />
+            <code value="BA" />
             <display value="Bachelor's Degree" />
           </coding>
         </valueCodeableConcept>

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -252,31 +252,31 @@ namespace VRDR.HTTP
 
             if (record.DeathLocationTypeHelper != null)
             {
-                if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Hospital_Dead_On_Arrival)
+                if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Dead_On_Arrival_At_Hospital)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Dead on arrival at hospital";
                 }
-                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Decedents_Home)
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Home)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Death in home";
                 }
-                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Hospice)
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Hospice)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Death in hospice";
                 }
-                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Hospital_Inpatient)
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Hospital)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Death in hospital";
                 }
-                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Emergency_Room_Outpatient)
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Hospital_Based_Emergency_Department_Or_Outpatient_Department)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Death in hospital-based emergency department or outpatient department";
                 }
-                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Long_Term_Care_Facility)
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Or_Long_Term_Care_Facility)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Death in nursing home or long term care facility";
                 }
-                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Unknown)
+                else if (record.DeathLocationTypeHelper == VRDR.ValueSets.PlaceOfDeath.Unk)
                 {
                     values["placeOfDeath.placeOfDeath.option"] = "Unknown";
                 }
@@ -517,25 +517,25 @@ namespace VRDR.HTTP
             switch (GetValue(values, "placeOfDeath.placeOfDeath.option"))
             {
                 case "Dead on arrival at hospital":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Hospital_Dead_On_Arrival;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Dead_On_Arrival_At_Hospital;
                     break;
                 case "Death in home":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Decedents_Home;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Home;
                     break;
                 case "Death in hospice":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Hospice;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Hospice;
                     break;
                 case "Death in hospital":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Hospital_Inpatient;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Hospital;
                     break;
                 case "Death in hospital-based emergency department or outpatient department":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Emergency_Room_Outpatient;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Hospital_Based_Emergency_Department_Or_Outpatient_Department;
                     break;
                 case "Death in nursing home or long term care facility":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Long_Term_Care_Facility;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Or_Long_Term_Care_Facility;
                     break;
                 case "Unknown":
-                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Unknown;
+                    deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Unk;
                     break;
                 default:
                     deathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Other;

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -186,8 +186,8 @@ namespace VRDR.Tests
             IJEMortality ijefromjson = new IJEMortality(djson);
             DeathRecord fromijefromjson = ijefromjson.ToDeathRecord();
 
-            Assert.NotEqual(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Hospice);
-            Assert.Equal(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Hospital_Inpatient);
+            Assert.NotEqual(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Death_In_Hospice);
+            Assert.Equal(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Death_In_Hospital);
             Assert.Equal("Death in hospital", fromijefromjson.DeathLocationType["display"]);
         }
 
@@ -309,9 +309,9 @@ namespace VRDR.Tests
 [Fact]
         public void Set_DeathLocationTypeHelper()
         {
-            SetterDeathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Long_Term_Care_Facility;
-            Assert.Equal(VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Long_Term_Care_Facility, SetterDeathRecord.DeathLocationTypeHelper);
-            Assert.Equal("Death in nursing home/Long term care facility", SetterDeathRecord.DeathLocationType["display"]);
+            SetterDeathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Or_Long_Term_Care_Facility;
+            Assert.Equal(VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Or_Long_Term_Care_Facility, SetterDeathRecord.DeathLocationTypeHelper);
+            Assert.Equal("Death in nursing home or long term care facility", SetterDeathRecord.DeathLocationType["display"]);
             Exception ex = Assert.Throws<System.ArgumentException>(() => SetterDeathRecord.DeathLocationTypeHelper = "NotAValidValue");
         }
 
@@ -515,21 +515,21 @@ namespace VRDR.Tests
         public void Set_MannerOfDeathType()
         {
             Dictionary<string, string> type = new Dictionary<string, string>();
-            SetterDeathRecord.MannerOfDeathTypeHelper = ValueSets.MannerOfDeath.Accident;
+            SetterDeathRecord.MannerOfDeathTypeHelper = ValueSets.MannerOfDeath.Accidental_Death;
             Assert.Equal(CodeSystems.SCT, SetterDeathRecord.MannerOfDeathType["system"]);
-            Assert.Equal(ValueSets.MannerOfDeath.Accident, SetterDeathRecord.MannerOfDeathTypeHelper);
-            Assert.Equal("Accident", SetterDeathRecord.MannerOfDeathType["display"]);
+            Assert.Equal(ValueSets.MannerOfDeath.Accidental_Death, SetterDeathRecord.MannerOfDeathTypeHelper);
+            Assert.Equal("Accidental death", SetterDeathRecord.MannerOfDeathType["display"]);
         }
 
         [Fact]
         public void Get_MannerOfDeathType()
         {
             Assert.Equal(CodeSystems.SCT, ((DeathRecord)JSONRecords[0]).MannerOfDeathType["system"]);
-            Assert.Equal(ValueSets.MannerOfDeath.Accident, ((DeathRecord)JSONRecords[0]).MannerOfDeathType["code"]);
-            Assert.Equal("Accident", ((DeathRecord)JSONRecords[0]).MannerOfDeathType["display"]);
+            Assert.Equal(ValueSets.MannerOfDeath.Accidental_Death, ((DeathRecord)JSONRecords[0]).MannerOfDeathType["code"]);
+            Assert.Equal("Accidental death", ((DeathRecord)JSONRecords[0]).MannerOfDeathType["display"]);
             Assert.Equal(CodeSystems.SCT, ((DeathRecord)XMLRecords[0]).MannerOfDeathType["system"]);
-            Assert.Equal(ValueSets.MannerOfDeath.Accident, ((DeathRecord)XMLRecords[0]).MannerOfDeathType["code"]);
-            Assert.Equal("Accident", ((DeathRecord)XMLRecords[0]).MannerOfDeathType["display"]);
+            Assert.Equal(ValueSets.MannerOfDeath.Accidental_Death, ((DeathRecord)XMLRecords[0]).MannerOfDeathType["code"]);
+            Assert.Equal("Accidental death", ((DeathRecord)XMLRecords[0]).MannerOfDeathType["display"]);
         }
 
         [Fact]
@@ -1527,10 +1527,10 @@ namespace VRDR.Tests
             Assert.Equal(VRDR.ValueSets.EducationLevel.Bachelors_Degree, SetterDeathRecord.EducationLevel["code"]);
             Assert.Equal(VRDR.CodeSystems.PH_PHINVS_CDC, SetterDeathRecord.EducationLevel["system"]);
             Assert.Equal("Bachelor's Degree", SetterDeathRecord.EducationLevel["display"]);
-            SetterDeathRecord.EducationLevelHelper = VRDR.ValueSets.EducationLevel.Associate_Degree;
-            Assert.Equal(VRDR.ValueSets.EducationLevel.Associate_Degree, SetterDeathRecord.EducationLevelHelper);
-            Assert.Equal(VRDR.CodeSystems.PH_PHINVS_CDC, SetterDeathRecord.EducationLevel["system"]);
-            Assert.Equal("Associate Degree", SetterDeathRecord.EducationLevel["display"]);
+            SetterDeathRecord.EducationLevelHelper = VRDR.ValueSets.EducationLevel.Associates_Or_Technical_Degree_Complete;
+            Assert.Equal(VRDR.ValueSets.EducationLevel.Associates_Or_Technical_Degree_Complete, SetterDeathRecord.EducationLevelHelper);
+            Assert.Equal(VRDR.CodeSystems.DegreeLicenceAndCertificate, SetterDeathRecord.EducationLevel["system"]);
+            Assert.Equal("Associate's or technical degree complete", SetterDeathRecord.EducationLevel["display"]);
 
         }
 
@@ -1538,10 +1538,10 @@ namespace VRDR.Tests
         public void Get_EducationLevel()
         {
             Assert.Equal(VRDR.ValueSets.EducationLevel.Bachelors_Degree, ((DeathRecord)JSONRecords[0]).EducationLevelHelper);
-            Assert.Equal(VRDR.CodeSystems.PH_PHINVS_CDC, ((DeathRecord)JSONRecords[0]).EducationLevel["system"]);
+            Assert.Equal(VRDR.CodeSystems.DegreeLicenceAndCertificate, ((DeathRecord)JSONRecords[0]).EducationLevel["system"]);
             Assert.Equal("Bachelor's Degree", ((DeathRecord)JSONRecords[0]).EducationLevel["display"]);
             Assert.Equal(VRDR.ValueSets.EducationLevel.Bachelors_Degree, ((DeathRecord)XMLRecords[0]).EducationLevelHelper);
-            Assert.Equal(VRDR.CodeSystems.PH_PHINVS_CDC, ((DeathRecord)XMLRecords[0]).EducationLevel["system"]);
+            Assert.Equal(VRDR.CodeSystems.DegreeLicenceAndCertificate, ((DeathRecord)XMLRecords[0]).EducationLevel["system"]);
             Assert.Equal("Bachelor's Degree", ((DeathRecord)XMLRecords[0]).EducationLevel["display"]);
         }
 

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -737,7 +737,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "7878000",
-              "display": "Accident"
+              "display": "Accidental death"
             }
           ]
         }
@@ -994,8 +994,8 @@
         "valueCodeableConcept": {
           "coding": [
             {
-              "system": "urn:oid:2.16.840.1.114222.4.5.274",
-              "code": "PHC1453",
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0360",
+              "code": "BA",
               "display": "Bachelor's Degree"
             }
           ]

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -585,7 +585,7 @@
           <coding>
             <system value="http://snomed.info/sct" />
             <code value="7878000" />
-            <display value="Accident" />
+            <display value="Accidental death" />
           </coding>
         </valueCodeableConcept>
       </Observation>
@@ -801,8 +801,8 @@
         </subject>
         <valueCodeableConcept>
           <coding>
-            <system value="urn:oid:2.16.840.1.114222.4.5.274" />
-            <code value="PHC1453" />
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0360" />
+            <code value="BA" />
             <display value="Bachelor's Degree" />
           </coding>
         </valueCodeableConcept>

--- a/VRDR.Tests/fixtures/xml/MissingValue.xml
+++ b/VRDR.Tests/fixtures/xml/MissingValue.xml
@@ -732,8 +732,8 @@
         </subject>
         <valueCodeableConcept>
           <coding>
-            <system value="urn:oid:2.16.840.1.114222.4.5.274" />
-            <code value="PHC1453" />
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0360" />
+            <code value="BA" />
             <display value="Bachelor's Degree" />
           </coding>
         </valueCodeableConcept>

--- a/VRDR/CodeSystems.cs
+++ b/VRDR/CodeSystems.cs
@@ -13,9 +13,11 @@ namespace VRDR
         public static string US_SSN = "http://hl7.org/fhir/sid/us-ssn";
 
         /// <summary>PHINVADS Race and Ethnicity.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_RaceAndEthnicity_CDC = "urn:oid:2.16.840.1.113883.6.238";
 
         /// <summary>PHINVADS Null Flavor.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_NullFlavor_HL7_V3 = "http://terminology.hl7.org/CodeSystem/v3-NullFlavor"; // "urn:oid:2.16.840.1.113883.5.1008";
 
         /// <summary>HL7 V3 Null Flavor.</summary>
@@ -25,40 +27,57 @@ namespace VRDR
         public static string Data_Absent_Reason_HL7_V3 = "http://terminology.hl7.org/CodeSystem/data-absent-reason";
 
         /// <summary>PHINVADS Local Coding System.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_PHINVS_CDC = "urn:oid:2.16.840.1.114222.4.5.274";
 
         /// <summary>PHINVADS Yes/No.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_YesNo_HL7_2x = "urn:oid:2.16.840.1.113883.12.136";
 
         /// <summary>PHINVADS County FIPS 6-4</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_County_FIPS_6_4 = "2.16.840.1.113883.6.93";
 
         /// <summary>PHINVADS Country GEC</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_Country_GEC = "2.16.840.1.113883.13.250";
+
         /// <summary>PHINVADS Place of Occurrence.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_PlaceOfOccurrence_ICD_10_WHO = "urn:oid:2.16.840.1.114222.4.5.320";
 
         /// <summary>PHINVADS SNOMED.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_SNOMED_CT = "urn:oid:2.16.840.1.113883.6.96";
+
         /// <summary>PHINVADS Marital Satus.</summary>
         public static string PH_MaritalStatus_HL7_2x = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
+
         /// <summary>PHINVADS USGS GNIS.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_USGS_GNIS = "urn:oid:2.16.840.1.113883.6.245";
+
         /// <summary>PHINVADS FIPS 5 2.</summary>
+        // TODO: FLAGGED FOR DELETION
         public static string PH_State_FIPS_5_2 = "urn:oid:2.16.840.1.113883.6.92";
+
         /// <summary>HL7 Location Physical Type.</summary>
         public static string HL7_location_physical_type = "http://terminology.hl7.org/CodeSystem/location-physical-type";
+
         /// <summary> CDC Census Occupation Code  </summary>
         public static string PH_Occupation_CDC_Census2010 = "urn:oid:2.16.840.1.114222.4.5.314";
+
         /// <summary> CDC Census Industry Code  </summary>
         public static string PH_Industry_CDC_Census2010 = "urn:oid:2.16.840.1.114222.4.5.315";
+
         /// <summary> US NPI HL7  </summary>
         public static string US_NPI_HL7 = "http://hl7.org/fhir/sid/us-npi";
+
         /// <summary>HL7 Identifier Type.</summary>
         public static string HL7_identifier_type = "http://terminology.hl7.org/CodeSystem/v2-0203";
-       /// <summary>HL7 Organization Type.</summary>
-        public static string HL7_organization_type =  "http://terminology.hl7.org/CodeSystem/organization-type";
 
+        /// <summary>HL7 Organization Type.</summary>
+        public static string HL7_organization_type =  "http://terminology.hl7.org/CodeSystem/organization-type";
 
         /// <summary>PHINVADS HL7 RoleCode.</summary>
         public static string PH_RoleCode_HL7_V3 = "urn:oid:2.16.840.1.113883.5.111";
@@ -68,6 +87,30 @@ namespace VRDR
 
         /// <summary> ISO 3166-2  </summary>
         public static string ISO_3166_2 = "urn:iso:std:iso:3166:-2";
+
+        /// <summary> Administrative Gender </summary>
+        public static string AdministrativeGender = "http://hl7.org/fhir/administrative-gender";
+
+        /// <summary> Bypass Edit Flag </summary>
+        public static string BypassEditFlag = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs";
+
+        /// <summary> Education Level </summary>
+        public static string EducationLevel = "http://terminology.hl7.org/CodeSystem/v3-EducationLevel";
+
+        /// <summary> Degree Licence and Certificate </summary>
+        public static string DegreeLicenceAndCertificate = "http://terminology.hl7.org/CodeSystem/v2-0360";
+
+        /// <summary> Pregnancy Status </summary>
+        public static string PregnancyStatus = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs";
+
+        /// <summary> Missing Value Reason </summary>
+        public static string MissingValueReason = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-missing-value-reason-cs";
+
+        /// <summary> Units of Measure </summary>
+        public static string UnitsOfMeasure = "http://unitsofmeasure.org";
+
+        /// <summary> HL7 Yes No </summary>
+        public static string YesNo = "http://terminology.hl7.org/CodeSystem/v2-0136";
 
     }
 

--- a/VRDR/ValueSets.cs
+++ b/VRDR/ValueSets.cs
@@ -252,12 +252,12 @@ namespace VRDR
             public static string  Some_College_Education = "SCOL";
             /// <summary> Doctoral_Or_Post_Graduate_Education </summary>
             public static string  Doctoral_Or_Post_Graduate_Education = "POSTG";
-            /// <summary> Associate_S_Or_Technical_Degree_Complete </summary>
-            public static string  Associate_S_Or_Technical_Degree_Complete = "AA";
-            /// <summary> Bachelor_S_Degree </summary>
-            public static string  Bachelor_S_Degree = "BA";
-            /// <summary> Master_S_Degree </summary>
-            public static string  Master_S_Degree = "MA";
+            /// <summary> Associates_Or_Technical_Degree_Complete </summary>
+            public static string  Associates_Or_Technical_Degree_Complete = "AA";
+            /// <summary> Bachelors_Degree </summary>
+            public static string  Bachelors_Degree = "BA";
+            /// <summary> Masters_Degree </summary>
+            public static string  Masters_Degree = "MA";
             /// <summary> Unknown </summary>
             public static string  Unknown = "UNK";
         };

--- a/VRDR/ValueSets.cs
+++ b/VRDR/ValueSets.cs
@@ -3,86 +3,51 @@ namespace VRDR
     /// <summary> ValueSet Helpers </summary>
     public static class ValueSets
     {
-        /// <summary> EducationLevel </summary>
-        public static class EducationLevel {
+        /////////// FLAGGED FOR DELETION
+        /// <summary> CertificationRole </summary>
+        public static class CertificationRole {
             /// <summary> Codes </summary>
             public static string[,] Codes = {
-                { "PHC1448", "8th grade or less", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1449", "9th through 12th grade; no diploma", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1450", "High School Graduate or GED Completed", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1451", "Some college credit, but no degree", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1452", "Associate Degree", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1453", "Bachelor's Degree", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1454", "Master's Degree", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1455", "Doctorate Degree or Professional Degree", VRDR.CodeSystems.PH_PHINVS_CDC },
+                { "455381000124109", "Medical Examiner/Coroner", VRDR.CodeSystems.SCT },
+                { "434641000124105", "Physician certified and pronounced death certificate", VRDR.CodeSystems.SCT },
+                { "434651000124107", "Physician certified death certificate", VRDR.CodeSystems.SCT },
+                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Medical Examiner/Coroner </summary>
+            public static string  Medical_Examiner_Coroner = "455381000124109";
+            /// <summary> Physician certified and pronounced death certificate </summary>
+            public static string  Physician_Certified_And_Pronounced_Death_Certificate = "434641000124105";
+            /// <summary> Physician certified death certificate </summary>
+            public static string  Physician_Certified_Death_Certificate = "434651000124107";
+            /// <summary> Other </summary>
+            public static string  Other = "OTH";
+        };
+        /// <summary> MethodsOfDisposition </summary>
+        public static class MethodsOfDisposition {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "449971000124106", "Burial", VRDR.CodeSystems.SCT },
+                { "449961000124104", "Cremation", VRDR.CodeSystems.SCT },
+                { "449951000124101", "Donation", VRDR.CodeSystems.SCT },
+                { "449931000124108", "Entombment", VRDR.CodeSystems.SCT },
+                { "449941000124103", "Removal from State", VRDR.CodeSystems.SCT },
+                { "OTH", "other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
                 { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
             };
-            /// <summary> _8th_Grade_Or_Less </summary>
-            public static string  _8th_Grade_Or_Less = "PHC1448";
-            /// <summary> _9th_Through_12th_Grade_No_Diploma </summary>
-            public static string  _9th_Through_12th_Grade_No_Diploma = "PHC1449";
-            /// <summary> High_School_Graduate_Or_Ged_Completed </summary>
-            public static string  High_School_Graduate_Or_Ged_Completed = "PHC1450";
-            /// <summary> Some_College_Credit_But_No_Degree </summary>
-            public static string  Some_College_Credit_But_No_Degree = "PHC1451";
-            /// <summary> Associate_Degree </summary>
-            public static string  Associate_Degree = "PHC1452";
-            /// <summary> Bachelors_Degree </summary>
-            public static string  Bachelors_Degree = "PHC1453";
-            /// <summary> Masters_Degree </summary>
-            public static string  Masters_Degree = "PHC1454";
-            /// <summary> Doctorate_Degree_Or_Professional_Degree </summary>
-            public static string  Doctorate_Degree_Or_Professional_Degree = "PHC1455";
+            /// <summary> Burial </summary>
+            public static string  Burial = "449971000124106";
+            /// <summary> Cremation </summary>
+            public static string  Cremation = "449961000124104";
+            /// <summary> Donation </summary>
+            public static string  Donation = "449951000124101";
+            /// <summary> Entombment </summary>
+            public static string  Entombment = "449931000124108";
+            /// <summary> Removal_From_State </summary>
+            public static string  Removal_From_State = "449941000124103";
+            /// <summary> Other </summary>
+            public static string  Other = "OTH";
             /// <summary> Unknown </summary>
             public static string  Unknown = "UNK";
-        };
-        /// <summary> MannerOfDeath </summary>
-        public static class MannerOfDeath {
-            /// <summary> Codes </summary>
-            public static string[,] Codes = {
-                { "38605008", "Natural", VRDR.CodeSystems.SCT },
-                { "7878000", "Accident", VRDR.CodeSystems.SCT },
-                { "44301001", "Suicide", VRDR.CodeSystems.SCT },
-                { "27935005", "Homicide", VRDR.CodeSystems.SCT },
-                { "185973002", "Pending Investigation", VRDR.CodeSystems.SCT },
-                { "65037004", "Could not be determined", VRDR.CodeSystems.SCT }
-            };
-            /// <summary> Natural </summary>
-            public static string  Natural = "38605008";
-            /// <summary> Accident </summary>
-            public static string  Accident = "7878000";
-            /// <summary> Suicide </summary>
-            public static string  Suicide = "44301001";
-            /// <summary> Homicide </summary>
-            public static string  Homicide = "27935005";
-            /// <summary> Pending_Investigation </summary>
-            public static string  Pending_Investigation = "185973002";
-            /// <summary> Could_Not_Be_Determined </summary>
-            public static string  Could_Not_Be_Determined = "65037004";
-        };
-        /// <summary> MaritalStatus </summary>
-        public static class MaritalStatus {
-            /// <summary> Codes </summary>
-            public static string[,] Codes = {
-                { "M", "Married", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
-                { "A", "Married but Separated", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
-                { "W", "Widowed", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
-                { "D", "Divorced", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
-                { "S", "Never Married", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
-                { "U", "Not Classifiable", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x }
-            };
-            /// <summary> Married </summary>
-            public static string  Married = "M";
-            /// <summary> Married_But_Separated </summary>
-            public static string  Married_But_Separated = "A";
-            /// <summary> Widowed </summary>
-            public static string  Widowed = "W";
-            /// <summary> Divorced </summary>
-            public static string  Divorced = "D";
-            /// <summary> Never_Married </summary>
-            public static string  Never_Married = "S";
-            /// <summary> Not_Classifiable </summary>
-            public static string  Not_Classifiable = "U";
         };
         /// <summary> PlaceOfInjury </summary>
         public static class PlaceOfInjury {
@@ -123,36 +88,6 @@ namespace VRDR
             /// <summary> No_Information </summary>
             public static string  No_Information = "NI";
         };
-        /// <summary> PlaceOfDeath </summary>
-        public static class PlaceOfDeath {
-            /// <summary> Codes </summary>
-            public static string[,] Codes = {
-                { "63238001", "Hospital Dead on Arrival", VRDR.CodeSystems.SCT },
-                { "440081000124100", "Decedent's Home", VRDR.CodeSystems.SCT },
-                { "440071000124103", "Hospice", VRDR.CodeSystems.SCT },
-                { "16983000", "Hospital Inpatient", VRDR.CodeSystems.SCT },
-                { "450391000124102", "Death in emergency Room/Outpatient", VRDR.CodeSystems.SCT },
-                { "450381000124100", "Death in nursing home/Long term care facility", VRDR.CodeSystems.SCT },
-                { "OTH", "other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
-            };
-            /// <summary> Hospital_Dead_On_Arrival </summary>
-            public static string  Hospital_Dead_On_Arrival = "63238001";
-            /// <summary> Decedents_Home </summary>
-            public static string  Decedents_Home = "440081000124100";
-            /// <summary> Hospice </summary>
-            public static string  Hospice = "440071000124103";
-            /// <summary> Hospital_Inpatient </summary>
-            public static string  Hospital_Inpatient = "16983000";
-            /// <summary> Death_In_Emergency_Room_Outpatient </summary>
-            public static string  Death_In_Emergency_Room_Outpatient = "450391000124102";
-            /// <summary> Death_In_Nursing_Home_Long_Term_Care_Facility </summary>
-            public static string  Death_In_Nursing_Home_Long_Term_Care_Facility = "450381000124100";
-            /// <summary> Other </summary>
-            public static string  Other = "OTH";
-            /// <summary> Unknown </summary>
-            public static string  Unknown = "UNK";
-        };
         /// <summary> TransportationRoles </summary>
         public static class TransportationRoles {
             /// <summary> Codes </summary>
@@ -171,78 +106,409 @@ namespace VRDR
             /// <summary> Other </summary>
             public static string  Other = "OTH";
         };
-        /// <summary> PregnancyStatus </summary>
-        public static class PregnancyStatus {
+        /////////// FLAGGED FOR DELETION
+
+        /// <summary> AdministrativeGender </summary>
+        public static class AdministrativeGender {
             /// <summary> Codes </summary>
             public static string[,] Codes = {
-                { "PHC1260", "Not pregnant within past year", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1261", "Pregnant at time of death", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1262", "Not pregnant, but pregnant within 42 days of death", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1263", "Not pregnant, but pregnant 43 days to 1 year before death", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "PHC1264", "Unknown if pregnant within the past year", VRDR.CodeSystems.PH_PHINVS_CDC },
-                { "NA", "Not Applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "male", "Male", VRDR.CodeSystems.AdministrativeGender },
+                { "female", "Female", VRDR.CodeSystems.AdministrativeGender },
+                { "unknown", "unknown", VRDR.CodeSystems.AdministrativeGender }
             };
-            /// <summary> Not_Pregnant_Within_Past_Year </summary>
-            public static string  Not_Pregnant_Within_Past_Year = "PHC1260";
-            /// <summary> Pregnant_At_Time_Of_Death </summary>
-            public static string  Pregnant_At_Time_Of_Death = "PHC1261";
-            /// <summary> Not_Pregnant_But_Pregnant_Within_42_Days_Of_Death </summary>
-            public static string  Not_Pregnant_But_Pregnant_Within_42_Days_Of_Death = "PHC1262";
-            /// <summary> Not_Pregnant_But_Pregnant_43_Days_To_1_Year_Before_Death </summary>
-            public static string  Not_Pregnant_But_Pregnant_43_Days_To_1_Year_Before_Death = "PHC1263";
-            /// <summary> Unknown_If_Pregnant_Within_The_Past_Year </summary>
-            public static string  Unknown_If_Pregnant_Within_The_Past_Year = "PHC1264";
-            /// <summary> Not_Applicable </summary>
-            public static string  Not_Applicable = "NA";
+            /// <summary> Male </summary>
+            public static string  Male = "male";
+            /// <summary> Female </summary>
+            public static string  Female = "female";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "unknown";
         };
-        /// <summary> MethodsOfDisposition </summary>
-        public static class MethodsOfDisposition {
+        /// <summary> CertifierTypes </summary>
+        public static class CertifierTypes {
             /// <summary> Codes </summary>
             public static string[,] Codes = {
-                { "449971000124106", "Burial", VRDR.CodeSystems.SCT },
-                { "449961000124104", "Cremation", VRDR.CodeSystems.SCT },
-                { "449951000124101", "Donation", VRDR.CodeSystems.SCT },
-                { "449931000124108", "Entombment", VRDR.CodeSystems.SCT },
-                { "449941000124103", "Removal from State", VRDR.CodeSystems.SCT },
-                { "OTH", "other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "455381000124109", "Medical Examiner/Coroner-On the basis of examination, and/or investigation, in my opinion, death occurred at the time, date, and place, and due to the cause(s) and manner stated.", VRDR.CodeSystems.SCT },
+                { "434641000124105", "Pronouncing & Certifying physician-To the best of my knowledge, death occurred at the time, date, and place, and due to the cause(s) and manner stated.", VRDR.CodeSystems.SCT },
+                { "434651000124107", "Certifying physician-To the best of my knowledge, death occurred due to the cause(s) and manner stated.", VRDR.CodeSystems.SCT },
+                { "OTH", "Other (Specify)", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Medical_Examiner_Coroner </summary>
+            public static string  Medical_Examiner_Coroner = "455381000124109";
+            /// <summary> Pronouncing_Certifying_Physician </summary>
+            public static string  Pronouncing_Certifying_Physician = "434641000124105";
+            /// <summary> Certifying_Physician </summary>
+            public static string  Certifying_Physician = "434651000124107";
+            /// <summary> Other_Specify </summary>
+            public static string  Other_Specify = "OTH";
+        };
+        /// <summary> ContributoryTobaccoUse </summary>
+        public static class ContributoryTobaccoUse {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "373066001", "Yes", VRDR.CodeSystems.SCT },
+                { "373067005", "No", VRDR.CodeSystems.SCT },
+                { "2931005", "Probably", VRDR.CodeSystems.SCT },
+                { "UNK", "Unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "NI", "no information", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Yes </summary>
+            public static string  Yes = "373066001";
+            /// <summary> No </summary>
+            public static string  No = "373067005";
+            /// <summary> Probably </summary>
+            public static string  Probably = "2931005";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+            /// <summary> No_Information </summary>
+            public static string  No_Information = "NI";
+        };
+        /// <summary> EditBypass01 </summary>
+        public static class EditBypass01 {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "0", "Edit Passed", VRDR.CodeSystems.BypassEditFlag },
+                { "1", "Edit Failed, Data Queried, and Verified", VRDR.CodeSystems.BypassEditFlag }
+            };
+            /// <summary> Edit_Passed </summary>
+            public static string  Edit_Passed = "0";
+            /// <summary> Edit_Failed_Data_Queried_And_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_And_Verified = "1";
+        };
+        /// <summary> EditBypass012 </summary>
+        public static class EditBypass012 {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "0", "Edit Passed", VRDR.CodeSystems.BypassEditFlag },
+                { "1", "Edit Failed, Data Queried, and Verified", VRDR.CodeSystems.BypassEditFlag },
+                { "2", "Edit Failed, Data Queried, but not Verified", VRDR.CodeSystems.BypassEditFlag }
+            };
+            /// <summary> Edit_Passed </summary>
+            public static string  Edit_Passed = "0";
+            /// <summary> Edit_Failed_Data_Queried_And_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_And_Verified = "1";
+            /// <summary> Edit_Failed_Data_Queried_But_Not_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_But_Not_Verified = "2";
+        };
+        /// <summary> EditBypass01234 </summary>
+        public static class EditBypass01234 {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "0", "Edit Passed", VRDR.CodeSystems.BypassEditFlag },
+                { "1", "Edit Failed, Data Queried, and Verified", VRDR.CodeSystems.BypassEditFlag },
+                { "2", "Edit Failed, Data Queried, but not Verified", VRDR.CodeSystems.BypassEditFlag },
+                { "3", "Edit Failed, Review Needed", VRDR.CodeSystems.BypassEditFlag },
+                { "4", "Edit Failed, Query Needed", VRDR.CodeSystems.BypassEditFlag }
+            };
+            /// <summary> Edit_Passed </summary>
+            public static string  Edit_Passed = "0";
+            /// <summary> Edit_Failed_Data_Queried_And_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_And_Verified = "1";
+            /// <summary> Edit_Failed_Data_Queried_But_Not_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_But_Not_Verified = "2";
+            /// <summary> Edit_Failed_Review_Needed </summary>
+            public static string  Edit_Failed_Review_Needed = "3";
+            /// <summary> Edit_Failed_Query_Needed </summary>
+            public static string  Edit_Failed_Query_Needed = "4";
+        };
+        /// <summary> EditBypass0124 </summary>
+        public static class EditBypass0124 {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "0", "Edit Passed", VRDR.CodeSystems.BypassEditFlag },
+                { "1", "Edit Failed, Data Queried, and Verified", VRDR.CodeSystems.BypassEditFlag },
+                { "2", "Edit Failed, Data Queried, but not Verified", VRDR.CodeSystems.BypassEditFlag },
+                { "4", "Edit Failed, Query Needed", VRDR.CodeSystems.BypassEditFlag }
+            };
+            /// <summary> Edit_Passed </summary>
+            public static string  Edit_Passed = "0";
+            /// <summary> Edit_Failed_Data_Queried_And_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_And_Verified = "1";
+            /// <summary> Edit_Failed_Data_Queried_But_Not_Verified </summary>
+            public static string  Edit_Failed_Data_Queried_But_Not_Verified = "2";
+            /// <summary> Edit_Failed_Query_Needed </summary>
+            public static string  Edit_Failed_Query_Needed = "4";
+        };
+        /// <summary> EducationLevel </summary>
+        public static class EducationLevel {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "ELEM", "Elementary School", VRDR.CodeSystems.EducationLevel },
+                { "SEC", "Some secondary or high school education", VRDR.CodeSystems.EducationLevel },
+                { "HS", "High School or secondary school degree complete", VRDR.CodeSystems.EducationLevel },
+                { "SCOL", "Some College education", VRDR.CodeSystems.EducationLevel },
+                { "POSTG", "Doctoral or post graduate education", VRDR.CodeSystems.EducationLevel },
+                { "AA", "Associate's or technical degree complete", VRDR.CodeSystems.DegreeLicenceAndCertificate },
+                { "BA", "Bachelor's degree", VRDR.CodeSystems.DegreeLicenceAndCertificate },
+                { "MA", "Master's degree", VRDR.CodeSystems.DegreeLicenceAndCertificate },
                 { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
             };
-            /// <summary> Burial </summary>
-            public static string  Burial = "449971000124106";
-            /// <summary> Cremation </summary>
-            public static string  Cremation = "449961000124104";
-            /// <summary> Donation </summary>
-            public static string  Donation = "449951000124101";
+            /// <summary> Elementary_School </summary>
+            public static string  Elementary_School = "ELEM";
+            /// <summary> Some_Secondary_Or_High_School_Education </summary>
+            public static string  Some_Secondary_Or_High_School_Education = "SEC";
+            /// <summary> High_School_Or_Secondary_School_Degree_Complete </summary>
+            public static string  High_School_Or_Secondary_School_Degree_Complete = "HS";
+            /// <summary> Some_College_Education </summary>
+            public static string  Some_College_Education = "SCOL";
+            /// <summary> Doctoral_Or_Post_Graduate_Education </summary>
+            public static string  Doctoral_Or_Post_Graduate_Education = "POSTG";
+            /// <summary> Associate_S_Or_Technical_Degree_Complete </summary>
+            public static string  Associate_S_Or_Technical_Degree_Complete = "AA";
+            /// <summary> Bachelor_S_Degree </summary>
+            public static string  Bachelor_S_Degree = "BA";
+            /// <summary> Master_S_Degree </summary>
+            public static string  Master_S_Degree = "MA";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+        };
+        /// <summary> MannerOfDeath </summary>
+        public static class MannerOfDeath {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "38605008", "Natural death", VRDR.CodeSystems.SCT },
+                { "7878000", "Accidental death", VRDR.CodeSystems.SCT },
+                { "44301001", "Suicide", VRDR.CodeSystems.SCT },
+                { "27935005", "Homicide", VRDR.CodeSystems.SCT },
+                { "185973002", "Patient awaiting investigation", VRDR.CodeSystems.SCT },
+                { "65037004", "Death, manner undetermined", VRDR.CodeSystems.SCT }
+            };
+            /// <summary> Natural_Death </summary>
+            public static string  Natural_Death = "38605008";
+            /// <summary> Accidental_Death </summary>
+            public static string  Accidental_Death = "7878000";
+            /// <summary> Suicide </summary>
+            public static string  Suicide = "44301001";
+            /// <summary> Homicide </summary>
+            public static string  Homicide = "27935005";
+            /// <summary> Patient_Awaiting_Investigation </summary>
+            public static string  Patient_Awaiting_Investigation = "185973002";
+            /// <summary> Death_Manner_Undetermined </summary>
+            public static string  Death_Manner_Undetermined = "65037004";
+        };
+        /// <summary> MaritalStatus </summary>
+        public static class MaritalStatus {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "D", "Divorced", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
+                { "L", "Legally Separated", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
+                { "M", "Married", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
+                { "S", "Never Married", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
+                { "W", "Widowed", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Divorced </summary>
+            public static string  Divorced = "D";
+            /// <summary> Legally_Separated </summary>
+            public static string  Legally_Separated = "L";
+            /// <summary> Married </summary>
+            public static string  Married = "M";
+            /// <summary> Never_Married </summary>
+            public static string  Never_Married = "S";
+            /// <summary> Widowed </summary>
+            public static string  Widowed = "W";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+        };
+        /// <summary> MethodOfDisposition </summary>
+        public static class MethodOfDisposition {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "449931000124108", "Entombment", VRDR.CodeSystems.SCT },
+                { "449941000124103", "Removal from state", VRDR.CodeSystems.SCT },
+                { "449951000124101", "Donation", VRDR.CodeSystems.SCT },
+                { "449961000124104", "Cremation", VRDR.CodeSystems.SCT },
+                { "449971000124106", "Burial", VRDR.CodeSystems.SCT },
+                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "UNK", "Unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
             /// <summary> Entombment </summary>
             public static string  Entombment = "449931000124108";
             /// <summary> Removal_From_State </summary>
             public static string  Removal_From_State = "449941000124103";
+            /// <summary> Donation </summary>
+            public static string  Donation = "449951000124101";
+            /// <summary> Cremation </summary>
+            public static string  Cremation = "449961000124104";
+            /// <summary> Burial </summary>
+            public static string  Burial = "449971000124106";
             /// <summary> Other </summary>
             public static string  Other = "OTH";
             /// <summary> Unknown </summary>
             public static string  Unknown = "UNK";
         };
-        /// <summary> CertificationRole </summary>
-        public static class CertificationRole {
+        /// <summary> NotApplicable </summary>
+        public static class NotApplicable {
             /// <summary> Codes </summary>
             public static string[,] Codes = {
-                { "455381000124109", "Medical Examiner/Coroner", VRDR.CodeSystems.SCT },
-                { "434641000124105", "Physician certified and pronounced death certificate", VRDR.CodeSystems.SCT },
-                { "434651000124107", "Physician certified death certificate", VRDR.CodeSystems.SCT },
-                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
             };
-            /// <summary> Medical Examiner/Coroner </summary>
-            public static string  Medical_Examiner_Coroner = "455381000124109";
-            /// <summary> Physician certified and pronounced death certificate </summary>
-            public static string  Physician_Certified_And_Pronounced_Death_Certificate = "434641000124105";
-            /// <summary> Physician certified death certificate </summary>
-            public static string  Physician_Certified_Death_Certificate = "434651000124107";
+            /// <summary> Not_Applicable </summary>
+            public static string  Not_Applicable = "NA";
+        };
+        /// <summary> PlaceOfDeath </summary>
+        public static class PlaceOfDeath {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "63238001", "Dead on arrival at hospital", VRDR.CodeSystems.SCT },
+                { "440081000124100", "Death in home", VRDR.CodeSystems.SCT },
+                { "440071000124103", "Death in hospice", VRDR.CodeSystems.SCT },
+                { "16983000", "Death in hospital", VRDR.CodeSystems.SCT },
+                { "450391000124102", "Death in hospital-based emergency department or outpatient department", VRDR.CodeSystems.SCT },
+                { "450381000124100", "Death in nursing home or long term care facility", VRDR.CodeSystems.SCT },
+                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "UNK", "UNK", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Dead_On_Arrival_At_Hospital </summary>
+            public static string  Dead_On_Arrival_At_Hospital = "63238001";
+            /// <summary> Death_In_Home </summary>
+            public static string  Death_In_Home = "440081000124100";
+            /// <summary> Death_In_Hospice </summary>
+            public static string  Death_In_Hospice = "440071000124103";
+            /// <summary> Death_In_Hospital </summary>
+            public static string  Death_In_Hospital = "16983000";
+            /// <summary> Death_In_Hospital_Based_Emergency_Department_Or_Outpatient_Department </summary>
+            public static string  Death_In_Hospital_Based_Emergency_Department_Or_Outpatient_Department = "450391000124102";
+            /// <summary> Death_In_Nursing_Home_Or_Long_Term_Care_Facility </summary>
+            public static string  Death_In_Nursing_Home_Or_Long_Term_Care_Facility = "450381000124100";
             /// <summary> Other </summary>
             public static string  Other = "OTH";
+            /// <summary> Unk </summary>
+            public static string  Unk = "UNK";
         };
-    }
+        /// <summary> PregnancyStatus </summary>
+        public static class PregnancyStatus {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "1", "Not pregnant within past year", VRDR.CodeSystems.PregnancyStatus },
+                { "2", "Pregnant at time of death", VRDR.CodeSystems.PregnancyStatus },
+                { "3", "Not pregnant, but pregnant within 42 days of death", VRDR.CodeSystems.PregnancyStatus },
+                { "4", "Not pregnant, but pregnant 43 days to 1 year before death", VRDR.CodeSystems.PregnancyStatus },
+                { "9", "Unknown if pregnant within the past year", VRDR.CodeSystems.PregnancyStatus },
+                { "NA", "Not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Not_Pregnant_Within_Past_Year </summary>
+            public static string  Not_Pregnant_Within_Past_Year = "1";
+            /// <summary> Pregnant_At_Time_Of_Death </summary>
+            public static string  Pregnant_At_Time_Of_Death = "2";
+            /// <summary> Not_Pregnant_But_Pregnant_Within_Days_Of_Death </summary>
+            public static string  Not_Pregnant_But_Pregnant_Within_Days_Of_Death = "3";
+            /// <summary> Not_Pregnant_But_Pregnant_Days_To_Year_Before_Death </summary>
+            public static string  Not_Pregnant_But_Pregnant_Days_To_Year_Before_Death = "4";
+            /// <summary> Unknown_If_Pregnant_Within_The_Past_Year </summary>
+            public static string  Unknown_If_Pregnant_Within_The_Past_Year = "9";
+            /// <summary> Not_Applicable </summary>
+            public static string  Not_Applicable = "NA";
+        };
+        /// <summary> RaceMissingValueReason </summary>
+        public static class RaceMissingValueReason {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "R", "Refused", VRDR.CodeSystems.MissingValueReason },
+                { "S", "Sought, but unknown", VRDR.CodeSystems.MissingValueReason },
+                { "C", "Not obtainable", VRDR.CodeSystems.MissingValueReason }
+            };
+            /// <summary> Refused </summary>
+            public static string  Refused = "R";
+            /// <summary> Sought_But_Unknown </summary>
+            public static string  Sought_But_Unknown = "S";
+            /// <summary> Not_Obtainable </summary>
+            public static string  Not_Obtainable = "C";
+        };
+        /// <summary> TransportationIncidentRole </summary>
+        public static class TransportationIncidentRole {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "236320001", "Vehicle driver", VRDR.CodeSystems.SCT },
+                { "257500003", "Passenger", VRDR.CodeSystems.SCT },
+                { "257518000", "Pedestrian", VRDR.CodeSystems.SCT },
+                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Vehicle_Driver </summary>
+            public static string  Vehicle_Driver = "236320001";
+            /// <summary> Passenger </summary>
+            public static string  Passenger = "257500003";
+            /// <summary> Pedestrian </summary>
+            public static string  Pedestrian = "257518000";
+            /// <summary> Other </summary>
+            public static string  Other = "OTH";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+            /// <summary> Not_Applicable </summary>
+            public static string  Not_Applicable = "NA";
+        };
+        /// <summary> UnitsOfAge </summary>
+        public static class UnitsOfAge {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "min", "Minutes", VRDR.CodeSystems.UnitsOfMeasure },
+                { "d", "Days", VRDR.CodeSystems.UnitsOfMeasure },
+                { "h", "Hours", VRDR.CodeSystems.UnitsOfMeasure },
+                { "mo", "Months", VRDR.CodeSystems.UnitsOfMeasure },
+                { "a", "Years", VRDR.CodeSystems.UnitsOfMeasure },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Minutes </summary>
+            public static string  Minutes = "min";
+            /// <summary> Days </summary>
+            public static string  Days = "d";
+            /// <summary> Hours </summary>
+            public static string  Hours = "h";
+            /// <summary> Months </summary>
+            public static string  Months = "mo";
+            /// <summary> Years </summary>
+            public static string  Years = "a";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+        };
+        /// <summary> YesNoNotApplicable </summary>
+        public static class YesNoNotApplicable {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "N", "No", VRDR.CodeSystems.YesNo },
+                { "Y", "Yes", VRDR.CodeSystems.YesNo },
+                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> No </summary>
+            public static string  No = "N";
+            /// <summary> Yes </summary>
+            public static string  Yes = "Y";
+            /// <summary> Not_Applicable </summary>
+            public static string  Not_Applicable = "NA";
+        };
+        /// <summary> YesNoUnknownNotApplicable </summary>
+        public static class YesNoUnknownNotApplicable {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "Y", "Yes", VRDR.CodeSystems.YesNo },
+                { "N", "No", VRDR.CodeSystems.YesNo },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Yes </summary>
+            public static string  Yes = "Y";
+            /// <summary> No </summary>
+            public static string  No = "N";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+            /// <summary> Not_Applicable </summary>
+            public static string  Not_Applicable = "NA";
+        };
+        /// <summary> YesNoUnknown </summary>
+        public static class YesNoUnknown {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "N", "No", VRDR.CodeSystems.YesNo },
+                { "Y", "Yes", VRDR.CodeSystems.YesNo },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> No </summary>
+            public static string  No = "N";
+            /// <summary> Yes </summary>
+            public static string  Yes = "Y";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+        };
+   }
 }
-
-
-
-

--- a/tools/generate_helper_code_from_value_sets.rb
+++ b/tools/generate_helper_code_from_value_sets.rb
@@ -122,7 +122,7 @@ valuesets.each do |vsfile, fieldname|
             end
             for concept in group["concept"]
                 display = concept["display"].split(/-[A-Z]/).first
-                display = display.split(/[^a-z]+/i).map(&:capitalize).join('_')
+                display = display.gsub("'", '').split(/[^a-z]+/i).map(&:capitalize).join('_')
                 if display[0][/\d/] then display = "_" + display end
                 file.puts "            /// <summary> #{display} </summary>"
                 file.puts "            public static string  #{display} = \"#{concept["code"]}\";"

--- a/tools/generate_helper_code_from_value_sets.rb
+++ b/tools/generate_helper_code_from_value_sets.rb
@@ -50,23 +50,41 @@ codesystems = {
     "http://snomed.info/sct" => "VRDR.CodeSystems.SCT",
     "http://terminology.hl7.org/CodeSystem/v3-NullFlavor" => "VRDR.CodeSystems.PH_NullFlavor_HL7_V3",
     "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus" => "VRDR.CodeSystems.PH_MaritalStatus_HL7_2x",
-    "urn:oid:2.16.840.1.114222.4.5.320" => "VRDR.CodeSystems.PH_PlaceOfOccurrence_ICD_10_WHO",
-    "http://hl7.org/fhir/us/vrdr/CodeSystem/PH-PHINVS-CDC" =>  "VRDR.CodeSystems.PH_PHINVS_CDC"
+    "http://hl7.org/fhir/administrative-gender" => "VRDR.CodeSystems.AdministrativeGender",
+    "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs" => "VRDR.CodeSystems.BypassEditFlag",
+    "http://terminology.hl7.org/CodeSystem/v3-EducationLevel" => "VRDR.CodeSystems.EducationLevel",
+    "http://terminology.hl7.org/CodeSystem/v2-0360" => "VRDR.CodeSystems.DegreeLicenceAndCertificate",
+    "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs" => "VRDR.CodeSystems.PregnancyStatus",
+    "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-missing-value-reason-cs" => "VRDR.CodeSystems.MissingValueReason",
+    "http://unitsofmeasure.org" => "VRDR.CodeSystems.UnitsOfMeasure",
+    "http://terminology.hl7.org/CodeSystem/v2-0136" => "VRDR.CodeSystems.YesNo"
 }
 valuesets = {
-    "ValueSet-PHVS-DecedentEducationLevel-NCHS.json" => "EducationLevel",
-    "ValueSet-PHVS-MannerOfDeath-NCHS.json" => "MannerOfDeath",
-    "ValueSet-PHVS-MaritalStatus-NCHS.json" => "MaritalStatus",
-    "ValueSet-PHVS-PlaceOfInjury-NCHS.json" => "PlaceOfInjury",
-    "ValueSet-PHVS-PlaceOfDeath-NCHS.json" => "PlaceOfDeath",
-    "ValueSet-PHVS-TransportationRelationships-NCHS.json" => "TransportationRoles",
-    "ValueSet-PHVS-PregnancyStatus-NCHS.json" => "PregnancyStatus",
-    "ValueSet-PHVS-MethodsOfDisposition-NCHS.json" => "MethodsOfDisposition",
-    "ValueSet-PHVS-CertifierTypes-NCHS.json" => "CertificationRole"
+    "ValueSet-vrdr-administrative-gender-vs.json" => "AdministrativeGender",
+    "ValueSet-vrdr-certifier-types-vs.json" => "CertifierTypes",
+    "ValueSet-vrdr-contributory-tobacco-use-vs.json" => "ContributoryTobaccoUse",
+    "ValueSet-vrdr-edit-bypass-01-vs.json" => "EditBypass01",
+    "ValueSet-vrdr-edit-bypass-012-vs.json" => "EditBypass012",
+    "ValueSet-vrdr-edit-bypass-01234-vs.json" => "EditBypass01234",
+    "ValueSet-vrdr-edit-bypass-0124-vs.json" => "EditBypass0124",
+    "ValueSet-vrdr-education-level-vs.json" => "EducationLevel",
+    "ValueSet-vrdr-manner-of-death-vs.json" => "MannerOfDeath",
+    "ValueSet-vrdr-marital-status-vs.json" => "MaritalStatus",
+    "ValueSet-vrdr-method-of-disposition-vs.json" => "MethodOfDisposition",
+    "ValueSet-vrdr-not-applicable-vs.json" => "NotApplicable",
+    "ValueSet-vrdr-place-of-death-vs.json" => "PlaceOfDeath",
+    "ValueSet-vrdr-pregnancy-status-vs.json" => "PregnancyStatus",
+    "ValueSet-vrdr-race-missing-value-reason-vs.json" => "RaceMissingValueReason",
+    "ValueSet-vrdr-transportation-incident-role-vs.json" => "TransportationIncidentRole",
+    "ValueSet-vrdr-units-of-age-vs.json" => "UnitsOfAge",
+    "ValueSet-vrdr-yes-no-not-applicable-vs.json" => "YesNoNotApplicable",
+    "ValueSet-vrdr-yes-no-unknown-not-applicable-vs.json" => "YesNoUnknownNotApplicable",
+    "ValueSet-vrdr-yes-no-unknown-vs.json" => "YesNoUnknown"
 }
-basedir = ARGV[0]
+
 outfilename = ARGV[1] + "/ValueSets.cs"
 file = file=File.open(outfilename,"w")
+systems_without_constants = []
 
 file.puts "namespace VRDR
 {
@@ -74,7 +92,8 @@ file.puts "namespace VRDR
     public static class ValueSets"
 file.puts "    {"
 valuesets.each do |vsfile, fieldname|
-        filename = ARGV[0] + "/site/" + vsfile
+        puts "Generating output for #{vsfile}"
+        filename = ARGV[0] + "/resources/" + vsfile
         value_set_data = JSON.parse(File.read(filename))
         file.puts "        /// <summary> #{fieldname} </summary>
         public static class #{fieldname} {
@@ -86,6 +105,8 @@ valuesets.each do |vsfile, fieldname|
             system = group["system"]
             if codesystems[system]
                 system = codesystems[system]
+            else
+              systems_without_constants << system
             end
             for concept in group["concept"]
                 file.puts "," if first == false
@@ -100,11 +121,8 @@ valuesets.each do |vsfile, fieldname|
                 system = codesystems[system]
             end
             for concept in group["concept"]
-                display = concept["display"].gsub("/"," ")
-                display = display.gsub(","," ")
-                display = display.gsub(";"," ")
-                display = display.gsub("'","")
-                display = display.split(" ").map(&:capitalize).join("_")
+                display = concept["display"].split(/-[A-Z]/).first
+                display = display.split(/[^a-z]+/i).map(&:capitalize).join('_')
                 if display[0][/\d/] then display = "_" + display end
                 file.puts "            /// <summary> #{display} </summary>"
                 file.puts "            public static string  #{display} = \"#{concept["code"]}\";"
@@ -115,3 +133,15 @@ valuesets.each do |vsfile, fieldname|
     end
 file.puts "   }
 }"
+
+puts
+puts "Saw the following code systems that don't have constants:"
+puts
+puts systems_without_constants.uniq
+puts
+puts "Suggestions:"
+puts
+systems_without_constants.uniq.each do |system|
+  puts "        /// <summary> #{system} </summary>"
+  puts "        public static string XYZ = \"#{system}\";"
+end


### PR DESCRIPTION
This pull request

1. Updates the Ruby code ([tools/generate_helper_code_from_value_sets.rb](https://github.com/nightingaleproject/vrdr-dotnet/compare/IG-develop-v1.3...update_value_sets?expand=1#diff-af64401fb0ac1ce3f990dbf329549780baf18799042c3bb10ae9a6f05dfa5a09)) used to generate ValueSet lookups used by the Helper functions for setting values based on codes
2. Updates [VRDR/ValueSets.cs](https://github.com/nightingaleproject/vrdr-dotnet/compare/IG-develop-v1.3...update_value_sets?expand=1#diff-6d35b69d28c93e4af9bc52d15dc05a53dcb6a886aa4a09e5f7e0cc14dd8f1113) with the lates run of the ruby script against the new IG
3. Adds some flags for code systems to delete from[VRDR/CodeSystems.cs](https://github.com/nightingaleproject/vrdr-dotnet/compare/IG-develop-v1.3...update_value_sets?expand=1#diff-f3faed72ef8f68a2d92e144925507685850bb0405d421d0ab81f95854dde2c9d); these can be deleted once the code is updated to no longer refer to these obsolete code systems