### PR TITLE
Causes of death

### DIFF
--- a/VRDR.CLI/1.xml
+++ b/VRDR.CLI/1.xml
@@ -594,115 +594,198 @@
   <entry>
     <fullUrl value="urn:uuid:8e4650ca-1d2a-4f73-a551-616fefd3e130" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="8e4650ca-1d2a-4f73-a551-616fefd3e130" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2" />
         </meta>
         <code>
-          <text value="Example Contributing Conditions" />
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69441-4" />
+            <display value="Other significant causes or conditions of death" />
+          </coding>
         </code>
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <asserter>
+        <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </performer>
+        <valueCodeableConcept>
+          <text value="Example Contributing Conditions" />
+        </valueCodeableConcept>
+      </Observation>
     </resource>
   </entry>
   <entry>
     <fullUrl value="urn:uuid:e3328799-6392-4f6b-9db9-556a9b8a88d3" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="e3328799-6392-4f6b-9db9-556a9b8a88d3" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
         <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
+        </subject>
+        <performer>
+          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
+        </performer>
+        <performer>
+          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
+        </performer>
+        <valueCodeableConcept>
           <coding>
             <system value="http://hl7.org/fhir/sid/icd-10" />
             <code value="I21.0" />
             <display value="Acute transmural myocardial infarction of anterior wall" />
           </coding>
           <text value="Rupture of myocardium" />
-        </code>
-        <subject>
-          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
-        </subject>
-        <onsetString value="minutes" />
-        <asserter>
-          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="minutes" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
     </resource>
   </entry>
   <entry>
     <fullUrl value="urn:uuid:5c0a0509-8297-4a53-a0ef-725daaaf9736" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="5c0a0509-8297-4a53-a0ef-725daaaf9736" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
-        <code>
+          <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
+        </subject>
+        <performer>
+          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
+        </performer>
+        <valueCodeableConcept>
           <coding>
             <system value="http://hl7.org/fhir/sid/icd-10" />
             <code value="I21.9" />
             <display value="Acute myocardial infarction, unspecified" />
           </coding>
           <text value="Acute myocardial infarction" />
-        </code>
-        <subject>
-          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
-        </subject>
-        <onsetString value="6 days" />
-        <asserter>
-          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="6 days" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
     </resource>
   </entry>
   <entry>
     <fullUrl value="urn:uuid:826a3c27-c712-4c65-b454-46cc4ca76c99" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="826a3c27-c712-4c65-b454-46cc4ca76c99" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
         <code>
-          <text value="Coronary artery thrombosis" />
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
         </code>
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <onsetString value="5 years" />
-        <asserter>
+        <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </performer>
+        <valueCodeableConcept>
+          <text value="Coronary artery thrombosis" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="5 years" />
+          </valueCodeableConcept>
+        </component>
+
+      </Observation>
     </resource>
   </entry>
   <entry>
     <fullUrl value="urn:uuid:46c9ed22-34f6-4d40-bdfa-9b7d6b3e9da6" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="46c9ed22-34f6-4d40-bdfa-9b7d6b3e9da6" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
         <code>
-          <text value="Atherosclerotic coronary artery disease" />
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
         </code>
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <onsetString value="7 years" />
-        <asserter>
+         <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </performer>
+        <valueCodeableConcept>
+          <text value="Atherosclerotic coronary artery disease" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="7 years" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
     </resource>
   </entry>
   <entry>

--- a/VRDR.CLI/1_wJurisdiction.json
+++ b/VRDR.CLI/1_wJurisdiction.json
@@ -746,35 +746,44 @@
     {
       "fullUrl": "urn:uuid:fc27b07f-99c9-48f8-a229-6eb5d8b598f0",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "fc27b07f-99c9-48f8-a229-6eb5d8b598f0",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Example Contributing Conditions"
         },
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "asserter": {
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69441-4",
+              "display": "Other significant causes or conditions of death]"
+            }
+          ]
         }
       }
     },
     {
       "fullUrl": "urn:uuid:b66d97ea-56b1-4397-8de3-fb989007485b",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "b66d97ea-56b1-4397-8de3-fb989007485b",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/icd-10",
@@ -787,23 +796,31 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "minutes",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }]
       }
     },
     {
       "fullUrl": "urn:uuid:8b7a9ca6-1276-402f-a521-35155234af14",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "8b7a9ca6-1276-402f-a521-35155234af14",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/icd-10",
@@ -816,54 +833,126 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "6 days",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "6 days"
+            }
+          }
+        ]
       }
     },
     {
       "fullUrl": "urn:uuid:bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Coronary artery thrombosis"
         },
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "5 years",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "5 years"
+            }
+          }
+        ]
       }
     },
     {
       "fullUrl": "urn:uuid:223eaadb-5909-458c-bbe5-604c120c3ce9",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "223eaadb-5909-458c-bbe5-604c120c3ce9",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Atherosclerotic coronary artery disease"
         },
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "7 years",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "7 years"
+            }
+          }
+        ]
       }
     },
     {

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -122,12 +122,12 @@ namespace VRDR.CLI
                 // INTERVAL1A
                 deathRecord.INTERVAL1A = "minutes";
 
-                // CODE1A
-                Dictionary<string, string> code1a = new Dictionary<string, string>();
-                code1a.Add("code", "I21.0");
-                code1a.Add("system", "http://hl7.org/fhir/sid/icd-10");
-                code1a.Add("display", "Acute transmural myocardial infarction of anterior wall");
-                deathRecord.CODE1A = code1a;
+                // // CODE1A
+                // Dictionary<string, string> code1a = new Dictionary<string, string>();
+                // code1a.Add("code", "I21.0");
+                // code1a.Add("system", "http://hl7.org/fhir/sid/icd-10");
+                // code1a.Add("display", "Acute transmural myocardial infarction of anterior wall");
+                // deathRecord.CODE1A = code1a;
 
                 // COD1B
                 deathRecord.COD1B = "Acute myocardial infarction";
@@ -135,12 +135,12 @@ namespace VRDR.CLI
                 // INTERVAL1B
                 deathRecord.INTERVAL1B = "6 days";
 
-                // CODE1B
-                Dictionary<string, string> code1b = new Dictionary<string, string>();
-                code1b.Add("code", "I21.9");
-                code1b.Add("system", "http://hl7.org/fhir/sid/icd-10");
-                code1b.Add("display", "Acute myocardial infarction, unspecified");
-                deathRecord.CODE1B = code1b;
+                // // CODE1B
+                // Dictionary<string, string> code1b = new Dictionary<string, string>();
+                // code1b.Add("code", "I21.9");
+                // code1b.Add("system", "http://hl7.org/fhir/sid/icd-10");
+                // code1b.Add("display", "Acute myocardial infarction, unspecified");
+                // deathRecord.CODE1B = code1b;
 
                 // COD1C
                 deathRecord.COD1C = "Coronary artery thrombosis";

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -139,7 +139,7 @@ namespace VRDR.Tests
             Assert.Equal(first.Race, second.Race);
             Assert.Equal(first.COD1A, second.COD1A);
             Assert.Equal(first.INTERVAL1B, second.INTERVAL1B);
-            Assert.Equal(first.CODE1A, second.CODE1A);
+            // Assert.Equal(first.CODE1A, second.CODE1A);
             Assert.Equal(first.CertifierAddress, second.CertifierAddress);
             Assert.Equal(first.CausesOfDeath, second.CausesOfDeath);
         }
@@ -700,29 +700,29 @@ namespace VRDR.Tests
             Assert.Equal("minutes", ((DeathRecord)XMLRecords[0]).INTERVAL1A);
         }
 
-        [Fact]
-        public void Set_CODE1A()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "I21.0");
-            code.Add("system", "http://hl7.org/fhir/sid/icd-10");
-            code.Add("display", "Acute transmural myocardial infarction of anterior wall");
-            SetterDeathRecord.CODE1A = code;
-            Assert.Equal("I21.0", SetterDeathRecord.CODE1A["code"]);
-            Assert.Equal("http://hl7.org/fhir/sid/icd-10", SetterDeathRecord.CODE1A["system"]);
-            Assert.Equal("Acute transmural myocardial infarction of anterior wall", SetterDeathRecord.CODE1A["display"]);
-        }
+        // [Fact]
+        // public void Set_CODE1A()
+        // {
+        //     Dictionary<string, string> code = new Dictionary<string, string>();
+        //     code.Add("code", "I21.0");
+        //     code.Add("system", "http://hl7.org/fhir/sid/icd-10");
+        //     code.Add("display", "Acute transmural myocardial infarction of anterior wall");
+        //     SetterDeathRecord.CODE1A = code;
+        //     Assert.Equal("I21.0", SetterDeathRecord.CODE1A["code"]);
+        //     Assert.Equal("http://hl7.org/fhir/sid/icd-10", SetterDeathRecord.CODE1A["system"]);
+        //     Assert.Equal("Acute transmural myocardial infarction of anterior wall", SetterDeathRecord.CODE1A["display"]);
+        // }
 
-        [Fact]
-        public void Get_CODE1A()
-        {
-            Assert.Equal("I21.0", ((DeathRecord)JSONRecords[0]).CODE1A["code"]);
-            Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)XMLRecords[0]).CODE1A["system"]);
-            Assert.Equal("Acute transmural myocardial infarction of anterior wall", ((DeathRecord)JSONRecords[0]).CODE1A["display"]);
-            Assert.Equal("I21.0", ((DeathRecord)XMLRecords[0]).CODE1A["code"]);
-            Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)JSONRecords[0]).CODE1A["system"]);
-            Assert.Equal("Acute transmural myocardial infarction of anterior wall", ((DeathRecord)XMLRecords[0]).CODE1A["display"]);
-        }
+        // [Fact]
+        // public void Get_CODE1A()
+        // {
+        //     Assert.Equal("I21.0", ((DeathRecord)JSONRecords[0]).CODE1A["code"]);
+        //     Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)XMLRecords[0]).CODE1A["system"]);
+        //     Assert.Equal("Acute transmural myocardial infarction of anterior wall", ((DeathRecord)JSONRecords[0]).CODE1A["display"]);
+        //     Assert.Equal("I21.0", ((DeathRecord)XMLRecords[0]).CODE1A["code"]);
+        //     Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)JSONRecords[0]).CODE1A["system"]);
+        //     Assert.Equal("Acute transmural myocardial infarction of anterior wall", ((DeathRecord)XMLRecords[0]).CODE1A["display"]);
+        // }
 
         [Fact]
         public void Set_COD1B()
@@ -752,29 +752,29 @@ namespace VRDR.Tests
             Assert.Equal("6 days", ((DeathRecord)XMLRecords[0]).INTERVAL1B);
         }
 
-        [Fact]
-        public void Set_CODE1B()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "code 2");
-            code.Add("system", "system 2");
-            code.Add("display", "display 2");
-            SetterDeathRecord.CODE1B = code;
-            Assert.Equal("code 2", SetterDeathRecord.CODE1B["code"]);
-            Assert.Equal("system 2", SetterDeathRecord.CODE1B["system"]);
-            Assert.Equal("display 2", SetterDeathRecord.CODE1B["display"]);
-        }
+        // [Fact]
+        // public void Set_CODE1B()
+        // {
+        //     Dictionary<string, string> code = new Dictionary<string, string>();
+        //     code.Add("code", "code 2");
+        //     code.Add("system", "system 2");
+        //     code.Add("display", "display 2");
+        //     SetterDeathRecord.CODE1B = code;
+        //     Assert.Equal("code 2", SetterDeathRecord.CODE1B["code"]);
+        //     Assert.Equal("system 2", SetterDeathRecord.CODE1B["system"]);
+        //     Assert.Equal("display 2", SetterDeathRecord.CODE1B["display"]);
+        // }
 
-        [Fact]
-        public void Get_CODE1B()
-        {
-            Assert.Equal("I21.9", ((DeathRecord)JSONRecords[0]).CODE1B["code"]);
-            Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)XMLRecords[0]).CODE1B["system"]);
-            Assert.Equal("Acute myocardial infarction, unspecified", ((DeathRecord)JSONRecords[0]).CODE1B["display"]);
-            Assert.Equal("I21.9", ((DeathRecord)XMLRecords[0]).CODE1B["code"]);
-            Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)JSONRecords[0]).CODE1B["system"]);
-            Assert.Equal("Acute myocardial infarction, unspecified", ((DeathRecord)XMLRecords[0]).CODE1B["display"]);
-        }
+        // [Fact]
+        // public void Get_CODE1B()
+        // {
+        //     Assert.Equal("I21.9", ((DeathRecord)JSONRecords[0]).CODE1B["code"]);
+        //     Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)XMLRecords[0]).CODE1B["system"]);
+        //     Assert.Equal("Acute myocardial infarction, unspecified", ((DeathRecord)JSONRecords[0]).CODE1B["display"]);
+        //     Assert.Equal("I21.9", ((DeathRecord)XMLRecords[0]).CODE1B["code"]);
+        //     Assert.Equal("http://hl7.org/fhir/sid/icd-10", ((DeathRecord)JSONRecords[0]).CODE1B["system"]);
+        //     Assert.Equal("Acute myocardial infarction, unspecified", ((DeathRecord)XMLRecords[0]).CODE1B["display"]);
+        // }
 
         [Fact]
         public void Set_COD1C()
@@ -804,18 +804,18 @@ namespace VRDR.Tests
             Assert.Equal("5 years", ((DeathRecord)XMLRecords[0]).INTERVAL1C);
         }
 
-        [Fact]
-        public void Set_CODE1C()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "code 3");
-            code.Add("system", "system 3");
-            code.Add("display", "display 3");
-            SetterDeathRecord.CODE1C = code;
-            Assert.Equal("code 3", SetterDeathRecord.CODE1C["code"]);
-            Assert.Equal("system 3", SetterDeathRecord.CODE1C["system"]);
-            Assert.Equal("display 3", SetterDeathRecord.CODE1C["display"]);
-        }
+        // [Fact]
+        // public void Set_CODE1C()
+        // {
+        //     Dictionary<string, string> code = new Dictionary<string, string>();
+        //     code.Add("code", "code 3");
+        //     code.Add("system", "system 3");
+        //     code.Add("display", "display 3");
+        //     SetterDeathRecord.CODE1C = code;
+        //     Assert.Equal("code 3", SetterDeathRecord.CODE1C["code"]);
+        //     Assert.Equal("system 3", SetterDeathRecord.CODE1C["system"]);
+        //     Assert.Equal("display 3", SetterDeathRecord.CODE1C["display"]);
+        // }
 
         [Fact]
         public void Set_COD1D()
@@ -858,167 +858,6 @@ namespace VRDR.Tests
             Assert.Equal("display 4", SetterDeathRecord.CODE1D["display"]);
         }
 
-        [Fact]
-        public void Set_COD1E()
-        {
-            SetterDeathRecord.COD1E = "exampleE";
-            Assert.Equal("exampleE", SetterDeathRecord.COD1E);
-        }
-
-        [Fact]
-        public void Set_INTERVAL1E()
-        {
-            SetterDeathRecord.INTERVAL1E = "exampleE";
-            Assert.Equal("exampleE", SetterDeathRecord.INTERVAL1E);
-        }
-
-        [Fact]
-        public void Set_CODE1E()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "exampleE");
-            code.Add("system", "exampleE");
-            code.Add("display", "exampleE");
-            SetterDeathRecord.CODE1E = code;
-            Assert.Equal("exampleE", SetterDeathRecord.CODE1E["code"]);
-            Assert.Equal("exampleE", SetterDeathRecord.CODE1E["system"]);
-            Assert.Equal("exampleE", SetterDeathRecord.CODE1E["display"]);
-        }
-
-        [Fact]
-        public void Set_COD1F()
-        {
-            SetterDeathRecord.COD1F = "exampleF";
-            Assert.Equal("exampleF", SetterDeathRecord.COD1F);
-        }
-
-        [Fact]
-        public void Set_INTERVAL1F()
-        {
-            SetterDeathRecord.INTERVAL1F = "exampleF";
-            Assert.Equal("exampleF", SetterDeathRecord.INTERVAL1F);
-        }
-
-        [Fact]
-        public void Set_CODE1F()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "exampleF");
-            code.Add("system", "exampleF");
-            code.Add("display", "exampleF");
-            SetterDeathRecord.CODE1F = code;
-            Assert.Equal("exampleF", SetterDeathRecord.CODE1F["code"]);
-            Assert.Equal("exampleF", SetterDeathRecord.CODE1F["system"]);
-            Assert.Equal("exampleF", SetterDeathRecord.CODE1F["display"]);
-        }
-
-        [Fact]
-        public void Set_COD1G()
-        {
-            SetterDeathRecord.COD1G = "exampleG";
-            Assert.Equal("exampleG", SetterDeathRecord.COD1G);
-        }
-
-        [Fact]
-        public void Set_INTERVAL1G()
-        {
-            SetterDeathRecord.INTERVAL1G = "exampleG";
-            Assert.Equal("exampleG", SetterDeathRecord.INTERVAL1G);
-        }
-
-        [Fact]
-        public void Set_CODE1G()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "exampleG");
-            code.Add("system", "exampleG");
-            code.Add("display", "exampleG");
-            SetterDeathRecord.CODE1G = code;
-            Assert.Equal("exampleG", SetterDeathRecord.CODE1G["code"]);
-            Assert.Equal("exampleG", SetterDeathRecord.CODE1G["system"]);
-            Assert.Equal("exampleG", SetterDeathRecord.CODE1G["display"]);
-        }
-
-        [Fact]
-        public void Set_COD1H()
-        {
-            SetterDeathRecord.COD1H = "exampleH";
-            Assert.Equal("exampleH", SetterDeathRecord.COD1H);
-        }
-
-        [Fact]
-        public void Set_INTERVAL1H()
-        {
-            SetterDeathRecord.INTERVAL1H = "exampleH";
-            Assert.Equal("exampleH", SetterDeathRecord.INTERVAL1H);
-        }
-
-        [Fact]
-        public void Set_CODE1H()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "exampleH");
-            code.Add("system", "exampleH");
-            code.Add("display", "exampleH");
-            SetterDeathRecord.CODE1H = code;
-            Assert.Equal("exampleH", SetterDeathRecord.CODE1H["code"]);
-            Assert.Equal("exampleH", SetterDeathRecord.CODE1H["system"]);
-            Assert.Equal("exampleH", SetterDeathRecord.CODE1H["display"]);
-        }
-
-        [Fact]
-        public void Set_COD1I()
-        {
-            SetterDeathRecord.COD1I = "exampleI";
-            Assert.Equal("exampleI", SetterDeathRecord.COD1I);
-        }
-
-        [Fact]
-        public void Set_INTERVAL1I()
-        {
-            SetterDeathRecord.INTERVAL1I = "exampleI";
-            Assert.Equal("exampleI", SetterDeathRecord.INTERVAL1I);
-        }
-
-        [Fact]
-        public void Set_CODE1I()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "exampleI");
-            code.Add("system", "exampleI");
-            code.Add("display", "exampleI");
-            SetterDeathRecord.CODE1I = code;
-            Assert.Equal("exampleI", SetterDeathRecord.CODE1I["code"]);
-            Assert.Equal("exampleI", SetterDeathRecord.CODE1I["system"]);
-            Assert.Equal("exampleI", SetterDeathRecord.CODE1I["display"]);
-        }
-
-        [Fact]
-        public void Set_COD1J()
-        {
-            SetterDeathRecord.COD1J = "exampleJ";
-            Assert.Equal("exampleJ", SetterDeathRecord.COD1J);
-        }
-
-        [Fact]
-        public void Set_INTERVAL1J()
-        {
-            SetterDeathRecord.INTERVAL1J = "exampleJ";
-            Assert.Equal("exampleJ", SetterDeathRecord.INTERVAL1J);
-        }
-
-        [Fact]
-        public void Set_CODE1J()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "exampleJ");
-            code.Add("system", "exampleJ");
-            code.Add("display", "exampleJ");
-            SetterDeathRecord.CODE1J = code;
-            Assert.Equal("exampleJ", SetterDeathRecord.CODE1J["code"]);
-            Assert.Equal("exampleJ", SetterDeathRecord.CODE1J["system"]);
-            Assert.Equal("exampleJ", SetterDeathRecord.CODE1J["display"]);
-        }
 
         [Fact]
         public void Set_GivenNames()

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -845,18 +845,18 @@ namespace VRDR.Tests
             Assert.Equal("7 years", ((DeathRecord)XMLRecords[0]).INTERVAL1D);
         }
 
-        [Fact]
-        public void Set_CODE1D()
-        {
-            Dictionary<string, string> code = new Dictionary<string, string>();
-            code.Add("code", "code 4");
-            code.Add("system", "system 4");
-            code.Add("display", "display 4");
-            SetterDeathRecord.CODE1D = code;
-            Assert.Equal("code 4", SetterDeathRecord.CODE1D["code"]);
-            Assert.Equal("system 4", SetterDeathRecord.CODE1D["system"]);
-            Assert.Equal("display 4", SetterDeathRecord.CODE1D["display"]);
-        }
+        // [Fact]
+        // public void Set_CODE1D()
+        // {
+        //     Dictionary<string, string> code = new Dictionary<string, string>();
+        //     code.Add("code", "code 4");
+        //     code.Add("system", "system 4");
+        //     code.Add("display", "display 4");
+        //     SetterDeathRecord.CODE1D = code;
+        //     Assert.Equal("code 4", SetterDeathRecord.CODE1D["code"]);
+        //     Assert.Equal("system 4", SetterDeathRecord.CODE1D["system"]);
+        //     Assert.Equal("display 4", SetterDeathRecord.CODE1D["display"]);
+        // }
 
 
         [Fact]

--- a/VRDR.Tests/fixtures/json/BadConditions.json
+++ b/VRDR.Tests/fixtures/json/BadConditions.json
@@ -673,14 +673,23 @@
     {
       "fullUrl": "urn:uuid:9bd492a0-ed7f-420b-95bc-7fa1612e4707",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "urn:uuid:9bd492a0-ed7f-420b-95bc-7fa1612e4707",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2"
           ]
         },
         "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69441-4",
+              "display": "Other significant causes or conditions of death]"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
           "text": "Example Contributing Conditions"
         },
         "subject": {
@@ -691,14 +700,23 @@
     {
       "fullUrl": "urn:uuid:d884238d-c335-40e8-a572-dab1e33d2aa1",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "urn:uuid:d884238d-c335-40e8-a572-dab1e33d2aa1",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2"
           ]
         },
         "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69441-4",
+              "display": "Other significant causes or conditions of death]"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/icd-10",
@@ -711,23 +729,47 @@
         "subject": {
           "reference": "urn:uuid:9521f45f-d8ca-4c62-9878-0686f1028bf5"
         },
-        "onsetString": "minutes",
-        "asserter": {
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "minutes"
+            }
+          }
+        ],
+        "performer": [{
           "reference": "urn:uuid:e6e8758f-cfc3-4147-b9ba-e33f544ab7c8"
-        }
+        }]
       }
     },
     {
       "fullUrl": "urn:uuid:e1944401-1182-4178-8243-39a7dfe578db",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "urn:uuid:e1944401-1182-4178-8243-39a7dfe578db",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
         "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/icd-10",
@@ -737,57 +779,119 @@
           ],
           "text": "Acute myocardial infarction"
         },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "minutes"
+            }
+          }
+        ],
         "subject": {
           "reference": "urn:uuid:9521f45f-d8ca-4c62-9878-0686f1028bf5"
         },
-        "onsetString": "6 days",
-        "asserter": {
+        "performer": [{
           "reference": "urn:uuid:e6e8758f-cfc3-4147-b9ba-e33f544ab7c8"
-        }
+        }]
       }
     },
     {
       "fullUrl": "urn:uuid:df627ee8-7dcc-4f99-bccd-a050ea8b7634",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "urn:uuid:df627ee8-7dcc-4f99-bccd-a050ea8b7634",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Coronary artery thrombosis"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
         },
         "subject": {
           "reference": "urn:uuid:9521f45f-d8ca-4c62-9878-0686f1028bf5"
         },
-        "onsetString": "5 years",
-        "asserter": {
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "5 years"
+            }
+          }
+        ],
+        "performer": [{
           "reference": "urn:uuid:e6e8758f-cfc3-4147-b9ba-e33f544ab7c8"
-        }
+        }]
       }
     },
     {
       "fullUrl": "urn:uuid:065de6e7-edb2-4b86-90d3-c7aa558d77bd",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "urn:uuid:065de6e7-edb2-4b86-90d3-c7aa558d77bd",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
         "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },        "valueCodeableConcept": {
           "text": "Atherosclerotic coronary artery disease"
         },
         "subject": {
           "reference": "urn:uuid:9521f45f-d8ca-4c62-9878-0686f1028bf5"
         },
-        "onsetString": "7 years",
-        "asserter": {
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "minutes"
+            }
+          }
+        ],
+        "performer": [{
           "reference": "urn:uuid:e6e8758f-cfc3-4147-b9ba-e33f544ab7c8"
-        }
+        }]
       }
     },
     {

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -807,7 +807,24 @@
         },
         "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }]
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "minutes"
+            }
+          }
+        ]
+
       }
     },
     {

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -746,21 +746,30 @@
     {
       "fullUrl": "urn:uuid:fc27b07f-99c9-48f8-a229-6eb5d8b598f0",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "fc27b07f-99c9-48f8-a229-6eb5d8b598f0",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Example Contributing Conditions"
         },
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "asserter": {
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
+        }],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69441-4",
+              "display": "Other significant causes or conditions of death]"
+            }
+          ]
         }
       }
     },
@@ -771,7 +780,7 @@
         "id": "b66d97ea-56b1-4397-8de3-fb989007485b",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
         "valueCodeableConcept": {
@@ -820,14 +829,14 @@
     {
       "fullUrl": "urn:uuid:8b7a9ca6-1276-402f-a521-35155234af14",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "8b7a9ca6-1276-402f-a521-35155234af14",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/icd-10",
@@ -840,54 +849,126 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "6 days",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "6 days"
+            }
+          }
+        ]
       }
     },
     {
       "fullUrl": "urn:uuid:bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "bbae6f36-26c2-4b20-b9d3-735d9c9f6c2f",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Coronary artery thrombosis"
         },
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "5 years",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "5 years"
+            }
+          }
+        ]
       }
     },
     {
       "fullUrl": "urn:uuid:223eaadb-5909-458c-bbe5-604c120c3ce9",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "223eaadb-5909-458c-bbe5-604c120c3ce9",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "text": "Atherosclerotic coronary artery disease"
         },
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "7 years",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "7 years"
+            }
+          }
+        ]
       }
     },
     {
@@ -1025,7 +1106,7 @@
         "id": "79c8753a-bb2b-4e99-800c-cabfe9b97b57",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-education-=level"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-education-level"
           ]
         },
         "extension": [

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -805,22 +805,6 @@
             }
           ]
         },
-        "component": [
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69440-6",
-                  "display": "Disease onset to death interval"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "text": "minutes"
-            }
-          }
-        ],
         "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
         }]

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -767,14 +767,14 @@
     {
       "fullUrl": "urn:uuid:b66d97ea-56b1-4397-8de3-fb989007485b",
       "resource": {
-        "resourceType": "Condition",
+        "resourceType": "Observation",
         "id": "b66d97ea-56b1-4397-8de3-fb989007485b",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
           ]
         },
-        "code": {
+        "valueCodeableConcept": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/icd-10",
@@ -787,10 +787,34 @@
         "subject": {
           "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
         },
-        "onsetString": "minutes",
-        "asserter": {
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "69453-9",
+              "display": "Cause of death [US Standard Certificate of Death]"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69440-6",
+                  "display": "Disease onset to death interval"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "minutes"
+            }
+          }
+        ],
+        "performer": [{
           "reference": "urn:uuid:0402b9de-2347-4580-a9bf-b984c161ed2d"
-        }
+        }]
       }
     },
     {

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -614,27 +614,45 @@
   <entry>
     <fullUrl value="urn:uuid:e3328799-6392-4f6b-9db9-556a9b8a88d3" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="e3328799-6392-4f6b-9db9-556a9b8a88d3" />
         <meta>
           <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
         <code>
           <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
+        </subject>
+        <performer>
+          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
+        </performer>
+        <valueCodeableConcept>
+          <coding>
             <system value="http://hl7.org/fhir/sid/icd-10" />
             <code value="I21.0" />
             <display value="Acute transmural myocardial infarction of anterior wall" />
           </coding>
           <text value="Rupture of myocardium" />
-        </code>
-        <subject>
-          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
-        </subject>
-        <onsetString value="minutes" />
-        <asserter>
-          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="minutes" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
     </resource>
   </entry>
   <entry>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -594,21 +594,28 @@
   <entry>
     <fullUrl value="urn:uuid:8e4650ca-1d2a-4f73-a551-616fefd3e130" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="8e4650ca-1d2a-4f73-a551-616fefd3e130" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2" />
         </meta>
         <code>
-          <text value="Example Contributing Conditions" />
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69441-4" />
+            <display value="Other significant causes or conditions of death" />
+          </coding>
         </code>
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <asserter>
+        <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </performer>
+        <valueCodeableConcept>
+          <text value="Example Contributing Conditions" />
+        </valueCodeableConcept>
+      </Observation>
     </resource>
   </entry>
   <entry>
@@ -617,7 +624,7 @@
       <Observation>
         <id value="e3328799-6392-4f6b-9db9-556a9b8a88d3" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
         <code>
           <coding>
@@ -629,6 +636,9 @@
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
+        <performer>
+          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
+        </performer>
         <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
         </performer>
@@ -658,69 +668,124 @@
   <entry>
     <fullUrl value="urn:uuid:5c0a0509-8297-4a53-a0ef-725daaaf9736" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="5c0a0509-8297-4a53-a0ef-725daaaf9736" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
-        <code>
+          <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
+        </subject>
+        <performer>
+          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
+        </performer>
+        <valueCodeableConcept>
           <coding>
             <system value="http://hl7.org/fhir/sid/icd-10" />
             <code value="I21.9" />
             <display value="Acute myocardial infarction, unspecified" />
           </coding>
           <text value="Acute myocardial infarction" />
-        </code>
-        <subject>
-          <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
-        </subject>
-        <onsetString value="6 days" />
-        <asserter>
-          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="6 days" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
     </resource>
   </entry>
   <entry>
     <fullUrl value="urn:uuid:826a3c27-c712-4c65-b454-46cc4ca76c99" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="826a3c27-c712-4c65-b454-46cc4ca76c99" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
         <code>
-          <text value="Coronary artery thrombosis" />
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
         </code>
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <onsetString value="5 years" />
-        <asserter>
+        <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </performer>
+        <valueCodeableConcept>
+          <text value="Coronary artery thrombosis" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="5 years" />
+          </valueCodeableConcept>
+        </component>
+
+      </Observation>
     </resource>
   </entry>
   <entry>
     <fullUrl value="urn:uuid:46c9ed22-34f6-4d40-bdfa-9b7d6b3e9da6" />
     <resource>
-      <Condition>
+      <Observation>
         <id value="46c9ed22-34f6-4d40-bdfa-9b7d6b3e9da6" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
         </meta>
         <code>
-          <text value="Atherosclerotic coronary artery disease" />
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
         </code>
         <subject>
           <reference value="urn:uuid:0042d54e-25fe-426d-8a3e-d002369951d8" />
         </subject>
-        <onsetString value="7 years" />
-        <asserter>
+         <performer>
           <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </asserter>
-      </Condition>
+        </performer>
+        <valueCodeableConcept>
+          <text value="Atherosclerotic coronary artery disease" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="7 years" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
     </resource>
   </entry>
   <entry>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -56,26 +56,26 @@ namespace VRDR
         private Observation MannerOfDeath;
 
         /// <summary>Condition Contributing to Death.</summary>
-        private Condition ConditionContributingToDeath;
+        private Observation ConditionContributingToDeath;
 
         /// <summary>Create a Cause Of Death Condition </summary>
-        private Condition CauseOfDeathCondition(int index){
-                    Condition CodCondition;
-                    CodCondition = new Condition();
+        private Observation CauseOfDeathCondition(int index){
+                    Observation CodCondition;
+                    CodCondition = new Observation();
                     CodCondition.Id = Guid.NewGuid().ToString();
                     CodCondition.Meta = new Meta();
-                    string[] condition_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" };
+                    string[] condition_profile = { ProfileURL.CauseOfDeathPart1 };
                     CodCondition.Meta.Profile = condition_profile;
-                    CodCondition.Category.Add (new CodeableConcept(CodeSystems.SCT, "16100001", "Death Diagnosis", null));
+                    CodCondition.Code = new CodeableConcept(CodeSystems.LOINC, "69453-9", "Cause of death [US Standard Certificate of Death]", null);
                     CodCondition.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    CodCondition.Asserter = new ResourceReference("urn:uuid:" + Certifier.Id);
+                    CodCondition.Performer.Add (new ResourceReference("urn:uuid:" + Certifier.Id));
                     AddReferenceToComposition(CodCondition.Id);
                     Bundle.AddResourceEntry(CodCondition, "urn:uuid:" + CodCondition.Id);
                     List.EntryComponent entry = new List.EntryComponent();
                     entry.Item = new ResourceReference("urn:uuid:" + CodCondition.Id);
-                    if (CauseOfDeathConditionPathway.Entry.Count() != 10)
+                    if (CauseOfDeathConditionPathway.Entry.Count() != 4)
                     {
-                        foreach (var i in Enumerable.Range(0, 10)) { CauseOfDeathConditionPathway.Entry.Add(null); }
+                        foreach (var i in Enumerable.Range(0, 4)) { CauseOfDeathConditionPathway.Entry.Add(null); }
                     }
                     CauseOfDeathConditionPathway.Entry[index] = entry;
                     return (CodCondition);
@@ -83,34 +83,16 @@ namespace VRDR
 
 
         /// <summary>Cause Of Death Condition Line A (#1).</summary>
-        private Condition CauseOfDeathConditionA;
+        private Observation CauseOfDeathConditionA;
 
         /// <summary>Cause Of Death Condition Line B (#2).</summary>
-        private Condition CauseOfDeathConditionB;
+        private Observation CauseOfDeathConditionB;
 
         /// <summary>Cause Of Death Condition Line C (#3).</summary>
-        private Condition CauseOfDeathConditionC;
+        private Observation CauseOfDeathConditionC;
 
         /// <summary>Cause Of Death Condition Line D (#4).</summary>
-        private Condition CauseOfDeathConditionD;
-
-        /// <summary>Cause Of Death Condition Line E (#5).</summary>
-        private Condition CauseOfDeathConditionE;
-
-        /// <summary>Cause Of Death Condition Line F (#6).</summary>
-        private Condition CauseOfDeathConditionF;
-
-        /// <summary>Cause Of Death Condition Line G (#7).</summary>
-        private Condition CauseOfDeathConditionG;
-
-        /// <summary>Cause Of Death Condition Line H (#8).</summary>
-        private Condition CauseOfDeathConditionH;
-
-        /// <summary>Cause Of Death Condition Line I (#9).</summary>
-        private Condition CauseOfDeathConditionI;
-
-        /// <summary>Cause Of Death Condition Line J (#10).</summary>
-        private Condition CauseOfDeathConditionJ;
+        private Observation CauseOfDeathConditionD;
 
         /// <summary>Cause Of Death Condition Pathway.</summary>
         private List CauseOfDeathConditionPathway;
@@ -1480,16 +1462,15 @@ namespace VRDR
                 }
                 else
                 {
-                    ConditionContributingToDeath = new Condition();
+                    ConditionContributingToDeath = new Observation();
                     ConditionContributingToDeath.Id = Guid.NewGuid().ToString();
                     ConditionContributingToDeath.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    ConditionContributingToDeath.Asserter = new ResourceReference("urn:uuid:" + Certifier.Id);
+                    ConditionContributingToDeath.Performer.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
                     ConditionContributingToDeath.Meta = new Meta();
-                    string[] condition_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death" };
+                    string[] condition_profile = { ProfileURL.CauseOfDeathPart2 };
                     ConditionContributingToDeath.Meta.Profile = condition_profile;
-                    ConditionContributingToDeath.Category.Add (new CodeableConcept(CodeSystems.SCT, "16100001", "Death diagnosis", null));
+                    ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
                     ConditionContributingToDeath.Code = new CodeableConcept();
-                    ConditionContributingToDeath.Category.Add (new CodeableConcept(CodeSystems.SCT, "16100001", "Death Diagnosis", null));
                     ConditionContributingToDeath.Code.Text = value;
                     AddReferenceToComposition(ConditionContributingToDeath.Id);
                     Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
@@ -1525,51 +1506,28 @@ namespace VRDR
         /// </example>
         [Property("Causes Of Death", Property.Types.TupleCOD, "Death Certification", "Conditions that resulted in the cause of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-of-Death-Pathway.html", true, 50)]
         [FHIRPath("Bundle.entry.resource.where($this is Condition).where(onset.empty().not())", "")]
-        public Tuple<string, string, Dictionary<string, string>>[] CausesOfDeath
+        public Tuple<string, string /*, Dictionary<string, string>*/>[] CausesOfDeath
         {
             get
             {
-                List<Tuple<string, string, Dictionary<string, string>>> results = new List<Tuple<string, string, Dictionary<string, string>>>();
-                if (!String.IsNullOrEmpty(COD1A) || !String.IsNullOrEmpty(INTERVAL1A) || (CODE1A != null && !String.IsNullOrEmpty(CODE1A["code"])))
+                List<Tuple<string, string/*, Dictionary<string, string>*/>> results = new List<Tuple<string, string /*, Dictionary<string, string>*/>>();
+                if (!String.IsNullOrEmpty(COD1A) || !String.IsNullOrEmpty(INTERVAL1A) /*|| (CODE1A != null && !String.IsNullOrEmpty(CODE1A["code"]))*/ )
                 {
-                    results.Add(Tuple.Create(COD1A, INTERVAL1A, CODE1A));
+                    results.Add(Tuple.Create(COD1A, INTERVAL1A /*, CODE1A)*/));
                 }
-                if (!String.IsNullOrEmpty(COD1B) || !String.IsNullOrEmpty(INTERVAL1B) || (CODE1B != null && !String.IsNullOrEmpty(CODE1B["code"])))
+                if (!String.IsNullOrEmpty(COD1B) || !String.IsNullOrEmpty(INTERVAL1B) /*|| (CODE1B != null && !String.IsNullOrEmpty(CODE1B["code"])) */)
                 {
-                    results.Add(Tuple.Create(COD1B, INTERVAL1B, CODE1B));
+                    results.Add(Tuple.Create(COD1B, INTERVAL1B/* , CODE1B*/));
                 }
-                if (!String.IsNullOrEmpty(COD1C) || !String.IsNullOrEmpty(INTERVAL1C) || (CODE1C != null && !String.IsNullOrEmpty(CODE1C["code"])))
+                if (!String.IsNullOrEmpty(COD1C) || !String.IsNullOrEmpty(INTERVAL1C) /*|| (CODE1C != null && !String.IsNullOrEmpty(CODE1C["code"])) */)
                 {
-                    results.Add(Tuple.Create(COD1C, INTERVAL1C, CODE1C));
+                    results.Add(Tuple.Create(COD1C, INTERVAL1C /*, CODE1C */));
                 }
-                if (!String.IsNullOrEmpty(COD1D) || !String.IsNullOrEmpty(INTERVAL1D) || (CODE1D != null && !String.IsNullOrEmpty(CODE1D["code"])))
+                if (!String.IsNullOrEmpty(COD1D) || !String.IsNullOrEmpty(INTERVAL1D) /*||  (CODE1D != null && !String.IsNullOrEmpty(CODE1D["code"])) */)
                 {
-                    results.Add(Tuple.Create(COD1D, INTERVAL1D, CODE1D));
+                    results.Add(Tuple.Create(COD1D, INTERVAL1D  /*, CODE1D */));
                 }
-                if (!String.IsNullOrEmpty(COD1E) || !String.IsNullOrEmpty(INTERVAL1E) || (CODE1E != null && !String.IsNullOrEmpty(CODE1E["code"])))
-                {
-                    results.Add(Tuple.Create(COD1E, INTERVAL1E, CODE1E));
-                }
-                if (!String.IsNullOrEmpty(COD1F) || !String.IsNullOrEmpty(INTERVAL1F) || (CODE1F != null && !String.IsNullOrEmpty(CODE1F["code"])))
-                {
-                    results.Add(Tuple.Create(COD1F, INTERVAL1F, CODE1F));
-                }
-                if (!String.IsNullOrEmpty(COD1G) || !String.IsNullOrEmpty(INTERVAL1G) || (CODE1G != null && !String.IsNullOrEmpty(CODE1G["code"])))
-                {
-                    results.Add(Tuple.Create(COD1G, INTERVAL1G, CODE1G));
-                }
-                if (!String.IsNullOrEmpty(COD1H) || !String.IsNullOrEmpty(INTERVAL1H) || (CODE1H != null && !String.IsNullOrEmpty(CODE1H["code"])))
-                {
-                    results.Add(Tuple.Create(COD1H, INTERVAL1H, CODE1H));
-                }
-                if (!String.IsNullOrEmpty(COD1I) || !String.IsNullOrEmpty(INTERVAL1I) || (CODE1I != null && !String.IsNullOrEmpty(CODE1I["code"])))
-                {
-                    results.Add(Tuple.Create(COD1I, INTERVAL1I, CODE1I));
-                }
-                if (!String.IsNullOrEmpty(COD1J) || !String.IsNullOrEmpty(INTERVAL1J) || (CODE1J != null && !String.IsNullOrEmpty(CODE1J["code"])))
-                {
-                    results.Add(Tuple.Create(COD1J, INTERVAL1J, CODE1J));
-                }
+
                 return results.ToArray();
             }
             set
@@ -1580,62 +1538,62 @@ namespace VRDR
                     {
                         COD1A = value[0].Item1;
                         INTERVAL1A = value[0].Item2;
-                        CODE1A = value[0].Item3;
+                        // CODE1A = value[0].Item3;
                     }
                     if (value.Length > 1)
                     {
                         COD1B = value[1].Item1;
                         INTERVAL1B = value[1].Item2;
-                        CODE1B = value[1].Item3;
+                        // CODE1B = value[1].Item3;
                     }
                     if (value.Length > 2)
                     {
                         COD1C = value[2].Item1;
                         INTERVAL1C = value[2].Item2;
-                        CODE1C = value[2].Item3;
+                        // CODE1C = value[2].Item3;
                     }
                     if (value.Length > 3)
                     {
                         COD1D = value[3].Item1;
                         INTERVAL1D = value[3].Item2;
-                        CODE1D = value[3].Item3;
+                        // CODE1D = value[3].Item3;
                     }
-                    if (value.Length > 4)
-                    {
-                        COD1E = value[4].Item1;
-                        INTERVAL1E = value[4].Item2;
-                        CODE1E = value[4].Item3;
-                    }
-                    if (value.Length > 5)
-                    {
-                        COD1F = value[5].Item1;
-                        INTERVAL1F = value[5].Item2;
-                        CODE1F = value[5].Item3;
-                    }
-                    if (value.Length > 6)
-                    {
-                        COD1G = value[6].Item1;
-                        INTERVAL1G = value[6].Item2;
-                        CODE1G = value[6].Item3;
-                    }
-                    if (value.Length > 7)
-                    {
-                        COD1H = value[7].Item1;
-                        INTERVAL1H = value[7].Item2;
-                        CODE1H = value[7].Item3;
-                    }
-                    if (value.Length > 8)
-                    {
-                        COD1I = value[8].Item1;
-                        INTERVAL1I = value[8].Item2;
-                        CODE1I = value[8].Item3;
-                    }
-                    if (value.Length > 9)
-                    {
-                        COD1J = value[9].Item1;
-                        INTERVAL1J = value[9].Item2;
-                        CODE1J = value[9].Item3;
-                    }
+                    // if (value.Length > 4)
+                    // {
+                    //     COD1E = value[4].Item1;
+                    //     INTERVAL1E = value[4].Item2;
+                    //     CODE1E = value[4].Item3;
+                    // }
+                    // if (value.Length > 5)
+                    // {
+                    //     COD1F = value[5].Item1;
+                    //     INTERVAL1F = value[5].Item2;
+                    //     CODE1F = value[5].Item3;
+                    // }
+                    // if (value.Length > 6)
+                    // {
+                    //     COD1G = value[6].Item1;
+                    //     INTERVAL1G = value[6].Item2;
+                    //     CODE1G = value[6].Item3;
+                    // }
+                    // if (value.Length > 7)
+                    // {
+                    //     COD1H = value[7].Item1;
+                    //     INTERVAL1H = value[7].Item2;
+                    //     CODE1H = value[7].Item3;
+                    // }
+                    // if (value.Length > 8)
+                    // {
+                    //     COD1I = value[8].Item1;
+                    //     INTERVAL1I = value[8].Item2;
+                    //     CODE1I = value[8].Item3;
+                    // }
+                    // if (value.Length > 9)
+                    // {
+                    //     COD1J = value[9].Item1;
+                    //     INTERVAL1J = value[9].Item2;
+                    //     CODE1J = value[9].Item3;
+                    // }
                 }
             }
         }
@@ -1648,7 +1606,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1A}");</para>
         /// </example>
-        [Property("COD1A", Property.Types.String, "Death Certification", "Cause of Death Part I, Line a.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("COD1A", Property.Types.String, "Death Certification", "Cause of Death Part I, Line a.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string COD1A
         {
             get
@@ -1685,16 +1643,21 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1A}");</para>
         /// </example>
-        [Property("INTERVAL1A", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line a.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("INTERVAL1A", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line a.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string INTERVAL1A
         {
             get
             {
-                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Onset != null)
+                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Component != null)
                 {
-                    return CauseOfDeathConditionA.Onset.ToString();
+                    var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    {
+                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                    }
                 }
-                return null;
+                return "";
             }
             set
             {
@@ -1702,58 +1665,73 @@ namespace VRDR
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
-                CauseOfDeathConditionA.Onset = new FhirString(value);
+                // Find correct component; if doesn't exist add another
+                var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp != null)
+                    {
+
+                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    }
+                    else
+                    {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
+                    component.Value = new CodeableConcept(null, null, null, value);
+                    CauseOfDeathConditionA.Component.Add(component);
+                }
             }
+
         }
 
-        /// <summary>Cause of Death Part I Code, Line a.</summary>
-        /// <value>the immediate cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "I21.0");</para>
-        /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
-        /// <para>code.Add("display", "Acute transmural myocardial infarction of anterior wall");</para>
-        /// <para>ExampleDeathRecord.CODE1A = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1A['display']}");</para>
-        /// </example>
-        [Property("CODE1A", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line a.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        public Dictionary<string, string> CODE1A
-        {
-            get
-            {
-                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionA.Code);
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                if(CauseOfDeathConditionA == null)
-                {
-                    CauseOfDeathConditionA = CauseOfDeathCondition(0);
-                }
-                if (CauseOfDeathConditionA.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionA.Code.Text;
-                    CauseOfDeathConditionA.Code = code;
-                }
-                else
-                {
-                CauseOfDeathConditionA.Code = DictToCodeableConcept(value);
-                }
-            }
-        }
+        // /// <summary>Cause of Death Part I Code, Line a.</summary>
+        // /// <value>the immediate cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        // /// <para>"code" - the code</para>
+        // /// <para>"system" - the code system this code belongs to</para>
+        // /// <para>"display" - a human readable meaning of the code</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>code.Add("code", "I21.0");</para>
+        // /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
+        // /// <para>code.Add("display", "Acute transmural myocardial infarction of anterior wall");</para>
+        // /// <para>ExampleDeathRecord.CODE1A = code;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1A['display']}");</para>
+        // /// </example>
+        // [Property("CODE1A", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line a.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // public Dictionary<string, string> CODE1A
+        // {
+        //     get
+        //     {
+        //         if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Code != null)
+        //         {
+        //             return CodeableConceptToDict(CauseOfDeathConditionA.Code);
+        //         }
+        //         return EmptyCodeDict();
+        //     }
+        //     set
+        //     {
+        //         if(CauseOfDeathConditionA == null)
+        //         {
+        //             CauseOfDeathConditionA = CauseOfDeathCondition(0);
+        //         }
+        //         if (CauseOfDeathConditionA.Code != null)
+        //         {
+        //             CodeableConcept code = DictToCodeableConcept(value);
+        //             code.Text = CauseOfDeathConditionA.Code.Text;
+        //             CauseOfDeathConditionA.Code = code;
+        //         }
+        //         else
+        //         {
+        //         CauseOfDeathConditionA.Code = DictToCodeableConcept(value);
+        //         }
+        //     }
+        // }
 
         /// <summary>Cause of Death Part I, Line b.</summary>
         /// <value>the first underlying cause of death literal.</value>
@@ -1763,7 +1741,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1B}");</para>
         /// </example>
-        [Property("COD1B", Property.Types.String, "Death Certification", "Cause of Death Part I, Line b.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("COD1B", Property.Types.String, "Death Certification", "Cause of Death Part I, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string COD1B
         {
             get
@@ -1801,16 +1779,21 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1B}");</para>
         /// </example>
-        [Property("INTERVAL1B", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line b.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1B
+     [Property("INTERVAL1B", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
+       public string INTERVAL1B
         {
             get
             {
-                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Onset != null)
+                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Component != null)
                 {
-                    return CauseOfDeathConditionB.Onset.ToString();
+                    var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    {
+                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                    }
                 }
-                return null;
+                return "";
             }
             set
             {
@@ -1818,58 +1801,72 @@ namespace VRDR
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
-                CauseOfDeathConditionB.Onset = new FhirString(value);
-            }
-        }
+                // Find correct component; if doesn't exist add another
+                var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp != null)
+                    {
 
-        /// <summary>Cause of Death Part I Code, Line b.</summary>
-        /// <value>the first underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "I21.9");</para>
-        /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
-        /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
-        /// <para>ExampleDeathRecord.CODE1B = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1B['display']}");</para>
-        /// </example>
-        [Property("CODE1B", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line b.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        public Dictionary<string, string> CODE1B
-        {
-            get
-            {
-                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionB.Code);
+                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    }
+                    else
+                    {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
+                    component.Value = new CodeableConcept(null, null, null, value);
+                    CauseOfDeathConditionB.Component.Add(component);
                 }
-                return EmptyCodeDict();
             }
-            set
-            {
-                if(CauseOfDeathConditionB == null)
-                {
-                    CauseOfDeathConditionB = CauseOfDeathCondition(1);
-                }
-                if (CauseOfDeathConditionB.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionB.Code.Text;
-                    CauseOfDeathConditionB.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionB.Code = DictToCodeableConcept(value);
-                }
-                            }
+
         }
+        // /// <summary>Cause of Death Part I Code, Line b.</summary>
+        // /// <value>the first underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        // /// <para>"code" - the code</para>
+        // /// <para>"system" - the code system this code belongs to</para>
+        // /// <para>"display" - a human readable meaning of the code</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>code.Add("code", "I21.9");</para>
+        // /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
+        // /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
+        // /// <para>ExampleDeathRecord.CODE1B = code;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1B['display']}");</para>
+        // /// </example>
+        // [Property("CODE1B", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // public Dictionary<string, string> CODE1B
+        // {
+        //     get
+        //     {
+        //         if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Code != null)
+        //         {
+        //             return CodeableConceptToDict(CauseOfDeathConditionB.Code);
+        //         }
+        //         return EmptyCodeDict();
+        //     }
+        //     set
+        //     {
+        //         if(CauseOfDeathConditionB == null)
+        //         {
+        //             CauseOfDeathConditionB = CauseOfDeathCondition(1);
+        //         }
+        //         if (CauseOfDeathConditionB.Code != null)
+        //         {
+        //             CodeableConcept code = DictToCodeableConcept(value);
+        //             code.Text = CauseOfDeathConditionB.Code.Text;
+        //             CauseOfDeathConditionB.Code = code;
+        //         }
+        //         else
+        //         {
+        //             CauseOfDeathConditionB.Code = DictToCodeableConcept(value);
+        //         }
+        //                     }
+        // }
 
         /// <summary>Cause of Death Part I, Line c.</summary>
         /// <value>the second underlying cause of death literal.</value>
@@ -1879,7 +1876,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1C}");</para>
         /// </example>
-        [Property("COD1C", Property.Types.String, "Death Certification", "Cause of Death Part I, Line c.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("COD1C", Property.Types.String, "Death Certification", "Cause of Death Part I, Line c.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string COD1C
         {
             get
@@ -1916,16 +1913,21 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1C}");</para>
         /// </example>
-        [Property("INTERVAL1C", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line c.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("INTERVAL1C", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line c.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string INTERVAL1C
         {
             get
             {
-                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Onset != null)
+                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Component != null)
                 {
-                    return CauseOfDeathConditionC.Onset.ToString();
+                    var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    {
+                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                    }
                 }
-                return null;
+                return "";
             }
             set
             {
@@ -1933,59 +1935,72 @@ namespace VRDR
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
+                // Find correct component; if doesn't exist add another
+                var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp != null)
+                    {
 
-                CauseOfDeathConditionC.Onset = new FhirString(value);
-              }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line c.</summary>
-        /// <value>the second underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "I21.9");</para>
-        /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
-        /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
-        /// <para>ExampleDeathRecord.CODE1C = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1C['display']}");</para>
-        /// </example>
-        [Property("CODE1C", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line c.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        public Dictionary<string, string> CODE1C
-        {
-            get
-            {
-                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionC.Code);
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                if(CauseOfDeathConditionC == null)
-                {
-                    CauseOfDeathConditionC = CauseOfDeathCondition(2);
-                }
-               if (CauseOfDeathConditionC.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionC.Code.Text;
-                    CauseOfDeathConditionC.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionC.Code = DictToCodeableConcept(value);
+                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    }
+                    else
+                    {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
+                    component.Value = new CodeableConcept(null, null, null, value);
+                    CauseOfDeathConditionC.Component.Add(component);
                 }
             }
         }
+
+        // /// <summary>Cause of Death Part I Code, Line c.</summary>
+        // /// <value>the second underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        // /// <para>"code" - the code</para>
+        // /// <para>"system" - the code system this code belongs to</para>
+        // /// <para>"display" - a human readable meaning of the code</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>code.Add("code", "I21.9");</para>
+        // /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
+        // /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
+        // /// <para>ExampleDeathRecord.CODE1C = code;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1C['display']}");</para>
+        // /// </example>
+        // [Property("CODE1C", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line c.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // public Dictionary<string, string> CODE1C
+        // {
+        //     get
+        //     {
+        //         if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Code != null)
+        //         {
+        //             return CodeableConceptToDict(CauseOfDeathConditionC.Code);
+        //         }
+        //         return EmptyCodeDict();
+        //     }
+        //     set
+        //     {
+        //         if(CauseOfDeathConditionC == null)
+        //         {
+        //             CauseOfDeathConditionC = CauseOfDeathCondition(2);
+        //         }
+        //        if (CauseOfDeathConditionC.Code != null)
+        //         {
+        //             CodeableConcept code = DictToCodeableConcept(value);
+        //             code.Text = CauseOfDeathConditionC.Code.Text;
+        //             CauseOfDeathConditionC.Code = code;
+        //         }
+        //         else
+        //         {
+        //             CauseOfDeathConditionC.Code = DictToCodeableConcept(value);
+        //         }
+        //     }
+        // }
 
         /// <summary>Cause of Death Part I, Line d.</summary>
         /// <value>the third underlying cause of death literal.</value>
@@ -1995,7 +2010,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1D}");</para>
         /// </example>
-        [Property("COD1D", Property.Types.String, "Death Certification", "Cause of Death Part I, Line d.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("COD1D", Property.Types.String, "Death Certification", "Cause of Death Part I, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string COD1D
         {
             get
@@ -2032,24 +2047,43 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1D}");</para>
         /// </example>
-        [Property("INTERVAL1D", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line d.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("INTERVAL1D", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
         public string INTERVAL1D
         {
             get
             {
-                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Onset != null)
+                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Component != null)
                 {
-                    return CauseOfDeathConditionD.Onset.ToString();
+                    var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    {
+                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                    }
                 }
-                return null;
+                return "";
             }
             set
             {
-                 if (CauseOfDeathConditionD == null)
-                 {
+                if(CauseOfDeathConditionD == null)
+                {
                     CauseOfDeathConditionD = CauseOfDeathCondition(3);
-                 }
-                CauseOfDeathConditionD.Onset = new FhirString(value);
+                }
+                // Find correct component; if doesn't exist add another
+                var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    if (intervalComp != null)
+                    {
+
+                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    }
+                    else
+                    {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
+                    component.Value = new CodeableConcept(null, null, null, value);
+                    CauseOfDeathConditionD.Component.Add(component);
+                }
             }
         }
 
@@ -2069,7 +2103,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1D['display']}");</para>
         /// </example>
-        [Property("CODE1D", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line d.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [Property("CODE1D", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -2102,702 +2136,6 @@ namespace VRDR
             }
         }
 
-        /// <summary>Cause of Death Part I, Line e.</summary>
-        /// <value>the fourth underlying cause of death literal.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.COD1E = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1E}");</para>
-        /// </example>
-        [Property("COD1E", Property.Types.String, "Death Certification", "Cause of Death Part I, Line e.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string COD1E
-        {
-            get
-            {
-                if (CauseOfDeathConditionE != null && CauseOfDeathConditionE.Code != null)
-                {
-                    return CauseOfDeathConditionE.Code.Text;
-                }
-                return null;
-            }
-            set
-            {
-                 if (CauseOfDeathConditionE == null)
-                 {
-                    CauseOfDeathConditionE = CauseOfDeathCondition(4);
-                 }
-                if (CauseOfDeathConditionE.Code != null)
-                {
-                    CauseOfDeathConditionE.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionE.Code = new CodeableConcept();
-                    CauseOfDeathConditionE.Code.Text = value;
-                }
-            }
-        }
-
-        /// <summary>Cause of Death Part I Interval, Line e.</summary>
-        /// <value>the fourth underlying cause of death approximate interval: onset to death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.INTERVAL1E = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1E}");</para>
-        /// </example>
-        [Property("INTERVAL1E", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line e.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1E
-        {
-            get
-            {
-                if (CauseOfDeathConditionE != null && CauseOfDeathConditionE.Onset != null)
-                {
-                    return CauseOfDeathConditionE.Onset.ToString();
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionE == null)
-                 {
-                    CauseOfDeathConditionE = CauseOfDeathCondition(4);
-                 }
-                CauseOfDeathConditionE.Onset = new FhirString(value);
-             }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line e.</summary>
-        /// <value>the fourth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "example");</para>
-        /// <para>code.Add("system", "example");</para>
-        /// <para>code.Add("display", "example");</para>
-        /// <para>ExampleDeathRecord.CODE1E = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1E['display']}");</para>
-        /// </example>
-        [Property("CODE1E", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line e.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        public Dictionary<string, string> CODE1E
-        {
-            get
-            {
-                if (CauseOfDeathConditionE != null && CauseOfDeathConditionE.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionE.Code);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                 if (CauseOfDeathConditionE == null)
-                 {
-                    CauseOfDeathConditionE = CauseOfDeathCondition(4);
-                 }
-                if (CauseOfDeathConditionE.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionE.Code.Text;
-                    CauseOfDeathConditionE.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionE.Code = DictToCodeableConcept(value);
-                }
-            }
-        }
-
-        /// <summary>Cause of Death Part I, Line f.</summary>
-        /// <value>the fifth underlying cause of death literal.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.COD1F = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1F}");</para>
-        /// </example>
-        [Property("COD1F", Property.Types.String, "Death Certification", "Cause of Death Part I, Line f.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string COD1F
-        {
-            get
-            {
-                if (CauseOfDeathConditionF != null && CauseOfDeathConditionF.Code != null)
-                {
-                    return CauseOfDeathConditionF.Code.Text;
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionF == null)
-                 {
-                    CauseOfDeathConditionF = CauseOfDeathCondition(5);
-                 }
-                  if (CauseOfDeathConditionF.Code != null)
-                {
-                    CauseOfDeathConditionF.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionF.Code = new CodeableConcept();
-                    CauseOfDeathConditionF.Code.Text = value;
-                }
-            }
-        }
-
-        /// <summary>Cause of Death Part I Interval, Line f.</summary>
-        /// <value>the fifth underlying cause of death approximate interval: onset to death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.INTERVAL1F = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1F}");</para>
-        /// </example>
-        [Property("INTERVAL1F", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line f.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1F
-        {
-            get
-            {
-                if (CauseOfDeathConditionF != null && CauseOfDeathConditionF.Onset != null)
-                {
-                    return CauseOfDeathConditionF.Onset.ToString();
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionF == null)
-                 {
-                    CauseOfDeathConditionF = CauseOfDeathCondition(5);
-                 }
-                CauseOfDeathConditionF.Onset = new FhirString(value);
-            }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line f.</summary>
-        /// <value>the fifth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "example");</para>
-        /// <para>code.Add("system", "example");</para>
-        /// <para>code.Add("display", "example");</para>
-        /// <para>ExampleDeathRecord.CODE1F = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1F['display']}");</para>
-        /// </example>
-        [Property("CODE1F", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line f.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        public Dictionary<string, string> CODE1F
-        {
-            get
-            {
-                if (CauseOfDeathConditionF != null && CauseOfDeathConditionF.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionF.Code);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (CauseOfDeathConditionF == null)
-                 {
-                    CauseOfDeathConditionF = CauseOfDeathCondition(5);
-                 }
-                if (CauseOfDeathConditionF.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionF.Code.Text;
-                    CauseOfDeathConditionF.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionF.Code = DictToCodeableConcept(value);
-                }
-             }
-        }
-
-        /// <summary>Cause of Death Part I, Line g.</summary>
-        /// <value>the sixth underlying cause of death literal.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.COD1G = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1G}");</para>
-        /// </example>
-        [Property("COD1G", Property.Types.String, "Death Certification", "Cause of Death Part I, Line g.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string COD1G
-        {
-            get
-            {
-                if (CauseOfDeathConditionG != null && CauseOfDeathConditionG.Code != null)
-                {
-                    return CauseOfDeathConditionG.Code.Text;
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionG == null)
-                 {
-                    CauseOfDeathConditionG = CauseOfDeathCondition(6);
-                 }
-                if (CauseOfDeathConditionG.Code != null)
-                {
-                    CauseOfDeathConditionG.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionG.Code = new CodeableConcept();
-                    CauseOfDeathConditionG.Code.Text = value;
-                }
-            }
-        }
-
-        /// <summary>Cause of Death Part I Interval, Line g.</summary>
-        /// <value>the sixth underlying cause of death approximate interval: onset to death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.INTERVAL1G = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1G}");</para>
-        /// </example>
-        [Property("INTERVAL1G", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line g.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1G
-        {
-            get
-            {
-                if (CauseOfDeathConditionG != null && CauseOfDeathConditionG.Onset != null)
-                {
-                    return CauseOfDeathConditionG.Onset.ToString();
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionG == null)
-                 {
-                    CauseOfDeathConditionG = CauseOfDeathCondition(6);
-                 }
-                CauseOfDeathConditionG.Onset = new FhirString(value);
-             }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line g.</summary>
-        /// <value>the sixth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "example");</para>
-        /// <para>code.Add("system", "example");</para>
-        /// <para>code.Add("display", "example");</para>
-        /// <para>ExampleDeathRecord.CODE1G = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1G['display']}");</para>
-        /// </example>
-        [Property("CODE1G", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line g.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        public Dictionary<string, string> CODE1G
-        {
-            get
-            {
-                if (CauseOfDeathConditionG != null && CauseOfDeathConditionG.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionG.Code);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-               if (CauseOfDeathConditionG == null)
-                {
-                    CauseOfDeathConditionG = CauseOfDeathCondition(6);
-                }
-                if (CauseOfDeathConditionG.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionG.Code.Text;
-                    CauseOfDeathConditionG.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionG.Code = DictToCodeableConcept(value);
-                }
-            }
-        }
-
-        /// <summary>Cause of Death Part I, Line h.</summary>
-        /// <value>the seventh underlying cause of death literal.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.COD1H = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1H}");</para>
-        /// </example>
-        [Property("COD1H", Property.Types.String, "Death Certification", "Cause of Death Part I, Line h.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string COD1H
-        {
-            get
-            {
-                if (CauseOfDeathConditionH != null && CauseOfDeathConditionH.Code != null)
-                {
-                    return CauseOfDeathConditionH.Code.Text;
-                }
-                return null;
-            }
-            set
-            {
-               if (CauseOfDeathConditionH == null)
-                 {
-                    CauseOfDeathConditionH = CauseOfDeathCondition(7);
-                 }
-                if (CauseOfDeathConditionH.Code != null)
-                {
-                    CauseOfDeathConditionH.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionH.Code = new CodeableConcept();
-                    CauseOfDeathConditionH.Code.Text = value;
-                }
-            }
-        }
-
-        /// <summary>Cause of Death Part I Interval, Line h.</summary>
-        /// <value>the seventh underlying cause of death approximate interval: onset to death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.INTERVAL1H = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1H}");</para>
-        /// </example>
-        [Property("INTERVAL1H", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line h.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1H
-        {
-            get
-            {
-                if (CauseOfDeathConditionH != null && CauseOfDeathConditionH.Onset != null)
-                {
-                    return CauseOfDeathConditionH.Onset.ToString();
-                }
-                return null;
-            }
-            set
-            {
-               if (CauseOfDeathConditionH == null)
-                {
-                    CauseOfDeathConditionH = CauseOfDeathCondition(7);
-                }
-                CauseOfDeathConditionH.Onset = new FhirString(value);
-            }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line h.</summary>
-        /// <value>the seventh underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "example");</para>
-        /// <para>code.Add("system", "example");</para>
-        /// <para>code.Add("display", "example");</para>
-        /// <para>ExampleDeathRecord.CODE1H = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1H['display']}");</para>
-        /// </example>
-        [Property("CODE1H", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line h.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        public Dictionary<string, string> CODE1H
-        {
-            get
-            {
-                if (CauseOfDeathConditionH != null && CauseOfDeathConditionH.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionH.Code);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-              if (CauseOfDeathConditionH == null)
-                {
-                    CauseOfDeathConditionH = CauseOfDeathCondition(7);
-                }
-                if (CauseOfDeathConditionH.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionH.Code.Text;
-                    CauseOfDeathConditionH.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionH.Code = DictToCodeableConcept(value);
-                }
-                            }
-        }
-
-        /// <summary>Cause of Death Part I, Line i.</summary>
-        /// <value>the eighth underlying cause of death literal.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.COD1I = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1I}");</para>
-        /// </example>
-        [Property("COD1I", Property.Types.String, "Death Certification", "Cause of Death Part I, Line i.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string COD1I
-        {
-            get
-            {
-                if (CauseOfDeathConditionI != null && CauseOfDeathConditionI.Code != null)
-                {
-                    return CauseOfDeathConditionI.Code.Text;
-                }
-                return null;
-            }
-            set
-            {
-              if (CauseOfDeathConditionI == null)
-                {
-                    CauseOfDeathConditionI = CauseOfDeathCondition(8);
-                }
-                if (CauseOfDeathConditionI.Code != null)
-                {
-                    CauseOfDeathConditionI.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionI.Code = new CodeableConcept();
-                    CauseOfDeathConditionI.Code.Text = value;
-                }
-                            }
-        }
-
-        /// <summary>Cause of Death Part I Interval, Line i.</summary>
-        /// <value>the eighth underlying cause of death approximate interval: onset to death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.INTERVAL1I = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1I}");</para>
-        /// </example>
-        [Property("INTERVAL1I", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line i.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1I
-        {
-            get
-            {
-                if (CauseOfDeathConditionI != null && CauseOfDeathConditionI.Onset != null)
-                {
-                    return CauseOfDeathConditionI.Onset.ToString();
-                }
-                return null;
-            }
-            set
-            {
-               if (CauseOfDeathConditionI == null)
-                {
-                    CauseOfDeathConditionI = CauseOfDeathCondition(8);
-                }
-                CauseOfDeathConditionI.Onset = new FhirString(value);
-             }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line i.</summary>
-        /// <value>the eighth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "example");</para>
-        /// <para>code.Add("system", "example");</para>
-        /// <para>code.Add("display", "example");</para>
-        /// <para>ExampleDeathRecord.CODE1I = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1I['display']}");</para>
-        /// </example>
-        [Property("CODE1I", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line i.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        public Dictionary<string, string> CODE1I
-        {
-            get
-            {
-                if (CauseOfDeathConditionI != null && CauseOfDeathConditionI.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionI.Code);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (CauseOfDeathConditionI == null)
-                {
-                    CauseOfDeathConditionI = CauseOfDeathCondition(8);
-                }
-                if (CauseOfDeathConditionI.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionI.Code.Text;
-                    CauseOfDeathConditionI.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionI.Code = DictToCodeableConcept(value);
-                }
-                            }
-        }
-
-        /// <summary>Cause of Death Part I, Line j.</summary>
-        /// <value>the ninth underlying cause of death literal.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.COD1J = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1J}");</para>
-        /// </example>
-        [Property("COD1J", Property.Types.String, "Death Certification", "Cause of Death Part I, Line j.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string COD1J
-        {
-            get
-            {
-                if (CauseOfDeathConditionJ != null && CauseOfDeathConditionJ.Code != null)
-                {
-                    return CauseOfDeathConditionJ.Code.Text;
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionJ == null)
-                {
-                    CauseOfDeathConditionJ = CauseOfDeathCondition(9);
-                }
-                if (CauseOfDeathConditionJ.Code != null)
-                {
-                    CauseOfDeathConditionJ.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionJ.Code = new CodeableConcept();
-                    CauseOfDeathConditionJ.Code.Text = value;
-                }
-             }
-        }
-
-        /// <summary>Cause of Death Part I Interval, Line j.</summary>
-        /// <value>the ninth underlying cause of death approximate interval: onset to death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.INTERVAL1J = "example";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1J}");</para>
-        /// </example>
-        [Property("INTERVAL1J", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line j.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        public string INTERVAL1J
-        {
-            get
-            {
-                if (CauseOfDeathConditionJ != null && CauseOfDeathConditionJ.Onset != null)
-                {
-                    return CauseOfDeathConditionJ.Onset.ToString();
-                }
-                return null;
-            }
-            set
-            {
-                if (CauseOfDeathConditionJ == null)
-                {
-                    CauseOfDeathConditionJ = CauseOfDeathCondition(9);
-                }
-
-                CauseOfDeathConditionJ.Onset = new FhirString(value);
-             }
-        }
-
-        /// <summary>Cause of Death Part I Code, Line j.</summary>
-        /// <value>the ninth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "example");</para>
-        /// <para>code.Add("system", "example");</para>
-        /// <para>code.Add("display", "example");</para>
-        /// <para>ExampleDeathRecord.CODE1J = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1J['display']}");</para>
-        /// </example>
-        [Property("CODE1J", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line j.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        public Dictionary<string, string> CODE1J
-        {
-            get
-            {
-                if (CauseOfDeathConditionJ != null && CauseOfDeathConditionJ.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionJ.Code);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (CauseOfDeathConditionJ == null)
-                {
-                    CauseOfDeathConditionJ = CauseOfDeathCondition(9);
-                }
-               if (CauseOfDeathConditionJ.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionJ.Code.Text;
-                    CauseOfDeathConditionJ.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionJ.Code = DictToCodeableConcept(value);
-                }
-            }
-        }
 
 
         /////////////////////////////////////////////////////////////////////////////////
@@ -7702,17 +7040,18 @@ public string SpouseMaidenName
             }
 
             // Grab Causes of Death using CauseOfDeathConditionPathway
-            List<Condition> causeConditions = new List<Condition>();
+            List<Observation> causeConditions = new List<Observation>();
             if (CauseOfDeathConditionPathway != null)
             {
                 foreach (List.EntryComponent condition in CauseOfDeathConditionPathway.Entry)
                 {
                     if (condition != null && condition.Item != null && condition.Item.Reference != null)
                     {
-                        var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Condition && (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
+                        var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69453-9") &&
+                        (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
                         if (codCond != null)
                         {
-                            causeConditions.Add((Condition)codCond.Resource);
+                            causeConditions.Add((Observation)codCond.Resource);
                         }
                     }
                 }
@@ -7732,41 +7071,41 @@ public string SpouseMaidenName
                 {
                     CauseOfDeathConditionD = causeConditions[3];
                 }
-                if (causeConditions.Count() > 4)
-                {
-                    CauseOfDeathConditionE = causeConditions[4];
-                }
-                if (causeConditions.Count() > 5)
-                {
-                    CauseOfDeathConditionF = causeConditions[5];
-                }
-                if (causeConditions.Count() > 6)
-                {
-                    CauseOfDeathConditionG = causeConditions[6];
-                }
-                if (causeConditions.Count() > 7)
-                {
-                    CauseOfDeathConditionH = causeConditions[7];
-                }
-                if (causeConditions.Count() > 8)
-                {
-                    CauseOfDeathConditionI = causeConditions[8];
-                }
-                if (causeConditions.Count() > 9)
-                {
-                    CauseOfDeathConditionJ = causeConditions[9];
-                }
+                // if (causeConditions.Count() > 4)
+                // {
+                //     CauseOfDeathConditionE = causeConditions[4];
+                // }
+                // if (causeConditions.Count() > 5)
+                // {
+                //     CauseOfDeathConditionF = causeConditions[5];
+                // }
+                // if (causeConditions.Count() > 6)
+                // {
+                //     CauseOfDeathConditionG = causeConditions[6];
+                // }
+                // if (causeConditions.Count() > 7)
+                // {
+                //     CauseOfDeathConditionH = causeConditions[7];
+                // }
+                // if (causeConditions.Count() > 8)
+                // {
+                //     CauseOfDeathConditionI = causeConditions[8];
+                // }
+                // if (causeConditions.Count() > 9)
+                // {
+                //     CauseOfDeathConditionJ = causeConditions[9];
+                // }
             }
 
             // Grab Condition Contributing To Death
-            List<Condition> remainingConditions = new List<Condition>();
-            foreach (var condition in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Condition ))
+            List<Observation> remainingConditions = new List<Observation>();
+            foreach (var condition in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69441-4")))
             {
                 if (condition != null)
                 {
-                    if (!causeConditions.Contains((Condition)condition.Resource))
+                    if (!causeConditions.Contains((Observation)condition.Resource))
                     {
-                        remainingConditions.Add((Condition)condition.Resource);
+                        remainingConditions.Add((Observation)condition.Resource);
 
                     }
                 }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -393,7 +393,7 @@ namespace VRDR
             CauseOfDeathConditionPathway = new List();
             CauseOfDeathConditionPathway.Id = Guid.NewGuid().ToString();
             CauseOfDeathConditionPathway.Meta = new Meta();
-            string[] causeofdeathconditionpathway_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway" };
+            string[] causeofdeathconditionpathway_profile = { ProfileURL.CauseOfDeathPathway };
             CauseOfDeathConditionPathway.Meta.Profile = causeofdeathconditionpathway_profile;
             CauseOfDeathConditionPathway.Status = List.ListStatus.Current;
             CauseOfDeathConditionPathway.Mode = Hl7.Fhir.Model.ListMode.Snapshot;
@@ -1503,7 +1503,7 @@ namespace VRDR
         /// <para>    Console.WriteLine($"Cause: {cause.Item1}, Onset: {cause.Item2}, Code: {cause.Item3}");</para>
         /// <para>}</para>
         /// </example>
-        [Property("Causes Of Death", Property.Types.TupleCOD, "Death Certification", "Conditions that resulted in the cause of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-of-Death-Pathway.html", true, 50)]
+        [Property("Causes Of Death", Property.Types.TupleCOD, "Death Certification", "Conditions that resulted in the cause of death.", true, IGURL.CauseOfDeathPathway, true, 50)]
         [FHIRPath("Bundle.entry.resource.where($this is Condition).where(onset.empty().not())", "")]
         public Tuple<string, string /*, Dictionary<string, string>*/>[] CausesOfDeath
         {

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -1557,42 +1557,7 @@ namespace VRDR
                         INTERVAL1D = value[3].Item2;
                         // CODE1D = value[3].Item3;
                     }
-                    // if (value.Length > 4)
-                    // {
-                    //     COD1E = value[4].Item1;
-                    //     INTERVAL1E = value[4].Item2;
-                    //     CODE1E = value[4].Item3;
-                    // }
-                    // if (value.Length > 5)
-                    // {
-                    //     COD1F = value[5].Item1;
-                    //     INTERVAL1F = value[5].Item2;
-                    //     CODE1F = value[5].Item3;
-                    // }
-                    // if (value.Length > 6)
-                    // {
-                    //     COD1G = value[6].Item1;
-                    //     INTERVAL1G = value[6].Item2;
-                    //     CODE1G = value[6].Item3;
-                    // }
-                    // if (value.Length > 7)
-                    // {
-                    //     COD1H = value[7].Item1;
-                    //     INTERVAL1H = value[7].Item2;
-                    //     CODE1H = value[7].Item3;
-                    // }
-                    // if (value.Length > 8)
-                    // {
-                    //     COD1I = value[8].Item1;
-                    //     INTERVAL1I = value[8].Item2;
-                    //     CODE1I = value[8].Item3;
-                    // }
-                    // if (value.Length > 9)
-                    // {
-                    //     COD1J = value[9].Item1;
-                    //     INTERVAL1J = value[9].Item2;
-                    //     CODE1J = value[9].Item3;
-                    // }
+
                 }
             }
         }
@@ -7039,30 +7004,7 @@ public string SpouseMaidenName
                 {
                     CauseOfDeathConditionD = causeConditions[3];
                 }
-                // if (causeConditions.Count() > 4)
-                // {
-                //     CauseOfDeathConditionE = causeConditions[4];
-                // }
-                // if (causeConditions.Count() > 5)
-                // {
-                //     CauseOfDeathConditionF = causeConditions[5];
-                // }
-                // if (causeConditions.Count() > 6)
-                // {
-                //     CauseOfDeathConditionG = causeConditions[6];
-                // }
-                // if (causeConditions.Count() > 7)
-                // {
-                //     CauseOfDeathConditionH = causeConditions[7];
-                // }
-                // if (causeConditions.Count() > 8)
-                // {
-                //     CauseOfDeathConditionI = causeConditions[8];
-                // }
-                // if (causeConditions.Count() > 9)
-                // {
-                //     CauseOfDeathConditionJ = causeConditions[9];
-                // }
+
             }
 
             // Grab Condition Contributing To Death

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -1448,9 +1448,9 @@ namespace VRDR
         {
             get
             {
-                if (ConditionContributingToDeath != null && ConditionContributingToDeath.Code != null && ConditionContributingToDeath.Code.Text != null)
+                if (ConditionContributingToDeath != null && ConditionContributingToDeath.Value != null)
                 {
-                    return ConditionContributingToDeath.Code.Text;
+                    return (CodeableConceptToDict((CodeableConcept)ConditionContributingToDeath.Value))["text"];
                 }
                 return null;
             }
@@ -1458,7 +1458,7 @@ namespace VRDR
             {
                 if (ConditionContributingToDeath != null)
                 {
-                    ConditionContributingToDeath.Code.Text = value;
+                    ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
                 }
                 else
                 {
@@ -1470,8 +1470,7 @@ namespace VRDR
                     string[] condition_profile = { ProfileURL.CauseOfDeathPart2 };
                     ConditionContributingToDeath.Meta.Profile = condition_profile;
                     ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
-                    ConditionContributingToDeath.Code = new CodeableConcept();
-                    ConditionContributingToDeath.Code.Text = value;
+                    ConditionContributingToDeath.Value= new CodeableConcept(null, null, null, value);
                     AddReferenceToComposition(ConditionContributingToDeath.Id);
                     Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
                 }
@@ -1611,9 +1610,9 @@ namespace VRDR
         {
             get
             {
-                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Code != null)
+                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Value != null)
                 {
-                    return CauseOfDeathConditionA.Code.Text;
+                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionA.Value))["text"];
                 }
                 return null;
             }
@@ -1623,15 +1622,7 @@ namespace VRDR
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
-                if (CauseOfDeathConditionA.Code != null)
-                {
-                    CauseOfDeathConditionA.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionA.Code = new CodeableConcept();
-                    CauseOfDeathConditionA.Code.Text = value;
-                }
+                CauseOfDeathConditionA.Value= new CodeableConcept(null, null, null, value);
             }
         }
 
@@ -1746,9 +1737,9 @@ namespace VRDR
         {
             get
             {
-                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Code != null)
+                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Value != null)
                 {
-                    return CauseOfDeathConditionB.Code.Text;
+                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionB.Value))["text"];
                 }
                 return null;
             }
@@ -1758,16 +1749,7 @@ namespace VRDR
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
-
-                if (CauseOfDeathConditionB.Code != null)
-                {
-                    CauseOfDeathConditionB.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionB.Code = new CodeableConcept();
-                    CauseOfDeathConditionB.Code.Text = value;
-                }
+                CauseOfDeathConditionB.Value = new CodeableConcept(null, null, null, value);
             }
         }
 
@@ -1881,9 +1863,9 @@ namespace VRDR
         {
             get
             {
-                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Code != null)
+                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Value != null)
                 {
-                    return CauseOfDeathConditionC.Code.Text;
+                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionC.Value))["text"];
                 }
                 return null;
             }
@@ -1893,15 +1875,9 @@ namespace VRDR
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
-                if (CauseOfDeathConditionC.Code != null)
-                {
-                    CauseOfDeathConditionC.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionC.Code = new CodeableConcept();
-                    CauseOfDeathConditionC.Code.Text = value;
-                }
+
+                CauseOfDeathConditionC.Value = new CodeableConcept(null, null, null, value);
+
             }
         }
 
@@ -2015,9 +1991,9 @@ namespace VRDR
         {
             get
             {
-                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Code != null)
+                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Value != null)
                 {
-                    return CauseOfDeathConditionD.Code.Text;
+                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionD.Value))["text"];
                 }
                 return null;
             }
@@ -2027,15 +2003,7 @@ namespace VRDR
                 {
                     CauseOfDeathConditionD = CauseOfDeathCondition(3);
                 }
-                if (CauseOfDeathConditionD.Code != null)
-                {
-                    CauseOfDeathConditionD.Code.Text = value;
-                }
-                else
-                {
-                    CauseOfDeathConditionD.Code = new CodeableConcept();
-                    CauseOfDeathConditionD.Code.Text = value;
-                }
+                CauseOfDeathConditionD.Value = new CodeableConcept(null, null, null, value);
             }
         }
 
@@ -2103,38 +2071,38 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1D['display']}");</para>
         /// </example>
-        [Property("CODE1D", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        public Dictionary<string, string> CODE1D
-        {
-            get
-            {
-                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Code != null)
-                {
-                    return CodeableConceptToDict(CauseOfDeathConditionD.Code);
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                if (CauseOfDeathConditionD == null)
-                {
-                    CauseOfDeathConditionD = CauseOfDeathCondition(3);
-                }
-               if (CauseOfDeathConditionD.Code != null)
-                {
-                    CodeableConcept code = DictToCodeableConcept(value);
-                    code.Text = CauseOfDeathConditionD.Code.Text;
-                    CauseOfDeathConditionD.Code = code;
-                }
-                else
-                {
-                    CauseOfDeathConditionD.Code = DictToCodeableConcept(value);
-                }
-            }
-        }
+        // [Property("CODE1D", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // public Dictionary<string, string> CODE1D
+        // {
+        //     get
+        //     {
+        //         if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Code != null)
+        //         {
+        //             return CodeableConceptToDict(CauseOfDeathConditionD.Code);
+        //         }
+        //         return EmptyCodeDict();
+        //     }
+        //     set
+        //     {
+        //         if (CauseOfDeathConditionD == null)
+        //         {
+        //             CauseOfDeathConditionD = CauseOfDeathCondition(3);
+        //         }
+        //        if (CauseOfDeathConditionD.Code != null)
+        //         {
+        //             CodeableConcept code = DictToCodeableConcept(value);
+        //             code.Text = CauseOfDeathConditionD.Code.Text;
+        //             CauseOfDeathConditionD.Code = code;
+        //         }
+        //         else
+        //         {
+        //             CauseOfDeathConditionD.Code = DictToCodeableConcept(value);
+        //         }
+        //     }
+        // }
 
 
 
@@ -7103,7 +7071,7 @@ public string SpouseMaidenName
             {
                 if (condition != null)
                 {
-                    if (!causeConditions.Contains((Observation)condition.Resource))
+                    if (!causeConditions.Contains((Observation)condition.Resource)) // should never trigger, since now Part1 and Part2 are observations with different codes
                     {
                         remainingConditions.Add((Observation)condition.Resource);
 
@@ -7868,7 +7836,7 @@ public string SpouseMaidenName
                     }
                     else if (property.Value["Type"] == Property.Types.TupleCOD)
                     {
-                        value = property.Value["Value"].ToObject<Tuple<string, string, Dictionary<string, string>>[]>();
+                        value = property.Value["Value"].ToObject<Tuple<string, string /*, Dictionary<string, string>*/>[]>();
                     }
                     else if (property.Value["Type"] == Property.Types.Dictionary)
                     {


### PR DESCRIPTION
1) Transitioned CausesOfDeath from Conditions to Observations.  This involved moving the content from the code field to the value field, and using appropriate codes for Part1 and Part2 causes of death.  The Interval value used to be stored in the value, and is now stored in a component.
2) update test cases to reflect these changes
3) Deleted or commented out a LOT of other stuff.
   - There used to be COD1E-COD1J, INTERVAL1E-INTERVAL1J despite the fact that there are only 4 Part1 causes of death (A-D)
    - There used to be CODE1A (with an E) that took a codeable concept as input.  However, NCHS doesn't want people sending coded content in the CODE1X fields, it is supposed to be English.   So, I commented all of these out everywhere they were used.   The only remaining interface sets/gets string values for these causes of death.
  4) Things I didn't change but maybe I should have:
     - The Part1 and Part2 causes of death are still labeled/named as conditions, despite the fact that they are now observations.
     - The CauseOfDeathPathway which seems like a silly construct has code in to sort out the two different types of conditions.  I left the code in despite the fact that there are no conditions, only two different types of observations (Part1 and Part2).   SOme of the checking is degenerate and should not be triggered.