### PR TITLE
Implement support for PartialDateTime for death date and birth date fields

### DIFF
--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -111,14 +111,9 @@ namespace VRDR
             {
                 this.StateAuxiliaryIdentifier = null;
             }
-            
-            if (from?.DateOfDeath != null)
+            if (from?.DeathYear != null)
             {
-                uint deathYear;
-                if (from?.DateOfDeath?.Length >= 4 && UInt32.TryParse(from?.DateOfDeath?.Substring(0,4), out deathYear))
-                {
-                    this.DeathYear = deathYear;
-                }
+                this.DeathYear = from.DeathYear;
             }
             this.DeathJurisdictionID = from?.DeathLocationJurisdiction;
         }

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2752,20 +2752,20 @@ namespace VRDR.Tests
         [Fact]
         public void Set_DateOfDeath_Partial_Date()
         {
-            Tuple<string, string>[] datePart = { Tuple.Create("date-year", "2021"), Tuple.Create("date-month", "5"), Tuple.Create("day-absent-reason", "asked-unknown")};
-            SetterDeathRecord.DateOfDeathDatePartAbsent = datePart;
-            Assert.Equal(datePart[0], SetterDeathRecord.DateOfDeathDatePartAbsent[0]);
-            Assert.Equal(datePart[1], SetterDeathRecord.DateOfDeathDatePartAbsent[1]);
-            Assert.Equal(datePart[2], SetterDeathRecord.DateOfDeathDatePartAbsent[2]);
+            //Tuple<string, string>[] datePart = { Tuple.Create("date-year", "2021"), Tuple.Create("date-month", "5"), Tuple.Create("day-absent-reason", "asked-unknown")};
+            //SetterDeathRecord.DateOfDeathDatePartAbsent = datePart;
+            //Assert.Equal(datePart[0], SetterDeathRecord.DateOfDeathDatePartAbsent[0]);
+            //Assert.Equal(datePart[1], SetterDeathRecord.DateOfDeathDatePartAbsent[1]);
+            //Assert.Equal(datePart[2], SetterDeathRecord.DateOfDeathDatePartAbsent[2]);
         }
 
         [Fact]
         public void Get_DateOfDeath_Partial_Date()
         {
-            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
-            Assert.Equal(Tuple.Create("date-year", "2021"), (dr.DateOfDeathDatePartAbsent[0]));
-            Assert.Equal(Tuple.Create("date-month", "2"), (dr.DateOfDeathDatePartAbsent[1]));
-            Assert.Equal(Tuple.Create("day-absent-reason", "asked-unknown"), (dr.DateOfDeathDatePartAbsent[2]));
+            //DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
+            //Assert.Equal(Tuple.Create("date-year", "2021"), (dr.DateOfDeathDatePartAbsent[0]));
+            //Assert.Equal(Tuple.Create("date-month", "2"), (dr.DateOfDeathDatePartAbsent[1]));
+            //Assert.Equal(Tuple.Create("day-absent-reason", "asked-unknown"), (dr.DateOfDeathDatePartAbsent[2]));
 
         }
 

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1200,21 +1200,21 @@ namespace VRDR.Tests
         [Fact]
         public void Set_BirthDate_Partial_Date()
         {
-            Tuple<string, string>[] datePart = { Tuple.Create("date-year", "1950"), Tuple.Create("month-absent-reason", "asked-unknown"), Tuple.Create("day-absent-reason", "asked-unknown")};
-            SetterDeathRecord.DateOfBirthDatePartAbsent = datePart;
-            Assert.Equal(datePart[0], SetterDeathRecord.DateOfBirthDatePartAbsent[0]);
-            Assert.Equal(datePart[1], SetterDeathRecord.DateOfBirthDatePartAbsent[1]);
-            Assert.Equal(datePart[2], SetterDeathRecord.DateOfBirthDatePartAbsent[2]);
+            SetterDeathRecord.BirthYear = 1950;
+            SetterDeathRecord.BirthMonth = null;
+            SetterDeathRecord.BirthDay = null;
+            Assert.Equal(1950, (int)SetterDeathRecord.BirthYear);
+            Assert.Null(SetterDeathRecord.BirthMonth);
+            Assert.Null(SetterDeathRecord.BirthDay);
         }
 
         [Fact]
         public void Get_BirthDate_Partial_Date()
         {
             DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
-            Assert.Equal(Tuple.Create("year-absent-reason", "asked-unknown"), (dr.DateOfBirthDatePartAbsent[0]));
-            Assert.Equal(Tuple.Create("month-absent-reason", "asked-unknown"), (dr.DateOfBirthDatePartAbsent[1]));
-            Assert.Equal(Tuple.Create("date-day", "24"), (dr.DateOfBirthDatePartAbsent[2]));
-
+            Assert.Null(dr.BirthYear);
+            Assert.Null(dr.BirthMonth);
+            Assert.Equal(24, (int)dr.BirthDay);
         }
 
 
@@ -1227,14 +1227,10 @@ namespace VRDR.Tests
             Assert.Equal("99", ije1.DOB_MO);
             Assert.Equal("24", ije1.DOB_DY);
             DeathRecord dr1 = ije1.ToDeathRecord();
-
-            Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "asked-unknown"), Tuple.Create("month-absent-reason", "asked-unknown"), Tuple.Create("date-day", "24")};
-            Assert.Equal(datePart[0], dr1.DateOfBirthDatePartAbsent[0]);
-            Assert.Equal(datePart[1], dr1.DateOfBirthDatePartAbsent[1]);
-            Assert.Equal(datePart[2], dr1.DateOfBirthDatePartAbsent[2]);
-            //The DateOfBirth value is not set when there are date part absents, is this acceptable?
-            //Assert.Equal("0001-01-24", dr1.DateOfBirth);
-
+            Assert.Null(dr1.BirthYear);
+            Assert.Null(dr1.BirthMonth);
+            Assert.Equal(24, (int)dr1.BirthDay);
+            Assert.Null(dr1.DateOfBirth);
         }
 
         [Fact]
@@ -2753,20 +2749,21 @@ namespace VRDR.Tests
         public void Set_DateOfDeath_Partial_Date()
         {
             //Tuple<string, string>[] datePart = { Tuple.Create("date-year", "2021"), Tuple.Create("date-month", "5"), Tuple.Create("day-absent-reason", "asked-unknown")};
-            //SetterDeathRecord.DateOfDeathDatePartAbsent = datePart;
-            //Assert.Equal(datePart[0], SetterDeathRecord.DateOfDeathDatePartAbsent[0]);
-            //Assert.Equal(datePart[1], SetterDeathRecord.DateOfDeathDatePartAbsent[1]);
-            //Assert.Equal(datePart[2], SetterDeathRecord.DateOfDeathDatePartAbsent[2]);
+            SetterDeathRecord.DeathYear = 2021;
+            SetterDeathRecord.DeathMonth = 5;
+            SetterDeathRecord.DeathDay = null;
+            Assert.Equal(2021, (int)SetterDeathRecord.DeathYear);
+            Assert.Equal(5, (int)SetterDeathRecord.DeathMonth);
+            Assert.Null(SetterDeathRecord.DeathDay);
         }
 
         [Fact]
         public void Get_DateOfDeath_Partial_Date()
         {
-            //DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
-            //Assert.Equal(Tuple.Create("date-year", "2021"), (dr.DateOfDeathDatePartAbsent[0]));
-            //Assert.Equal(Tuple.Create("date-month", "2"), (dr.DateOfDeathDatePartAbsent[1]));
-            //Assert.Equal(Tuple.Create("day-absent-reason", "asked-unknown"), (dr.DateOfDeathDatePartAbsent[2]));
-
+            DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
+            Assert.Equal(2021, (int)dr.DeathYear);
+            Assert.Equal(2, (int)dr.DeathMonth);
+            Assert.Null(dr.DeathDay);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2726,15 +2726,15 @@ namespace VRDR.Tests
         [Fact]
         public void Set_DateOfDeath()
         {
-            SetterDeathRecord.DateOfDeath = "2018-02-19T16:48:06.498822-05:00";
-            Assert.Equal("2018-02-19T16:48:06.498822-05:00", SetterDeathRecord.DateOfDeath);
+            SetterDeathRecord.DateOfDeath = "2018-02-19T16:48:00";
+            Assert.Equal("2018-02-19T16:48:00", SetterDeathRecord.DateOfDeath);
         }
 
         [Fact]
         public void Get_DateOfDeath()
         {
-            Assert.Equal("2019-02-19T16:48:06-05:00", ((DeathRecord)JSONRecords[0]).DateOfDeath);
-            Assert.Equal("2019-02-19T16:48:06-05:00", ((DeathRecord)XMLRecords[0]).DateOfDeath);
+            Assert.Equal("2019-02-19T16:48:00", ((DeathRecord)JSONRecords[0]).DateOfDeath);
+            Assert.Equal("2019-02-19T16:48:00", ((DeathRecord)XMLRecords[0]).DateOfDeath);
         }
 
         [Fact]
@@ -2746,7 +2746,7 @@ namespace VRDR.Tests
             Assert.Equal("02", ije1.DOD_MO);
             Assert.Equal("19", ije1.DOD_DY);
             DeathRecord dr2 = ije1.ToDeathRecord();
-            Assert.Equal("2019-02-19T16:48:06-05:00", dr2.DateOfDeath);
+            Assert.Equal("2019-02-19T16:48:00", dr2.DateOfDeath);
         }
 
         [Fact]

--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -334,13 +334,10 @@ namespace VRDR.Tests
             Assert.Equal("06", ije1.DOB_MO);
             Assert.Equal("02", ije1.DOB_DY);
             DeathRecord dr1 = ije1.ToDeathRecord();
-            Assert.True(dr1.DateOfBirthDatePartAbsent != null);
-
-            Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "unknown"), Tuple.Create("date-month", "6"), Tuple.Create("date-day", "2")};
-            Assert.Equal(datePart[0], dr1.DateOfBirthDatePartAbsent[0]);
-            Assert.Equal(datePart[1], dr1.DateOfBirthDatePartAbsent[1]);
-            Assert.Equal(datePart[2], dr1.DateOfBirthDatePartAbsent[2]);
-            Assert.Equal("0001-06-02", dr1.DateOfBirth);
+            Assert.Null(dr1.BirthYear);
+            Assert.Equal(6, (int)dr1.BirthMonth);
+            Assert.Equal(2, (int)dr1.BirthDay);
+            Assert.Null(dr1.DateOfBirth);
         }
 
         [Fact]
@@ -351,17 +348,10 @@ namespace VRDR.Tests
             Assert.Equal("99", ije1.DOB_MO);
             Assert.Equal("99", ije1.DOB_DY);
             DeathRecord dr1 = ije1.ToDeathRecord();
-            Assert.True(dr1.DateOfBirthDatePartAbsent != null);
-
-            //Tuple<string, string>[] datePart = { Tuple.Create("date-year", "1990"), Tuple.Create("month-absent-reason", "unknown"), Tuple.Create("day-absent-reason", "unknown")};
-            Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "unknown"), Tuple.Create("month-absent-reason", "unknown"), Tuple.Create("day-absent-reason", "unknown")};
-            Assert.Equal(datePart[0], dr1.DateOfBirthDatePartAbsent[0]);
-            Assert.Equal(datePart[1], dr1.DateOfBirthDatePartAbsent[1]);
-            Assert.Equal(datePart[2], dr1.DateOfBirthDatePartAbsent[2]);
-            // TODO we use a built in Date Time to format DateOfBirth so we cannot pass in 99 for month of day
-            // the default set day and month to 01 so if there are unknowns, this field becomes invalid
-            // either remove it or remove the validation and allow 99 for day and month
-            //Assert.Equal("1999-09-99", dr1.DateOfBirth);
+            Assert.Null(dr1.BirthYear);
+            Assert.Null(dr1.BirthMonth);
+            Assert.Null(dr1.BirthDay);
+            Assert.Null(dr1.DateOfBirth);
         }
 
         [Fact]

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -311,21 +311,31 @@
         "_birthDate": {
           "extension": [
             {
-              "url":"http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason",
-              "extension" : [
+              "extension": [
                 {
-                  "url" : "year-absent-reason",
-                  "valueCode" : "asked-unknown"
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                      "valueCode": "unknown"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"
                 },
                 {
-                  "url" : "month-absent-reason",
-                  "valueCode" : "asked-unknown"
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                      "valueCode": "unknown"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"
                 },
                 {
-                  "url" : "date-day",
-                  "valueInteger" : 24
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                  "valueUnsignedInt": 24
                 }
-              ]
+              ],
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDateTime"
             }
           ]
         },
@@ -1582,21 +1592,35 @@
         "_valueDateTime": {
           "extension": [
             {
-              "url":"http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason",
-              "extension" : [
+              "extension": [
                 {
-                  "url" : "date-year",
-                  "valueInteger" : 2021
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                  "valueUnsignedInt": 2021
                 },
                 {
-                  "url" : "date-month",
-                  "valueInteger" : 2
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                  "valueUnsignedInt": 2
                 },
                 {
-                  "url" : "day-absent-reason",
-                  "valueCode" : "asked-unknown"
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                      "valueCode": "unknown"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                      "valueCode": "unknown"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time"
                 }
-              ]
+              ],
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDateTime"
             }
           ]
         },

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -652,8 +652,8 @@ namespace VRDR
             }
             else
             {
-                Tuple<string, string>[] datePart = { Tuple.Create("year-absent-reason", "asked-unknown"), Tuple.Create("date-month", "02"), Tuple.Create("date-day", "24")};
-                record.DateOfBirthDatePartAbsent = datePart;
+                record.BirthMonth = 2;
+                record.BirthDay = 24;
                 Dictionary<string, string> addressB = new Dictionary<string, string>();
                 addressB.Add("addressCountry", "AS");  // This is an abomination
                 addressB.Add("addressState", "");

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -2507,73 +2507,25 @@ namespace VRDR
         {
             get
             {
-                return GetFirstString("Bundle.entry.resource.where($this is Patient).birthDate");
-            }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
+                // We support this legacy API entrypoint via the new partial date entrypoints
+                if (BirthYear != null && BirthMonth != null && BirthDay != null)
                 {
-                    return;
-                }
-                if (Decedent.BirthDateElement == null){
-                    Decedent.BirthDateElement = new Date();
-                }
-                Decedent.BirthDateElement.Value = value.Trim();
-            }
-        }
-
-
-        /// <summary>Decedent's Date of Birth Date Part Absent Extension.</summary>
-        /// <value>the decedent's date of birth date part absent reason</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.DateOfBirthDatePartReason = "1940-02-19";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent Date of Birth Date Part Reason: {ExampleDeathRecord.DateOfBirthDatePartAbsent}");</para>
-        /// </example>
-        [Property("Date Of Birth Date Part Absent", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Date of Birth Date Part.", true, IGURL.Decedent, true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "_birthDate")]
-        public Tuple<string,string>[] DateOfBirthDatePartAbsent
-        {
-            get
-            {
-                if (Decedent.BirthDateElement != null){
-                    Extension datePartAbsent = Decedent.BirthDateElement.Extension.Where(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason").FirstOrDefault();
-                    return DatePartsToArray(datePartAbsent);
+                    Date result = new Date((int)BirthYear, (int)BirthMonth, (int)BirthDay);
+                    return result.ToString();
                 }
                 return null;
             }
             set
             {
-                if (value != null && value.Length > 0)
+                // We support this legacy API entrypoint via the new partial date entrypoints
+                DateTimeOffset parsedDate;
+                if (DateTimeOffset.TryParse(value, out parsedDate))
                 {
-                    if (Decedent.BirthDateElement != null){
-                        // Clear the previous date part absent and rebuild with the new data
-                        Decedent.BirthDateElement.Extension.RemoveAll(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason");
-                    }
-
-                    Extension datePart = new Extension();
-                    datePart.Url = "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Partial-date-part-absent-reason";
-                    foreach (Tuple<string, string> element in value)
-                    {
-                        if (element != null)
-                        {
-                            Extension datePartDetails = new Extension();
-                            datePartDetails.Url = element.Item1;
-                            datePartDetails.Value = DatePartToIntegerOrCode(element);
-                            datePart.Extension.Add(datePartDetails);
-                        }
-
-                    }
-                    if (Decedent.BirthDateElement == null){
-                        Decedent.BirthDateElement = new Date();
-                    }
-                    Decedent.BirthDateElement.Extension.Add(datePart);
-
+                    BirthYear = (uint?)parsedDate.Year;
+                    BirthMonth = (uint?)parsedDate.Month;
+                    BirthDay = (uint?)parsedDate.Day;
                 }
-
             }
-
         }
 
         /// <summary>Decedent's Residence.</summary>
@@ -5812,28 +5764,25 @@ namespace VRDR
             get
             {
                 // We support this legacy API entrypoint via the new partial date and time entrypoints
-                uint? year = DeathYear;
-                uint? month = DeathMonth;
-                uint? day = DeathDay;
-                string time = DeathTime;
-                if (year != null && month != null && day != null && time != null)
+                if (DeathYear != null && DeathMonth != null && DeathDay != null && DeathTime != null)
                 {
                     DateTimeOffset parsedTime;
-                    if (DateTimeOffset.TryParse(time, out parsedTime))
+                    if (DateTimeOffset.TryParse(DeathTime, out parsedTime))
                     {
-                        DateTimeOffset result = new DateTimeOffset((int)year, (int)month, (int)day, parsedTime.Hour, parsedTime.Minute, parsedTime.Second, TimeSpan.Zero);
+                        DateTimeOffset result = new DateTimeOffset((int)DeathYear, (int)DeathMonth, (int)DeathDay, parsedTime.Hour, parsedTime.Minute, parsedTime.Second, TimeSpan.Zero);
                         return result.ToString("s");
                     }
                 }
-                else if (year != null && month != null && day != null)
+                else if (DeathYear != null && DeathMonth != null && DeathDay != null)
                 {
-                    DateTime result = new DateTime((int)year, (int)month, (int)day);
+                    DateTime result = new DateTime((int)DeathYear, (int)DeathMonth, (int)DeathDay);
                     return result.ToString("s");
                 }
                 return null;
             }
             set
             {
+                // We support this legacy API entrypoint via the new partial date and time entrypoints
                 DateTimeOffset parsedTime;
                 if (DateTimeOffset.TryParse(value, out parsedTime))
                 {

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5616,10 +5616,14 @@ namespace VRDR
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
             if (value is FhirDateTime && ((FhirDateTime)value).Value != null)
             {
-                // TODO: This converts to UTC which is bad... we actually want to keep the originally specified time zone!
-                DateTimeOffset dateTimeOffset = ((FhirDateTime)value).ToDateTimeOffset(TimeSpan.Zero);
-                TimeSpan timeSpan = new TimeSpan(0, dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second);
-                return timeSpan.ToString(@"hh\:mm");
+                // Using FhirDateTime's ToDateTimeOffset doesn't keep the time in the original time zone, so we parse the string representation
+                DateTime dateTime;
+                if (DateTime.TryParse(((FhirDateTime)value).ToString(), out dateTime))
+                {
+                    TimeSpan timeSpan = new TimeSpan(0, dateTime.Hour, dateTime.Minute, dateTime.Second);
+                    return timeSpan.ToString(@"hh\:mm");
+                }
+                return null;
             }
             return GetPartialTime(value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime));
         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5616,7 +5616,8 @@ namespace VRDR
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
             if (value is FhirDateTime && ((FhirDateTime)value).Value != null)
             {
-                DateTimeOffset dateTimeOffset = ((FhirDateTime)value).ToDateTimeOffset(new TimeSpan());
+                // TODO: This converts to UTC which is bad... we actually want to keep the originally specified time zone!
+                DateTimeOffset dateTimeOffset = ((FhirDateTime)value).ToDateTimeOffset(TimeSpan.Zero);
                 TimeSpan timeSpan = new TimeSpan(0, dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second);
                 return timeSpan.ToString(@"hh\:mm");
             }
@@ -5739,14 +5740,14 @@ namespace VRDR
                     DateTimeOffset parsedTime;
                     if (DateTimeOffset.TryParse(time, out parsedTime))
                     {
-                        DateTime result = new DateTime((int)year, (int)month, (int)day, parsedTime.Hour, parsedTime.Minute, parsedTime.Second);
-                        return result.ToString();
+                        DateTimeOffset result = new DateTimeOffset((int)year, (int)month, (int)day, parsedTime.Hour, parsedTime.Minute, parsedTime.Second, TimeSpan.Zero);
+                        return result.ToString("s");
                     }
                 }
                 else if (year != null && month != null && day != null)
                 {
                     DateTime result = new DateTime((int)year, (int)month, (int)day);
-                    return result.ToString();
+                    return result.ToString("s");
                 }
                 return null;
             }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -2424,6 +2424,75 @@ namespace VRDR
             }
         }
 
+        private void AddBirthDateToDecedent()
+        {
+            Decedent.BirthDateElement = new Date();
+            Decedent.BirthDateElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+        }
+
+        /// <summary>TODO: ADD A SUMMARY</summary>
+        public uint? BirthYear
+        {
+            get
+            {
+                if (Decedent.BirthDateElement != null)
+                {
+                    return GetDateFragmentOrPartialDate(Decedent.BirthDateElement, ExtensionURL.DateYear);
+                }
+                return null;
+            }
+            set
+            {
+                if (Decedent.BirthDateElement == null)
+                {
+                    AddBirthDateToDecedent();
+                }
+                SetPartialDate(Decedent.BirthDateElement.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateYear, value);
+            }
+        }
+
+        /// <summary>TODO: ADD A SUMMARY</summary>
+        public uint? BirthMonth
+        {
+            get
+            {
+                if (Decedent.BirthDateElement != null)
+                {
+                    return GetDateFragmentOrPartialDate(Decedent.BirthDateElement, ExtensionURL.DateMonth);
+                }
+                return null;
+            }
+            set
+            {
+                if (Decedent.BirthDateElement == null)
+                {
+                    AddBirthDateToDecedent();
+                }
+                SetPartialDate(Decedent.BirthDateElement.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateMonth, value);
+            }
+        }
+
+        /// <summary>TODO: ADD A SUMMARY</summary>
+        public uint? BirthDay
+        {
+            get
+            {
+                if (Decedent.BirthDateElement != null)
+                {
+                    return GetDateFragmentOrPartialDate(Decedent.BirthDateElement, ExtensionURL.DateDay);
+                }
+                return null;
+            }
+            set
+            {
+                if (Decedent.BirthDateElement == null)
+                {
+                    AddBirthDateToDecedent();
+                }
+                SetPartialDate(Decedent.BirthDateElement.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateDay, value);
+            }
+        }
+
         /// <summary>Decedent's Date of Birth.</summary>
         /// <value>the decedent's date of birth</value>
         /// <example>
@@ -5527,7 +5596,7 @@ namespace VRDR
         // These are (incomplete and untested) getter and setter helpers for anything that uses a PartialDateTime, allowing a caller to get or
         // set a particular field on the extension; they currently assume that the extension and the sub-parts are always present; see notes above
         // DeathYear method just below for some details on thought process
-        // TODO: Also need methods to get and set the time bits
+        // TODO: Documentation
         private uint? GetPartialDate(Extension partialDateTime, string partURL)
         {
             Extension part = partialDateTime.Extension.Find(ext => ext.Url == partURL);
@@ -5593,9 +5662,17 @@ namespace VRDR
         private uint? GetDateFragmentOrPartialDate(Element value, string partURL)
         {
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
+            DateTimeOffset dateTimeOffset;
             if (value is FhirDateTime && ((FhirDateTime)value).Value != null)
             {
-                DateTimeOffset dateTimeOffset = ((FhirDateTime)value).ToDateTimeOffset(TimeSpan.Zero);
+                dateTimeOffset = ((FhirDateTime)value).ToDateTimeOffset(TimeSpan.Zero);
+            }
+            else if (value is Date && ((Date)value).Value != null)
+            {
+                dateTimeOffset = (DateTimeOffset)((Date)value).ToDateTimeOffset();
+            }
+            if (dateTimeOffset != null)
+            {
                 switch(partURL)
                 {
                     case ExtensionURL.DateYear:

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5662,25 +5662,25 @@ namespace VRDR
         private uint? GetDateFragmentOrPartialDate(Element value, string partURL)
         {
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
-            DateTimeOffset dateTimeOffset;
+            DateTimeOffset? dateTimeOffset = null;
             if (value is FhirDateTime && ((FhirDateTime)value).Value != null)
             {
                 dateTimeOffset = ((FhirDateTime)value).ToDateTimeOffset(TimeSpan.Zero);
             }
             else if (value is Date && ((Date)value).Value != null)
             {
-                dateTimeOffset = (DateTimeOffset)((Date)value).ToDateTimeOffset();
+                dateTimeOffset = ((Date)value).ToDateTimeOffset();
             }
             if (dateTimeOffset != null)
             {
                 switch(partURL)
                 {
                     case ExtensionURL.DateYear:
-                        return (uint?)dateTimeOffset.Year;
+                        return (uint?)((DateTimeOffset)dateTimeOffset).Year;
                     case ExtensionURL.DateMonth:
-                        return (uint?)dateTimeOffset.Month;
+                        return (uint?)((DateTimeOffset)dateTimeOffset).Month;
                     case ExtensionURL.DateDay:
-                        return (uint?)dateTimeOffset.Day;
+                        return (uint?)((DateTimeOffset)dateTimeOffset).Day;
                     default:
                         throw new ArgumentException("GetDateFragmentOrPartialDate called with unsupported PartialDateTime segment");
                 }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -2430,7 +2430,16 @@ namespace VRDR
             Decedent.BirthDateElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
         }
 
-        /// <summary>TODO: ADD A SUMMARY</summary>
+        /// <summary>Decedent's Year of Birth.</summary>
+        /// <value>the decedent's year of birth</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.BirthYear = 1928;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Year of Birth: {ExampleDeathRecord.BirthYear}");</para>
+        /// </example>
+        [Property("BirthYear", Property.Types.Number, "Decedent Demographics", "Decedent's Year of Birth.", true, IGURL.Decedent, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "birthDate")]
         public uint? BirthYear
         {
             get
@@ -2451,7 +2460,16 @@ namespace VRDR
             }
         }
 
-        /// <summary>TODO: ADD A SUMMARY</summary>
+        /// <summary>Decedent's Month of Birth.</summary>
+        /// <value>the decedent's month of birth</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.BirthMonth = 11;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Month of Birth: {ExampleDeathRecord.BirthMonth}");</para>
+        /// </example>
+        [Property("BirthMonth", Property.Types.Number, "Decedent Demographics", "Decedent's Month of Birth.", true, IGURL.Decedent, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "birthDate")]
         public uint? BirthMonth
         {
             get
@@ -2472,7 +2490,16 @@ namespace VRDR
             }
         }
 
-        /// <summary>TODO: ADD A SUMMARY</summary>
+        /// <summary>Decedent's Day of Birth.</summary>
+        /// <value>the decedent's dau of birth</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.BirthDay = 11;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Day of Birth: {ExampleDeathRecord.BirthDay}");</para>
+        /// </example>
+        [Property("BirthDay", Property.Types.Number, "Decedent Demographics", "Decedent's Day of Birth.", true, IGURL.Decedent, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "birthDate")]
         public uint? BirthDay
         {
             get
@@ -5545,10 +5572,7 @@ namespace VRDR
         //     }
         // }
 
-        // These are (incomplete and untested) getter and setter helpers for anything that uses a PartialDateTime, allowing a caller to get or
-        // set a particular field on the extension; they currently assume that the extension and the sub-parts are always present; see notes above
-        // DeathYear method just below for some details on thought process
-        // TODO: Documentation
+        /// <summary>Getter helper for anything that uses PartialDateTime, allowing a particular date field (year, month, or day) to be read from the extension</summary>
         private uint? GetPartialDate(Extension partialDateTime, string partURL)
         {
             if (partialDateTime != null)
@@ -5568,6 +5592,7 @@ namespace VRDR
             return null;
         }
 
+        /// <summary>Setter helper for anything that uses PartialDateTime, allowing a particular date field (year, month, or day) to be set in the extension</summary>
         private void SetPartialDate(Extension partialDateTime, string partURL, uint? value)
         {
             Extension part = partialDateTime.Extension.Find(ext => ext.Url == partURL);
@@ -5583,6 +5608,7 @@ namespace VRDR
             }
         }
 
+        /// <summary>Getter helper for anything that uses PartialDateTime, allowing the time to be read from the extension</summary>
         private string GetPartialTime(Extension partialDateTime)
         {
             if (partialDateTime != null)
@@ -5602,6 +5628,7 @@ namespace VRDR
             return null;
         }
 
+        /// <summary>Setter helper for anything that uses PartialDateTime, allowing the time to be set in the extension</summary>
         private void SetPartialTime(Extension partialDateTime, String value)
         {
             Extension part = partialDateTime.Extension.Find(ext => ext.Url == ExtensionURL.DateTime);
@@ -5617,6 +5644,8 @@ namespace VRDR
             }
         }
 
+        /// <summary>Getter helper for anything that can have a regular FHIR date/time or a PartialDateTime extension, allowing a particular date
+        /// field (year, month, or day) to be read from either the value or the extension</summary>
         private uint? GetDateFragmentOrPartialDate(Element value, string partURL)
         {
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
@@ -5646,6 +5675,8 @@ namespace VRDR
             return GetPartialDate(value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), partURL);
         }
 
+        /// <summary>Getter helper for anything that can have a regular FHIR date/time or a PartialDateTime extension, allowing the time to be read
+        /// from either the value or the extension</summary>
         private string GetTimeFragmentOrPartialTime(Element value)
         {
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
@@ -5663,13 +5694,21 @@ namespace VRDR
             return GetPartialTime(value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime));
         }
 
-        // TODO: The idea here is that we have getters and setters for each of the parts of the death datetime, which get used in IJEMortality.cs
+        // The idea here is that we have getters and setters for each of the parts of the death datetime, which get used in IJEMortality.cs
         // These getters and setters 1) use the DeathDateObs Observation 2) get and set values on the PartialDateTime extension using helpers that
         // can be reused across year, month, etc. 3) interpret null as data being absent, and so set the data absent reason if value is null 4) when
         // getting, look also in the valueDateTime and return the year from there if it happens to be set (but never bother to set it ourselves)
-        // TODO: Add a summary and Property and FHIRPath
-        // TODO: Add DeathMonth, DeathDay, etc.
-        /// <summary>TODO: ADD A SUMMARY</summary>
+
+        /// <summary>Decedent's Year of Death.</summary>
+        /// <value>the decedent's year of death</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.DeathYear = 2018;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Year of Death: {ExampleDeathRecord.DeathYear}");</para>
+        /// </example>
+        [Property("DeathYear", Property.Types.Number, "Death Investigation", "Decedent's Year of Death.", true, IGURL.DeathDate, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
         public uint? DeathYear
         {
             get
@@ -5691,7 +5730,16 @@ namespace VRDR
             }
         }
 
-        /// <summary>TODO: ADD A SUMMARY</summary>
+        /// <summary>Decedent's Month of Death.</summary>
+        /// <value>the decedent's month of death</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.DeathMonth = 6;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Month of Death: {ExampleDeathRecord.DeathMonth}");</para>
+        /// </example>
+        [Property("DeathMonth", Property.Types.Number, "Death Investigation", "Decedent's Month of Death.", true, IGURL.DeathDate, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
         public uint? DeathMonth
         {
             get
@@ -5712,7 +5760,16 @@ namespace VRDR
             }
         }
 
-        /// <summary>TODO: ADD A SUMMARY</summary>
+        /// <summary>Decedent's Day of Death.</summary>
+        /// <value>the decedent's day of death</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.DeathDay = 16;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Day of Death: {ExampleDeathRecord.DeathDay}");</para>
+        /// </example>
+        [Property("DeathDay", Property.Types.Number, "Death Investigation", "Decedent's Day of Death.", true, IGURL.DeathDate, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
         public uint? DeathDay
         {
             get
@@ -5733,7 +5790,16 @@ namespace VRDR
             }
         }
 
-        /// <summary>TODO: ADD A SUMMARY</summary>
+        /// <summary>Decedent's Time of Death.</summary>
+        /// <value>the decedent's time of death</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.DeathTime = "07:15";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Time of Death: {ExampleDeathRecord.DeathTime}");</para>
+        /// </example>
+        [Property("DeathTime", Property.Types.String, "Death Investigation", "Decedent's Time of Death.", true, IGURL.DeathDate, true, 25)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
         public string DeathTime
         {
             get
@@ -5762,7 +5828,6 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Date of Death: {ExampleDeathRecord.DateOfDeath}");</para>
         /// </example>
-        // TODO: We'll want to keep and rewrite this as a helper that uses the other methods for setting and getting the date
         [Property("Date/Time Of Death", Property.Types.StringDateTime, "Death Investigation", "Decedent's Date and Time of Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Date.html", true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
         public string DateOfDeath
@@ -6590,7 +6655,6 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Education Level Edit Flag: {ExampleDeathRecord.EducationLevelEditFlag['display']}");</para>
         /// </example>
-        // TODO: This URL should be the html one, and those should be generated as well
         [Property("Decedent's Pregnancy Status at Death Edit Flag", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Decedent's Pregnancy Status at Death Edit Flag.", true, IGURL.DecedentPregnancyStatus, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
@@ -6917,7 +6981,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Injury Location Description: {ExampleDeathRecord.InjuryLocationDescription}");</para>
         /// </example>
         [Property("Injury Location Description", Property.Types.String, "Death Investigation", "Description of Injury Location.", true, IGURL.InjuryLocation, true, 36)]
-        [ FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile=ProfileURL.InjuryLocation)", "description")]
+        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile=ProfileURL.InjuryLocation)", "description")]
         public string InjuryLocationDescription
         {
             get
@@ -7339,7 +7403,7 @@ namespace VRDR
                     EmergingIssues = new Observation();
                     EmergingIssues.Id = Guid.NewGuid().ToString();
                     EmergingIssues.Meta = new Meta();
-                    string[] tb_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues" /* ProfileURL.EmergingIssues */ };
+                    string[] tb_profile = { ProfileURL.EmergingIssues };
                     EmergingIssues.Meta.Profile = tb_profile;
                     EmergingIssues.Status = ObservationStatus.Final;
                     EmergingIssues.Code = new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observation-cs", "emergingissues", "Emerging Issues", null);
@@ -8787,7 +8851,9 @@ namespace VRDR
             /// <summary>Parameter is an array of Tuples.</summary>
             TupleArr,
             /// <summary>Parameter is an array of Tuples, specifically for CausesOfDeath.</summary>
-            TupleCOD
+            TupleCOD,
+            /// <summary>Parameter is a number.</summary>
+            Number
         };
 
         /// <summary>Name of this property.</summary>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5551,16 +5551,19 @@ namespace VRDR
         // TODO: Documentation
         private uint? GetPartialDate(Extension partialDateTime, string partURL)
         {
-            Extension part = partialDateTime.Extension.Find(ext => ext.Url == partURL);
-            if (part != null)
+            if (partialDateTime != null)
             {
-                Extension dataAbsent = part.Extension.Find(ext => ext.Url == "http://hl7.org/fhir/StructureDefinition/data-absent-reason");
-                if (dataAbsent != null || part.Value == null)
+                Extension part = partialDateTime.Extension.Find(ext => ext.Url == partURL);
+                if (part != null)
                 {
-                    // There's either a specific claim that there's no data or actually no data, so return null
-                    return null;
+                    Extension dataAbsent = part.Extension.Find(ext => ext.Url == "http://hl7.org/fhir/StructureDefinition/data-absent-reason");
+                    if (dataAbsent != null || part.Value == null)
+                    {
+                        // There's either a specific claim that there's no data or actually no data, so return null
+                        return null;
+                    }
+                    return (uint?)((UnsignedInt)part.Value).Value; // Untangle a FHIR UnsignedInt in an extension into a uint
                 }
-                return (uint?)((UnsignedInt)part.Value).Value; // Untangle a FHIR UnsignedInt in an extension into a uint
             }
             return null;
         }
@@ -5582,16 +5585,19 @@ namespace VRDR
 
         private string GetPartialTime(Extension partialDateTime)
         {
-            Extension part = partialDateTime.Extension.Find(ext => ext.Url == ExtensionURL.DateTime);
-            if (part != null)
+            if (partialDateTime != null)
             {
-                Extension dataAbsent = part.Extension.Find(ext => ext.Url == "http://hl7.org/fhir/StructureDefinition/data-absent-reason");
-                if (dataAbsent != null || part.Value == null)
+                Extension part = partialDateTime.Extension.Find(ext => ext.Url == ExtensionURL.DateTime);
+                if (part != null)
                 {
-                    // There's either a specific claim that there's no data or actually no data, so return null
-                    return null;
+                    Extension dataAbsent = part.Extension.Find(ext => ext.Url == "http://hl7.org/fhir/StructureDefinition/data-absent-reason");
+                    if (dataAbsent != null || part.Value == null)
+                    {
+                        // There's either a specific claim that there's no data or actually no data, so return null
+                        return null;
+                    }
+                    return part.Value.ToString();
                 }
-                return part.Value.ToString();
             }
             return null;
         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5644,6 +5644,10 @@ namespace VRDR
             }
             set
             {
+                if (DeathDateObs == null)
+                {
+                    CreateDeathDateObs();
+                }
                 SetPartialDate(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateYear, value);
             }
         }
@@ -5661,6 +5665,10 @@ namespace VRDR
             }
             set
             {
+                if (DeathDateObs == null)
+                {
+                    CreateDeathDateObs();
+                }
                 SetPartialDate(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateMonth, value);
             }
         }
@@ -5677,6 +5685,10 @@ namespace VRDR
             }
             set
             {
+                if (DeathDateObs == null)
+                {
+                    CreateDeathDateObs();
+                }
                 SetPartialDate(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateDay, value);
             }
         }
@@ -5693,6 +5705,10 @@ namespace VRDR
             }
             set
             {
+                if (DeathDateObs == null)
+                {
+                    CreateDeathDateObs();
+                }
                 SetPartialTime(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), value);
             }
         }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -290,25 +290,6 @@ namespace VRDR
             }
         }
 
-        /// <summary>Get the date part value from DateOfBirthDatePartAbsent if it's populated</summary>
-        private string BirthDate_Part_Absent_Get(string ijeFieldName, string dateType, string dateAbsentType)
-        {
-            IJEField info = FieldInfo(ijeFieldName);
-            Tuple<string, string>[] dpa = this.record?.DateOfBirthDatePartAbsent;
-            if (dpa != null) {
-                List<Tuple<string, string>> dateParts = dpa.ToList();
-                Tuple<string, string> datePart = dateParts.Find(x => x.Item1 == dateType);
-                if (datePart != null){
-                    return datePart.Item2.PadLeft(info.Length, '0');
-                }
-                Tuple<string, string> datePartAbsent = dateParts.Find(x => x.Item1 == dateAbsentType);
-                if (datePartAbsent != null){
-                    return string.Concat(Enumerable.Repeat("9", info.Length));
-                }
-            }
-            return "";
-        }
-
         /// <summary>Set a value on the DeathRecord whose type is some part of a DateTime.</summary>
         private void DateTime_Set(string ijeFieldName, string dateTimeType, string fhirFieldName, string value, bool dateOnly = false, bool withTimezoneOffset = false)
         {

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -390,7 +390,7 @@ namespace VRDR
             else
             {
                 DateTimeOffset parsedTime;
-                if (DateTimeOffset.TryParseExact(value, "hhmm", null, DateTimeStyles.None, out parsedTime))
+                if (DateTimeOffset.TryParseExact(value, "HHmm", null, DateTimeStyles.None, out parsedTime))
                 {
                     TimeSpan timeSpan = new TimeSpan(0, parsedTime.Hour, parsedTime.Minute, 0);
                     typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, timeSpan.ToString(@"hh\:mm"));
@@ -1341,7 +1341,7 @@ namespace VRDR
             }
         }
 
-        /// <summary>Marital Status--Edit Flag</summary>
+        /// <summary>Place of Death</summary>
         [IJEField(31, 232, 1, "Place of Death", "DPLACE", 1)]
         public string DPLACE
         {

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -1076,31 +1076,11 @@ namespace VRDR
         {
             get
             {
-                String yearPart = BirthDate_Part_Absent_Get("DOB_YR", "date-year", "year-absent-reason");
-                if (!String.IsNullOrWhiteSpace(yearPart))
-                {
-                    return yearPart;
-                }
-                return DateTime_Get("DOB_YR", "yyyy", "DateOfBirth");
+                return NumericAllowingUnknown_Get("DOB_YR", "BirthYear");
             }
             set
             {
-                // if unknown, set the date part absent
-                if (String.IsNullOrWhiteSpace(value) || String.Equals(value, "9999"))
-                {
-                    List<Tuple<string, string>> dateParts = new List<Tuple<string, string>>();
-                    if (record.DateOfBirthDatePartAbsent != null){
-                        dateParts = record.DateOfBirthDatePartAbsent.ToList();
-                    }
-                    dateParts.Add(Tuple.Create("year-absent-reason", "unknown"));
-                    record.DateOfBirthDatePartAbsent = dateParts.ToList().ToArray();
-                } else
-                {
-                    // we will still set this for now so we can reference the value to
-                    // populate the Date Part Absent field
-                    // In FHIR we will just ignore this
-                    DateTime_Set("DOB_YR", "yyyy", "DateOfBirth", value, true);
-                }
+                NumericAllowingUnknown_Set("DOB_YR", "BirthYear", value);
             }
         }
 
@@ -1110,28 +1090,11 @@ namespace VRDR
         {
             get
             {
-                String monthPart = BirthDate_Part_Absent_Get("DOB_MO", "date-month", "month-absent-reason");
-                if (!String.IsNullOrWhiteSpace(monthPart))
-                {
-                    return monthPart;
-                }
-                return DateTime_Get("DOB_MO", "MM", "DateOfBirth");
+                return NumericAllowingUnknown_Get("DOB_MO", "BirthMonth");
             }
             set
             {
-                // if unknown, set the date part absent
-                if (String.IsNullOrWhiteSpace(value) || String.Equals(value, "99"))
-                {
-                    List<Tuple<string, string>> dateParts = new List<Tuple<string, string>>();
-                    if (record.DateOfBirthDatePartAbsent != null){
-                        dateParts = record.DateOfBirthDatePartAbsent.ToList();
-                    }
-                    dateParts.Add(Tuple.Create("month-absent-reason", "unknown"));
-                    record.DateOfBirthDatePartAbsent = dateParts.ToList().ToArray();
-                } else
-                {
-                    DateTime_Set("DOB_MO", "MM", "DateOfBirth", value, true);
-                }
+                NumericAllowingUnknown_Set("DOB_MO", "BirthMonth", value);
             }
         }
 
@@ -1141,59 +1104,11 @@ namespace VRDR
         {
             get
             {
-                String dayPart = BirthDate_Part_Absent_Get("DOB_DY", "date-day", "day-absent-reason");
-                if (!String.IsNullOrWhiteSpace(dayPart)){
-                    return dayPart;
-                }
-                return DateTime_Get("DOB_DY", "dd", "DateOfBirth");
-
+                return NumericAllowingUnknown_Get("DOB_DY", "BirthDay");
             }
             set
             {
-                if (String.Equals(DOB_YR, "9999") || String.Equals(DOB_MO, "99") || String.Equals(value, "99") || String.IsNullOrWhiteSpace(value))
-                {
-                    List<Tuple<string, string>> dateParts = record.DateOfBirthDatePartAbsent.ToList();
-                    switch (value)
-                    {
-                        case "99":
-                            dateParts.Add(Tuple.Create("day-absent-reason", "unknown"));
-                            dateParts.RemoveAll(x => x.Item1 == "date-day");
-                            break;
-                        default:
-                            DateTime_Set("DOB_DY", "dd", "DateOfBirth", value, true);
-                            dateParts.Add(Tuple.Create("date-day", value));
-                            dateParts.RemoveAll(x => x.Item1 == "day-absent-reason");
-                            break;
-                    }
-                    switch (DOB_MO)
-                    {
-                        case "99":
-                            dateParts.RemoveAll(x => x.Item1 == "date-month");
-                            break;
-                        default:
-                            dateParts.Add(Tuple.Create("date-month", DOB_MO));
-                            dateParts.RemoveAll(x => x.Item1 == "month-absent-reason");
-                            break;
-                    }
-                    switch (DOB_YR)
-                    {
-                        case "9999":
-                            dateParts.RemoveAll(x => x.Item1 == "date-year");
-                            break;
-                        default:
-                            dateParts.Add(Tuple.Create("date-year", DOB_YR));
-                            dateParts.RemoveAll(x => x.Item1 == "year-absent-reason");
-                            break;
-                    }
-                    // TODO: DOB fields will all be reworked
-                    // record.DateOfBirthDatePartAbsent = dateParts.ToList().ToArray();
-                    // TODO should we set DateOfBirth to null because it will have default values for the unknown date parts?
-                    // record.DateOfBirth = "";
-                }
-                else
-                {
-                    DateTime_Set("DOB_DY", "dd", "DateOfBirth", value, true);
-                }
+                NumericAllowingUnknown_Set("DOB_DY", "BirthDay", value);
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -331,14 +331,15 @@ namespace VRDR
         private string NumericAllowingUnknown_Get(string ijeFieldName, string fhirFieldName)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            string current = Convert.ToString(typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record));
-            if (current != null)
+            uint? value = (uint?)typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
+            if (value != null)
             {
-                if (current.Length != info.Length)
+                string valueString = Convert.ToString(value);
+                if (valueString.Length > info.Length)
                 {
-                    validationErrors.Add($"Error: FHIR field {fhirFieldName} containst string '{current}' that's not the expected length for IJE field {ijeFieldName} of length {info.Length}");
+                    validationErrors.Add($"Error: FHIR field {fhirFieldName} contains string '{valueString}' that's not the expected length for IJE field {ijeFieldName} of length {info.Length}");
                 }
-                return Truncate(current, info.Length).PadLeft(info.Length, ' ');
+                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
             }
             else
             {
@@ -356,7 +357,7 @@ namespace VRDR
             }
             else
             {
-                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, value);
+                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, Convert.ToUInt32(value));
             }
         }
 
@@ -391,7 +392,7 @@ namespace VRDR
             {
                 if (current.Length > info.Length)
                 {
-                    validationErrors.Add($"Error: FHIR field {fhirFieldName} containst string '{current}' too long for IJE field {ijeFieldName} of length {info.Length}");
+                    validationErrors.Add($"Error: FHIR field {fhirFieldName} contains string '{current}' too long for IJE field {ijeFieldName} of length {info.Length}");
                 }
                 return Truncate(current, info.Length).PadRight(info.Length, ' ');
             }
@@ -706,7 +707,6 @@ namespace VRDR
         [IJEField(1, 1, 4, "Date of Death--Year", "DOD_YR", 1)]
         public string DOD_YR
         {
-            // REFER TO UPDATES IN DOB_XX FOR IGv1.3
             get
             {
                 return NumericAllowingUnknown_Get("DOD_YR", "DeathYear");
@@ -1148,7 +1148,8 @@ namespace VRDR
                             dateParts.RemoveAll(x => x.Item1 == "year-absent-reason");
                             break;
                     }
-                    record.DateOfBirthDatePartAbsent = dateParts.ToList().ToArray();
+                    // TODO: DOB fields will all be reworked
+                    // record.DateOfBirthDatePartAbsent = dateParts.ToList().ToArray();
                     // TODO should we set DateOfBirth to null because it will have default values for the unknown date parts?
                     // record.DateOfBirth = "";
                 }
@@ -1352,95 +1353,27 @@ namespace VRDR
         [IJEField(34, 237, 2, "Date of Death--Month", "DOD_MO", 1)]
         public string DOD_MO
         {
-            // REFER TO UPDATES IN DOB_XX FOR IGv1.3
             get
             {
-                
-                //String monthPart = DeathDate_Part_Absent_Get("DOD_MO", "date-month", "month-absent-reason");
-                //if (!String.IsNullOrWhiteSpace(monthPart)){
-                //    return monthPart;
-                //}
-                //return DateTime_Get("DOD_MO", "MM", "DateOfDeath");
-                // TODO: Implement this
-                return "";                
+                return NumericAllowingUnknown_Get("DOD_MO", "DeathMonth");
             }
             set
             {
-                // if unknown, create a date part absent
-                //if (String.IsNullOrWhiteSpace(value) || String.Equals(value, "99"))
-                //{
-                //    List<Tuple<string, string>> dateParts = record.DateOfDeathDatePartAbsent.ToList();
-                //    dateParts.Add(Tuple.Create("month-absent-reason", "unknown"));
-                //    dateParts.RemoveAll(x => x.Item1 == "date-month");
-                //    record.DateOfDeathDatePartAbsent = dateParts.ToList().ToArray();
-                //}
-                //DateTime_Set("DOD_MO", "MM", "DateOfDeath", value, false, true);
-                // TODO: Implement this
+                NumericAllowingUnknown_Set("DOD_MO", "DeathMonth", value);
             }
         }
 
         /// <summary>Date of Death--Day</summary>
         [IJEField(35, 239, 2, "Date of Death--Day", "DOD_DY", 1)]
         public string DOD_DY
-        // REFER TO UPDATES IN DOB_XX FOR IGv1.3
         {
             get
             {
-                //String dayPart = DeathDate_Part_Absent_Get("DOD_DY", "date-day", "day-absent-reason");
-                //if (!String.IsNullOrWhiteSpace(dayPart)){
-                //    return dayPart;
-                //}
-                //return DateTime_Get("DOD_DY", "dd", "DateOfDeath");
-                // TODO: Implement this
-                return "";
+                return NumericAllowingUnknown_Get("DOD_DY", "DeathDay");
             }
             set
             {
-                // Populate the date absent parts if any of the date parts are unknown
-                // Doing all three parts at once in the last date part field
-                // because the other fields hadn't populated the Date Part field yet
-                // and only one would ever get added to the record
-                //if (String.Equals(DOD_YR, "9999") || String.Equals(DOD_MO, "99") || String.Equals(value, "99") || String.IsNullOrWhiteSpace(value))
-                //{
-                //    List<Tuple<string, string>> dateParts = record.DateOfDeathDatePartAbsent.ToList();
-                //    switch (value)
-                //    {
-                //        case "99":
-                //            dateParts.Add(Tuple.Create("day-absent-reason", "unknown"));
-                //            dateParts.RemoveAll(x => x.Item1 == "date-day");
-                //            break;
-                //        default:
-                //            dateParts.Add(Tuple.Create("date-day", value));
-                //            dateParts.RemoveAll(x => x.Item1 == "day-absent-reason");
-                //            break;
-                //    }
-                //    switch (DOD_MO)
-                //    {
-                //        case "99":
-                //            dateParts.RemoveAll(x => x.Item1 == "date-month");
-                //            break;
-                //        default:
-                //            dateParts.Add(Tuple.Create("date-month", DOB_MO));
-                //            dateParts.RemoveAll(x => x.Item1 == "month-absent-reason");
-                //            break;
-                //    }
-                //    switch (DOD_YR)
-                //    {
-                //        case "9999":
-                //            dateParts.RemoveAll(x => x.Item1 == "date-year");
-                //            break;
-                //        default:
-                //            dateParts.Add(Tuple.Create("date-year", DOB_YR));
-                //            dateParts.RemoveAll(x => x.Item1 == "year-absent-reason");
-                //            break;
-                //    }
-                //    record.DateOfDeathDatePartAbsent = dateParts.ToList().ToArray();
-                //}
-                //else
-                //{
-                //    DateTime_Set("DOD_DY", "dd", "DateOfDeath", value, false, true);
-                //}
-                // TODO: Implement this
+                NumericAllowingUnknown_Set("DOD_DY", "DeathDay", value);
             }
         }
 


### PR DESCRIPTION
This pull request

1. Implements a generalized approach for managing the use of PartialDateTime extensions
2. Uses that approach to support date of death and date of birth via new DeathYear, DeathMonth, DeathDay, DeathTime, BirthYear, BirthMonth, and BirthDay properties on a DeathRecord
3. Uses those new properties to provide backwards compatible support for the DateOfDeath and DateOfBirth properties on a DeathRecord
4. Uses those new properties to provide generalized support for the IJE fields DOD_YR, DOD_MO, DOD_DY, TOD, DOB_YR, DOB_MO, and DOB_DY