### PR TITLE
Certifier, Manner of Death, Death Certification,  Injury Incident Cleanup, Emerging Issues

### DIFF
--- a/VRDR.CLI/1.json
+++ b/VRDR.CLI/1.json
@@ -556,7 +556,7 @@
         "id": "cffcc6e0-7324-4898-b876-9107d275eafa",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home"
           ]
         },
         "active": true,
@@ -564,9 +564,9 @@
           {
             "coding": [
               {
-                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                "code": "bus",
-                "display": "Non-Healthcare Business or Corporation"
+                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs",
+                "code": "funeralhome",
+                "display": "Funeral Home"
               }
             ]
           }
@@ -1496,23 +1496,18 @@
         "id": "4678efc2-2529-4a7e-8266-fdc907d89e00",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                "system": "2.16.840.1.113883.6.92",
-                "code": "25",
-                "display": "MA"
-                }
-              ]
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
             }
-          }
-        ],
+          ]
+        }],
         "name": "Example Death Location Name",
         "description": "Example Death Location Description",
         "address": {

--- a/VRDR.CLI/1.xml
+++ b/VRDR.CLI/1.xml
@@ -439,9 +439,9 @@
         <active value="true" />
         <type>
           <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/organization-type" />
-            <code value="bus" />
-            <display value="Non-Healthcare Business or Corporation" />
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs" />
+            <code value="funeralhome" />
+            <display value="Funeral Home" />
           </coding>
         </type>
         <name value="Smith Funeral Home" />
@@ -530,6 +530,13 @@
           <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" />
         </meta>
         <name value="Bedford Cemetery" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs" />
+            <code value="disposition" />
+            <display value="Disposition Location" />
+          </coding>
+        </type>
         <address>
           <line value="603 Example Street" />
           <line value="Line 2" />
@@ -1304,19 +1311,17 @@
       <Location>
         <id value="d1113c5e-ccba-437e-9fbd-64ebfdcfb617" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" />
-        </meta>
-        <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id">
-          <valueCodeableConcept>
-            <coding>
-              <system value="2.16.840.1.113883.6.92"/>
-              <code value="25"/>
-              <display value="MA"/>
-            </coding>
-          </valueCodeableConcept>
-        </extension>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location" />
+        </meta>>
         <name value="Example Death Location Name" />
         <description value="Example Death Location Description" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="death" />
+            <display value="death location" />
+          </coding>
+        </type>
         <address>
           <line value="671 Example Street" />
           <line value="Line 2" />

--- a/VRDR.CLI/1_wJurisdiction.json
+++ b/VRDR.CLI/1_wJurisdiction.json
@@ -602,68 +602,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:84452aa0-fc31-4f4c-848f-b8f1e5bba1c0",
-      "resource": {
-        "resourceType": "Practitioner",
-        "id": "84452aa0-fc31-4f4c-848f-b8f1e5bba1c0",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician"
-          ]
-        },
-        "identifier": [
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "9876543210"
-          }
-        ],
-        "name": [
-          {
-            "use": "official",
-            "family": "Last",
-            "given": [
-              "FD",
-              "Middle"
-            ],
-            "suffix": [
-              "Jr."
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl": "urn:uuid:a9a45b6c-566c-4ad7-bce7-8c23751b669d",
-      "resource": {
-        "resourceType": "Practitioner",
-        "id": "a9a45b6c-566c-4ad7-bce7-8c23751b669d",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Pronouncement-Performer"
-          ]
-        },
-        "identifier": [
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "0000000000"
-          }
-        ],
-        "name": [
-          {
-            "use": "official",
-            "family": "Last",
-            "given": [
-              "FD",
-              "Middle"
-            ],
-            "suffix": [
-              "Jr."
-            ]
-          }
-        ]
-      }
-    },
-    {
       "fullUrl": "urn:uuid:2d71d05b-7f52-4c13-bd19-68a251e3544d",
       "resource": {
         "resourceType": "Procedure",
@@ -764,7 +702,7 @@
         "id": "cffcc6e0-7324-4898-b876-9107d275eafa",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home"
           ]
         },
         "active": true,
@@ -772,9 +710,9 @@
           {
             "coding": [
               {
-                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                "code": "bus",
-                "display": "Non-Healthcare Business or Corporation"
+                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs",
+                "code": "funeralhome",
+                "display": "Funeral Home"
               }
             ]
           }
@@ -874,9 +812,18 @@
         "id": "fe696fc7-7683-4268-92d8-b3a7c88b1587",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "disposition",
+              "display": "disposition location"
+            }
+          ]
+        }],
         "name": "Bedford Cemetery",
         "address": {
           "line": [
@@ -1437,12 +1384,12 @@
         "id": "fc9de024-0fae-4bda-bfbb-04c08c083a43",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-disposition-method"
           ]
         },
         "extension": [
           {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location",
+            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location",
             "valueReference": {
               "reference": "urn:uuid:fe696fc7-7683-4268-92d8-b3a7c88b1587"
             }
@@ -1739,9 +1686,18 @@
         "id": "3c1f5202-68de-47e8-813f-43a3f7f29129",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "injury",
+              "display": "injury location"
+            }
+          ]
+        }],
         "name": "Example Injury Location Name",
         "description": "Example Injury Location Description",
         "address": {
@@ -1832,9 +1788,18 @@
         "id": "4678efc2-2529-4a7e-8266-fdc907d89e00",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
+            }
+          ]
+        }],
         "name": "Example Death Location Name",
         "description": "Example Death Location Description",
         "address": {
@@ -1847,20 +1812,7 @@
           "state": "MA",
           "postalCode": "01730",
           "country": "US"
-        },
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-            "valueCodeableConcept": {
-              "coding": [ {
-                "system": "urn:oid:2.16.840.1.113883.6.92",
-                "code": "25",
-                "display": "MA"
-              }
-              ]
-            }
-          }
-        ]
+        }
       }
     },
     {
@@ -1905,6 +1857,26 @@
               ]
             },
             "valueDateTime": "2018-02-20T16:48:06-05:00"
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "58332-8",
+                  "display": "Location of death"
+                }
+              ]
+            },
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "system" : "http://snomed.info/sct",
+                  "code" : "440081000124100",
+                  "display": "Death in home"
+                }
+              ]
+            }
           }
         ]
       }

--- a/VRDR.CLI/1_wJurisdiction.xml
+++ b/VRDR.CLI/1_wJurisdiction.xml
@@ -606,14 +606,14 @@
       <Organization>
         <id value="b2b3e7ce-5abc-4f22-a76f-d6e39dc8991c" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home" />
         </meta>
         <active value="true" />
         <type>
           <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/organization-type" />
-            <code value="bus" />
-            <display value="Non-Healthcare Business or Corporation" />
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs" />
+            <code value="funeralhome" />
+            <display value="Funeral Home" />
           </coding>
         </type>
         <name value="Smith Funeral Home" />
@@ -699,9 +699,16 @@
       <Location>
         <id value="9bebc631-70b1-4052-bb61-7909caa7f5d4" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location" />
         </meta>
         <name value="Bedford Cemetery" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs" />
+            <code value="disposition" />
+            <display value="Disposition Location" />
+          </coding>
+        </type>
         <address>
           <line value="603 Example Street" />
           <line value="Line 2" />
@@ -1113,11 +1120,6 @@
         <meta>
           <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method" />
         </meta>
-        <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location">
-          <valueReference>
-            <reference value="urn:uuid:9bebc631-70b1-4052-bb61-7909caa7f5d4" />
-          </valueReference>
-        </extension>
         <status value="final" />
         <code>
           <coding>
@@ -1412,19 +1414,17 @@
       <Location>
         <id value="d1113c5e-ccba-437e-9fbd-64ebfdcfb617" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location" />
         </meta>
-         <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id">
-         <valueCodeableConcept>
-            <coding>
-              <system value="urn:oid:2.16.840.1.113883.6.92"/>
-              <code value="25" />
-              <display value="MA"/>
-            </coding>
-            </valueCodeableConcept>
-        </extension>
         <name value="Example Death Location Name" />
         <description value="Example Death Location Description" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="death" />
+            <display value="death location" />
+          </coding>
+        </type>
         <address>
           <line value="671 Example Street" />
           <line value="Line 2" />

--- a/VRDR.CLI/1_wJurisdiction.xml
+++ b/VRDR.CLI/1_wJurisdiction.xml
@@ -1471,6 +1471,22 @@
           </code>
           <valueDateTime value="2018-02-20T16:48:06-05:00" />
         </component>
+             <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="58332-8" />
+              <display value="Location of death" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="440081000124100"/>
+              <display value="Death in home"/>
+            </coding>
+          </valueCodeableConcept>
+        </component>
       </Observation>
     </resource>
   </entry>

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -40,33 +40,6 @@ namespace VRDR.CLI
                 certificationRole.Add("display", "Physician");
                 deathRecord.CertificationRole = certificationRole;
 
-                // // InterestedPartyIdentifier
-                // var ipId = new Dictionary<string, string>();
-                // ipId["system"] = "http://hl7.org/fhir/sid/us-npi";
-                // ipId["value"] = "0000000000";
-                // deathRecord.InterestedPartyIdentifier = ipId;
-
-                // // InterestedPartyName
-                // deathRecord.InterestedPartyName = "Example Hospital";
-
-                // // InterestedPartyAddress
-                // Dictionary<string, string> address = new Dictionary<string, string>();
-                // address.Add("addressLine1", "10 Example Street");
-                // address.Add("addressLine2", "Line 2");
-                // address.Add("addressCity", "Bedford");
-                // address.Add("addressCounty", "Middlesex");
-                // address.Add("addressState", "MA");
-                // address.Add("addressZip", "01730");
-                // address.Add("addressCountry", "US");
-                // deathRecord.InterestedPartyAddress = address;
-
-                // // InterestedPartyType
-                // Dictionary<string, string> type = new Dictionary<string, string>();
-                // type.Add("code", "prov");
-                // type.Add("system", "http://terminology.hl7.org/CodeSystem/organization-type");
-                // type.Add("display", "Healthcare Provider");
-                // deathRecord.InterestedPartyType = type;
-
                 // State Local Identifier
                 deathRecord.StateLocalIdentifier = "42";
 
@@ -105,13 +78,6 @@ namespace VRDR.CLI
 
                 // // CertifierLicenseNumber
                 // deathRecord.CertifierLicenseNumber = "789123456";
-
-                // // CertifierQualification
-                // Dictionary<string, string> qualification = new Dictionary<string, string>();
-                // qualification.Add("code", "434641000124105");
-                // qualification.Add("system", "http://snomed.info/sct");
-                // qualification.Add("display", "Physician certified and pronounced death certificate");
-                // deathRecord.CertifierQualification = qualification;
 
                 // ContributingConditions
                 deathRecord.ContributingConditions = "Example Contributing Conditions";
@@ -389,13 +355,6 @@ namespace VRDR.CLI
                 codeIW.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
                 codeIW.Add("display", "No");
                 deathRecord.InjuryAtWork = codeIW;
-
-                // // TransportationInjury
-                // Dictionary<string, string> codeTI = new Dictionary<string, string>();
-                // codeTI.Add("code", "Y");
-                // codeTI.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                // codeTI.Add("display", "Yes");
-                // deathRecord.TransportationEvent = codeTI;
 
                 // InjuryPlace
                 deathRecord.InjuryPlaceDescription = "Home";

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -234,21 +234,21 @@ namespace VRDR.CLI
                 mserv.Add("display", "Yes");
                 deathRecord.MilitaryService = mserv;
 
-                // MorticianGivenNames
-                string[] fdnames = { "FD", "Middle" };
-                deathRecord.MorticianGivenNames = fdnames;
+                // // MorticianGivenNames
+                // string[] fdnames = { "FD", "Middle" };
+                // deathRecord.MorticianGivenNames = fdnames;
 
-                // MorticianFamilyName
-                deathRecord.MorticianFamilyName = "Last";
+                // // MorticianFamilyName
+                // deathRecord.MorticianFamilyName = "Last";
 
-                // MorticianSuffix
-                deathRecord.MorticianSuffix = "Jr.";
+                // // MorticianSuffix
+                // deathRecord.MorticianSuffix = "Jr.";
 
-                // MorticianIdentifier
-                var mortId = new Dictionary<string, string>();
-                mortId["value"] = "9876543210";
-                mortId["system"] = "http://hl7.org/fhir/sid/us-npi";
-                deathRecord.MorticianIdentifier = mortId;
+                // // MorticianIdentifier
+                // var mortId = new Dictionary<string, string>();
+                // mortId["value"] = "9876543210";
+                // mortId["system"] = "http://hl7.org/fhir/sid/us-npi";
+                // deathRecord.MorticianIdentifier = mortId;
 
                 // FuneralHomeAddress
                 Dictionary<string, string> fdaddress = new Dictionary<string, string>();
@@ -265,7 +265,7 @@ namespace VRDR.CLI
                 deathRecord.FuneralHomeName = "Smith Funeral Home";
 
                 // FuneralDirectorPhone
-                deathRecord.FuneralDirectorPhone = "000-000-0000";
+                //deathRecord.FuneralDirectorPhone = "000-000-0000";
 
                 // DispositionLocationAddress
                 Dictionary<string, string> dladdress = new Dictionary<string, string>();
@@ -571,6 +571,7 @@ namespace VRDR.CLI
                     {
                         continue;
                     }
+                    Console.WriteLine($"Property: Name: {property.Name.ToString()} Type: {property.PropertyType.ToString()}");
                     string one;
                     string two;
                     string three;

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -40,32 +40,32 @@ namespace VRDR.CLI
                 certificationRole.Add("display", "Physician");
                 deathRecord.CertificationRole = certificationRole;
 
-                // InterestedPartyIdentifier
-                var ipId = new Dictionary<string, string>();
-                ipId["system"] = "http://hl7.org/fhir/sid/us-npi";
-                ipId["value"] = "0000000000";
-                deathRecord.InterestedPartyIdentifier = ipId;
+                // // InterestedPartyIdentifier
+                // var ipId = new Dictionary<string, string>();
+                // ipId["system"] = "http://hl7.org/fhir/sid/us-npi";
+                // ipId["value"] = "0000000000";
+                // deathRecord.InterestedPartyIdentifier = ipId;
 
-                // InterestedPartyName
-                deathRecord.InterestedPartyName = "Example Hospital";
+                // // InterestedPartyName
+                // deathRecord.InterestedPartyName = "Example Hospital";
 
-                // InterestedPartyAddress
-                Dictionary<string, string> address = new Dictionary<string, string>();
-                address.Add("addressLine1", "10 Example Street");
-                address.Add("addressLine2", "Line 2");
-                address.Add("addressCity", "Bedford");
-                address.Add("addressCounty", "Middlesex");
-                address.Add("addressState", "MA");
-                address.Add("addressZip", "01730");
-                address.Add("addressCountry", "US");
-                deathRecord.InterestedPartyAddress = address;
+                // // InterestedPartyAddress
+                // Dictionary<string, string> address = new Dictionary<string, string>();
+                // address.Add("addressLine1", "10 Example Street");
+                // address.Add("addressLine2", "Line 2");
+                // address.Add("addressCity", "Bedford");
+                // address.Add("addressCounty", "Middlesex");
+                // address.Add("addressState", "MA");
+                // address.Add("addressZip", "01730");
+                // address.Add("addressCountry", "US");
+                // deathRecord.InterestedPartyAddress = address;
 
-                // InterestedPartyType
-                Dictionary<string, string> type = new Dictionary<string, string>();
-                type.Add("code", "prov");
-                type.Add("system", "http://terminology.hl7.org/CodeSystem/organization-type");
-                type.Add("display", "Healthcare Provider");
-                deathRecord.InterestedPartyType = type;
+                // // InterestedPartyType
+                // Dictionary<string, string> type = new Dictionary<string, string>();
+                // type.Add("code", "prov");
+                // type.Add("system", "http://terminology.hl7.org/CodeSystem/organization-type");
+                // type.Add("display", "Healthcare Provider");
+                // deathRecord.InterestedPartyType = type;
 
                 // State Local Identifier
                 deathRecord.StateLocalIdentifier = "42";
@@ -390,12 +390,12 @@ namespace VRDR.CLI
                 codeIW.Add("display", "No");
                 deathRecord.InjuryAtWork = codeIW;
 
-                // TransportationInjury
-                Dictionary<string, string> codeTI = new Dictionary<string, string>();
-                codeTI.Add("code", "Y");
-                codeTI.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
-                codeTI.Add("display", "Yes");
-                deathRecord.TransportationEvent = codeTI;
+                // // TransportationInjury
+                // Dictionary<string, string> codeTI = new Dictionary<string, string>();
+                // codeTI.Add("code", "Y");
+                // codeTI.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");
+                // codeTI.Add("display", "Yes");
+                // deathRecord.TransportationEvent = codeTI;
 
                 // InjuryPlace
                 deathRecord.InjuryPlaceDescription = "Home";

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -103,15 +103,15 @@ namespace VRDR.CLI
                 certifierIdentifier.Add("value", "1234567890");
                 deathRecord.CertifierIdentifier = certifierIdentifier;
 
-                // CertifierLicenseNumber
-                deathRecord.CertifierLicenseNumber = "789123456";
+                // // CertifierLicenseNumber
+                // deathRecord.CertifierLicenseNumber = "789123456";
 
-                // CertifierQualification
-                Dictionary<string, string> qualification = new Dictionary<string, string>();
-                qualification.Add("code", "434641000124105");
-                qualification.Add("system", "http://snomed.info/sct");
-                qualification.Add("display", "Physician certified and pronounced death certificate");
-                deathRecord.CertifierQualification = qualification;
+                // // CertifierQualification
+                // Dictionary<string, string> qualification = new Dictionary<string, string>();
+                // qualification.Add("code", "434641000124105");
+                // qualification.Add("system", "http://snomed.info/sct");
+                // qualification.Add("display", "Physician certified and pronounced death certificate");
+                // deathRecord.CertifierQualification = qualification;
 
                 // ContributingConditions
                 deathRecord.ContributingConditions = "Example Contributing Conditions";

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -578,9 +578,10 @@ namespace VRDR.CLI
                     if (property.PropertyType.ToString() == "System.Collections.Generic.Dictionary`2[System.String,System.String]")
                     {
                         Dictionary<string,string> oneDict = (Dictionary<string,string>)property.GetValue(d1);
-                        one = String.Join(", ", oneDict.Select(x => x.Key + "=" + x.Value).ToArray());
-                        two = String.Join(", ", ((Dictionary<string,string>)property.GetValue(d2)).Select(x => x.Key + "=" + x.Value).ToArray());
-                        three = String.Join(", ", ((Dictionary<string,string>)property.GetValue(d3)).Select(x => x.Key + "=" + x.Value).ToArray());
+                        // Ignore empty entries in the dictionary so they don't throw off comparisons.
+                        one = String.Join(", ", oneDict.Select(x => (x.Value != "")?(x.Key + "=" + x.Value):("")).ToArray()).Replace(" ,","");
+                        two = String.Join(", ", ((Dictionary<string,string>)property.GetValue(d2)).Select(x => (x.Value != "")?(x.Key + "=" + x.Value):("")).ToArray()).Replace(" ,","");;
+                        three = String.Join(", ", ((Dictionary<string,string>)property.GetValue(d3)).Select(x => (x.Value != "")?(x.Key + "=" + x.Value):("")).ToArray()).Replace(" ,","");;
                     }
                     else if (property.PropertyType.ToString() == "System.String[]")
                     {

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -958,7 +958,7 @@ namespace VRDR.Tests
             raddress.Add("addressUnitnum", "A");
 
             SetterDeathRecord.Residence = raddress;
-            
+
             Assert.Equal("101 Example Street", SetterDeathRecord.Residence["addressLine1"]);
             Assert.Equal("Line 2", SetterDeathRecord.Residence["addressLine2"]);
             Assert.Equal("Bedford", SetterDeathRecord.Residence["addressCity"]);
@@ -2327,42 +2327,42 @@ namespace VRDR.Tests
             Assert.Equal("N",((DeathRecord)XMLRecords[0]).InjuryAtWorkHelper);
         }
 
-        [Fact]
-        public void Set_TransportationEvent()
-        {
-            Dictionary<string, string> ite = new Dictionary<string, string>();
-            ite.Add("code", "Y");
-            ite.Add("system", VRDR.CodeSystems.PH_YesNo_HL7_2x);
-            ite.Add("display", "Yes");
-            SetterDeathRecord.TransportationEvent = ite;
-            Assert.Equal("Y", SetterDeathRecord.TransportationEvent["code"]);
-            Assert.Equal(VRDR.CodeSystems.PH_YesNo_HL7_2x, SetterDeathRecord.TransportationEvent["system"]);
-            Assert.Equal("Yes", SetterDeathRecord.TransportationEvent["display"]);
-            Assert.True(SetterDeathRecord.TransportationEventBoolean);
-            SetterDeathRecord.TransportationEventBoolean = false;
-            Assert.Equal("N", SetterDeathRecord.TransportationEvent["code"]);
-            Assert.Equal(VRDR.CodeSystems.PH_YesNo_HL7_2x, SetterDeathRecord.TransportationEvent["system"]);
-            Assert.Equal("No", SetterDeathRecord.TransportationEvent["display"]);
-            Assert.False(SetterDeathRecord.TransportationEventBoolean);
-            SetterDeathRecord.TransportationEventBoolean = null;
-            Assert.Equal("UNK", SetterDeathRecord.TransportationEvent["code"]);
-            Assert.Equal(VRDR.CodeSystems.PH_NullFlavor_HL7_V3, SetterDeathRecord.TransportationEvent["system"]);
-            Assert.Equal("unknown", SetterDeathRecord.TransportationEvent["display"]);
-            Assert.Null(SetterDeathRecord.TransportationEventBoolean);
-        }
+        // [Fact]
+        // public void Set_TransportationEvent()
+        // {
+        //     Dictionary<string, string> ite = new Dictionary<string, string>();
+        //     ite.Add("code", "Y");
+        //     ite.Add("system", VRDR.CodeSystems.PH_YesNo_HL7_2x);
+        //     ite.Add("display", "Yes");
+        //     SetterDeathRecord.TransportationEvent = ite;
+        //     Assert.Equal("Y", SetterDeathRecord.TransportationEvent["code"]);
+        //     Assert.Equal(VRDR.CodeSystems.PH_YesNo_HL7_2x, SetterDeathRecord.TransportationEvent["system"]);
+        //     Assert.Equal("Yes", SetterDeathRecord.TransportationEvent["display"]);
+        //     Assert.True(SetterDeathRecord.TransportationEventBoolean);
+        //     SetterDeathRecord.TransportationEventBoolean = false;
+        //     Assert.Equal("N", SetterDeathRecord.TransportationEvent["code"]);
+        //     Assert.Equal(VRDR.CodeSystems.PH_YesNo_HL7_2x, SetterDeathRecord.TransportationEvent["system"]);
+        //     Assert.Equal("No", SetterDeathRecord.TransportationEvent["display"]);
+        //     Assert.False(SetterDeathRecord.TransportationEventBoolean);
+        //     SetterDeathRecord.TransportationEventBoolean = null;
+        //     Assert.Equal("UNK", SetterDeathRecord.TransportationEvent["code"]);
+        //     Assert.Equal(VRDR.CodeSystems.PH_NullFlavor_HL7_V3, SetterDeathRecord.TransportationEvent["system"]);
+        //     Assert.Equal("unknown", SetterDeathRecord.TransportationEvent["display"]);
+        //     Assert.Null(SetterDeathRecord.TransportationEventBoolean);
+        // }
 
-        [Fact]
-        public void Get_TransportationEvent()
-        {
-            Assert.Equal("Y", ((DeathRecord)JSONRecords[0]).TransportationEvent["code"]);
-            Assert.Equal(VRDR.CodeSystems.YesNo_0136HL7_V2, ((DeathRecord)JSONRecords[0]).TransportationEvent["system"]);
-            Assert.Equal("Yes", ((DeathRecord)JSONRecords[0]).TransportationEvent["display"]);
-            Assert.True(((DeathRecord)JSONRecords[0]).TransportationEventBoolean);
-            Assert.Equal("Y", ((DeathRecord)XMLRecords[0]).TransportationEvent["code"]);
-            Assert.Equal(VRDR.CodeSystems.YesNo_0136HL7_V2, ((DeathRecord)XMLRecords[0]).TransportationEvent["system"]);
-            Assert.Equal("Yes", ((DeathRecord)XMLRecords[0]).TransportationEvent["display"]);
-            Assert.True(((DeathRecord)XMLRecords[0]).TransportationEventBoolean);
-        }
+        // [Fact]
+        // public void Get_TransportationEvent()
+        // {
+        //     Assert.Equal("Y", ((DeathRecord)JSONRecords[0]).TransportationEvent["code"]);
+        //     Assert.Equal(VRDR.CodeSystems.YesNo, ((DeathRecord)JSONRecords[0]).TransportationEvent["system"]);
+        //     Assert.Equal("Yes", ((DeathRecord)JSONRecords[0]).TransportationEvent["display"]);
+        //     Assert.True(((DeathRecord)JSONRecords[0]).TransportationEventBoolean);
+        //     Assert.Equal("Y", ((DeathRecord)XMLRecords[0]).TransportationEvent["code"]);
+        //     Assert.Equal(VRDR.CodeSystems.YesNo, ((DeathRecord)XMLRecords[0]).TransportationEvent["system"]);
+        //     Assert.Equal("Yes", ((DeathRecord)XMLRecords[0]).TransportationEvent["display"]);
+        //     Assert.True(((DeathRecord)XMLRecords[0]).TransportationEventBoolean);
+        // }
 
         [Fact]
         public void Set_DeathLocationAddress()

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1795,6 +1795,12 @@ namespace VRDR.Tests
             fdaddress.Add("addressState", "MA");
             fdaddress.Add("addressZip", "01730");
             fdaddress.Add("addressCountry", "US");
+            fdaddress.Add("addressPredir", "W");
+            fdaddress.Add("addressPostdir", "E");
+            fdaddress.Add("addressStname", "Example");
+            fdaddress.Add("addressStnum", "11");
+            fdaddress.Add("addressStdesig", "Street");
+            fdaddress.Add("addressUnitnum", "3");
             SetterDeathRecord.FuneralHomeAddress = fdaddress;
             Assert.Equal("1011010 Example Street", SetterDeathRecord.FuneralHomeAddress["addressLine1"]);
             Assert.Equal("Line 2", SetterDeathRecord.FuneralHomeAddress["addressLine2"]);
@@ -1803,6 +1809,12 @@ namespace VRDR.Tests
             Assert.Equal("MA", SetterDeathRecord.FuneralHomeAddress["addressState"]);
             Assert.Equal("01730", SetterDeathRecord.FuneralHomeAddress["addressZip"]);
             Assert.Equal("US", SetterDeathRecord.FuneralHomeAddress["addressCountry"]);
+            Assert.Equal("W", SetterDeathRecord.FuneralHomeAddress["addressPredir"]);
+            Assert.Equal("E", SetterDeathRecord.FuneralHomeAddress["addressPostdir"]);
+            Assert.Equal("Example", SetterDeathRecord.FuneralHomeAddress["addressStname"]);
+            Assert.Equal("11", SetterDeathRecord.FuneralHomeAddress["addressStnum"]);
+            Assert.Equal("Street", SetterDeathRecord.FuneralHomeAddress["addressStdesig"]);
+            Assert.Equal("3", SetterDeathRecord.FuneralHomeAddress["addressUnitnum"]);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2533,7 +2533,7 @@ namespace VRDR.Tests
         [Fact]
         public void Get_DateOfDeathPronouncement()
         {
-            Assert.Equal("2019-02-20T16:48:06-05:00", ((DeathRecord)JSONRecords[0]).DateOfDeathPronouncement);
+            Assert.Equal("2018-02-20T16:48:06-05:00", ((DeathRecord)JSONRecords[0]).DateOfDeathPronouncement);
             Assert.Equal("2019-02-20T16:48:06-05:00", ((DeathRecord)XMLRecords[0]).DateOfDeathPronouncement);
         }
 

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1820,6 +1820,7 @@ namespace VRDR.Tests
         [Fact]
         public void Get_FuneralHomeAddress()
         {
+            Assert.Equal("1011010 Example Street", ((DeathRecord)XMLRecords[0]).FuneralHomeAddress["addressLine1"]);
             Assert.Equal("1011010 Example Street", ((DeathRecord)JSONRecords[0]).FuneralHomeAddress["addressLine1"]);
             Assert.Equal("Line 2", ((DeathRecord)JSONRecords[0]).FuneralHomeAddress["addressLine2"]);
             Assert.Equal("Bedford", ((DeathRecord)JSONRecords[0]).FuneralHomeAddress["addressCity"]);
@@ -1827,7 +1828,7 @@ namespace VRDR.Tests
             Assert.Equal("MA", ((DeathRecord)JSONRecords[0]).FuneralHomeAddress["addressState"]);
             Assert.Equal("01730", ((DeathRecord)JSONRecords[0]).FuneralHomeAddress["addressZip"]);
             Assert.Equal("US", ((DeathRecord)JSONRecords[0]).FuneralHomeAddress["addressCountry"]);
-            Assert.Equal("1011010 Example Street", ((DeathRecord)XMLRecords[0]).FuneralHomeAddress["addressLine1"]);
+
             Assert.Equal("Line 2", ((DeathRecord)XMLRecords[0]).FuneralHomeAddress["addressLine2"]);
             Assert.Equal("Bedford", ((DeathRecord)XMLRecords[0]).FuneralHomeAddress["addressCity"]);
             Assert.Equal("Middlesex", ((DeathRecord)XMLRecords[0]).FuneralHomeAddress["addressCounty"]);
@@ -1848,20 +1849,6 @@ namespace VRDR.Tests
         {
             Assert.Equal("Smith Funeral Home", ((DeathRecord)JSONRecords[0]).FuneralHomeName);
             Assert.Equal("Smith Funeral Home", ((DeathRecord)XMLRecords[0]).FuneralHomeName);
-        }
-
-        [Fact]
-        public void Set_FuneralDirectorPhone()
-        {
-            SetterDeathRecord.FuneralDirectorPhone = "000-000-0000";
-            Assert.Equal("000-000-0000", SetterDeathRecord.FuneralDirectorPhone);
-        }
-
-        [Fact]
-        public void Get_FuneralDirectorPhone()
-        {
-            Assert.Equal("000-000-0000", ((DeathRecord)JSONRecords[0]).FuneralDirectorPhone);
-            Assert.Equal("000-000-0000", ((DeathRecord)XMLRecords[0]).FuneralDirectorPhone);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2581,24 +2581,24 @@ namespace VRDR.Tests
         public void Get_EmergingIssues()
         {
             Assert.Equal("A", ((DeathRecord)JSONRecords[0]).EmergingIssue1_1);
-            Assert.Equal("A", ((DeathRecord)XMLRecords[0]).EmergingIssue1_1);
             Assert.Equal("B", ((DeathRecord)JSONRecords[0]).EmergingIssue1_2);
-            Assert.Equal("B", ((DeathRecord)XMLRecords[0]).EmergingIssue1_2);
             Assert.Equal("C", ((DeathRecord)JSONRecords[0]).EmergingIssue1_3);
-            Assert.Equal("C", ((DeathRecord)XMLRecords[0]).EmergingIssue1_3);
             Assert.Equal("D", ((DeathRecord)JSONRecords[0]).EmergingIssue1_4);
-            Assert.Equal("D", ((DeathRecord)XMLRecords[0]).EmergingIssue1_4);
             Assert.Equal("E", ((DeathRecord)JSONRecords[0]).EmergingIssue1_5);
-            Assert.Equal("E", ((DeathRecord)XMLRecords[0]).EmergingIssue1_5);
             Assert.Equal("F", ((DeathRecord)JSONRecords[0]).EmergingIssue1_6);
-            Assert.Equal("F", ((DeathRecord)XMLRecords[0]).EmergingIssue1_6);
             Assert.Equal("AAAAAAAA", ((DeathRecord)JSONRecords[0]).EmergingIssue8_1);
-            Assert.Equal("AAAAAAAA", ((DeathRecord)XMLRecords[0]).EmergingIssue8_1);
             Assert.Equal("BBBBBBBB", ((DeathRecord)JSONRecords[0]).EmergingIssue8_2);
-            Assert.Equal("BBBBBBBB", ((DeathRecord)XMLRecords[0]).EmergingIssue8_2);
             Assert.Equal("CCCCCCCC", ((DeathRecord)JSONRecords[0]).EmergingIssue8_3);
-            Assert.Equal("CCCCCCCC", ((DeathRecord)XMLRecords[0]).EmergingIssue8_3);
             Assert.Equal("AAAAAAAAAAAAAAAAAAAA", ((DeathRecord)JSONRecords[0]).EmergingIssue20);
+            Assert.Equal("A", ((DeathRecord)XMLRecords[0]).EmergingIssue1_1);
+            Assert.Equal("B", ((DeathRecord)XMLRecords[0]).EmergingIssue1_2);
+            Assert.Equal("C", ((DeathRecord)XMLRecords[0]).EmergingIssue1_3);
+            Assert.Equal("D", ((DeathRecord)XMLRecords[0]).EmergingIssue1_4);
+            Assert.Equal("E", ((DeathRecord)XMLRecords[0]).EmergingIssue1_5);
+            Assert.Equal("F", ((DeathRecord)XMLRecords[0]).EmergingIssue1_6);
+            Assert.Equal("AAAAAAAA", ((DeathRecord)XMLRecords[0]).EmergingIssue8_1);
+            Assert.Equal("BBBBBBBB", ((DeathRecord)XMLRecords[0]).EmergingIssue8_2);
+            Assert.Equal("CCCCCCCC", ((DeathRecord)XMLRecords[0]).EmergingIssue8_3);
             Assert.Equal("AAAAAAAAAAAAAAAAAAAA", ((DeathRecord)XMLRecords[0]).EmergingIssue20);
         }
 

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1662,69 +1662,69 @@ namespace VRDR.Tests
             Assert.Equal(VRDR.ValueSets.YesNoUnknown.Yes,((DeathRecord)XMLRecords[0]).MilitaryServiceHelper);
          }
 
-        [Fact]
-        public void Set_MorticianGivenNames()
-        {
-            string[] fdnames = { "FD", "Middle" };
-            SetterDeathRecord.MorticianGivenNames = fdnames;
-            Assert.Equal("FD", SetterDeathRecord.MorticianGivenNames[0]);
-            Assert.Equal("Middle", SetterDeathRecord.MorticianGivenNames[1]);
-        }
+        // [Fact]
+        // public void Set_MorticianGivenNames()
+        // {
+        //     string[] fdnames = { "FD", "Middle" };
+        //     SetterDeathRecord.MorticianGivenNames = fdnames;
+        //     Assert.Equal("FD", SetterDeathRecord.MorticianGivenNames[0]);
+        //     Assert.Equal("Middle", SetterDeathRecord.MorticianGivenNames[1]);
+        // }
 
-        [Fact]
-        public void Get_MorticianGivenNames()
-        {
-            Assert.Equal("FD", ((DeathRecord)JSONRecords[0]).MorticianGivenNames[0]);
-            Assert.Equal("Middle", ((DeathRecord)JSONRecords[0]).MorticianGivenNames[1]);
-            Assert.Equal("FD", ((DeathRecord)XMLRecords[0]).MorticianGivenNames[0]);
-            Assert.Equal("Middle", ((DeathRecord)XMLRecords[0]).MorticianGivenNames[1]);
-        }
+        // [Fact]
+        // public void Get_MorticianGivenNames()
+        // {
+        //     Assert.Equal("FD", ((DeathRecord)JSONRecords[0]).MorticianGivenNames[0]);
+        //     Assert.Equal("Middle", ((DeathRecord)JSONRecords[0]).MorticianGivenNames[1]);
+        //     Assert.Equal("FD", ((DeathRecord)XMLRecords[0]).MorticianGivenNames[0]);
+        //     Assert.Equal("Middle", ((DeathRecord)XMLRecords[0]).MorticianGivenNames[1]);
+        // }
 
-        [Fact]
-        public void Set_MorticianFamilyName()
-        {
-            SetterDeathRecord.MorticianFamilyName = "Last";
-            Assert.Equal("Last", SetterDeathRecord.MorticianFamilyName);
-        }
+        // [Fact]
+        // public void Set_MorticianFamilyName()
+        // {
+        //     SetterDeathRecord.MorticianFamilyName = "Last";
+        //     Assert.Equal("Last", SetterDeathRecord.MorticianFamilyName);
+        // }
 
-        [Fact]
-        public void Get_MorticianFamilyName()
-        {
-            Assert.Equal("Last", ((DeathRecord)JSONRecords[0]).MorticianFamilyName);
-            Assert.Equal("Last", ((DeathRecord)XMLRecords[0]).MorticianFamilyName);
-        }
+        // [Fact]
+        // public void Get_MorticianFamilyName()
+        // {
+        //     Assert.Equal("Last", ((DeathRecord)JSONRecords[0]).MorticianFamilyName);
+        //     Assert.Equal("Last", ((DeathRecord)XMLRecords[0]).MorticianFamilyName);
+        // }
 
-        [Fact]
-        public void Set_MorticianSuffix()
-        {
-            SetterDeathRecord.MorticianSuffix = "Sr.";
-            Assert.Equal("Sr.", SetterDeathRecord.MorticianSuffix);
-        }
+        // [Fact]
+        // public void Set_MorticianSuffix()
+        // {
+        //     SetterDeathRecord.MorticianSuffix = "Sr.";
+        //     Assert.Equal("Sr.", SetterDeathRecord.MorticianSuffix);
+        // }
 
-        [Fact]
-        public void Get_MorticianSuffix()
-        {
-            Assert.Equal("Jr.", ((DeathRecord)JSONRecords[0]).MorticianSuffix);
-            Assert.Equal("Jr.", ((DeathRecord)XMLRecords[0]).MorticianSuffix);
-        }
+        // [Fact]
+        // public void Get_MorticianSuffix()
+        // {
+        //     Assert.Equal("Jr.", ((DeathRecord)JSONRecords[0]).MorticianSuffix);
+        //     Assert.Equal("Jr.", ((DeathRecord)XMLRecords[0]).MorticianSuffix);
+        // }
 
-        [Fact]
-        public void Set_MorticianIdentifier()
-        {
-            var id = new Dictionary<string, string>();
-            id["system"] = "foo";
-            id["value"] = "9876543210";
-            SetterDeathRecord.MorticianIdentifier = id;
-            Assert.Equal("foo", SetterDeathRecord.MorticianIdentifier["system"]);
-            Assert.Equal("9876543210", SetterDeathRecord.MorticianIdentifier["value"]);
-        }
+        // [Fact]
+        // public void Set_MorticianIdentifier()
+        // {
+        //     var id = new Dictionary<string, string>();
+        //     id["system"] = "foo";
+        //     id["value"] = "9876543210";
+        //     SetterDeathRecord.MorticianIdentifier = id;
+        //     Assert.Equal("foo", SetterDeathRecord.MorticianIdentifier["system"]);
+        //     Assert.Equal("9876543210", SetterDeathRecord.MorticianIdentifier["value"]);
+        // }
 
-        [Fact]
-        public void Get_MorticianIdentifier()
-        {
-            Assert.Equal("9876543210", ((DeathRecord)JSONRecords[0]).MorticianIdentifier["value"]);
-            Assert.Equal("9876543210", ((DeathRecord)XMLRecords[0]).MorticianIdentifier["value"]);
-        }
+        // [Fact]
+        // public void Get_MorticianIdentifier()
+        // {
+        //     Assert.Equal("9876543210", ((DeathRecord)JSONRecords[0]).MorticianIdentifier["value"]);
+        //     Assert.Equal("9876543210", ((DeathRecord)XMLRecords[0]).MorticianIdentifier["value"]);
+        // }
 
         [Fact]
         public void Set_PronouncerGivenNames()

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -580,6 +580,12 @@ namespace VRDR.Tests
             caddress.Add("addressState", "MA");
             caddress.Add("addressZip", "01730");
             caddress.Add("addressCountry", "US");
+            caddress.Add("addressPredir", "W");
+            caddress.Add("addressPostdir", "E");
+            caddress.Add("addressStname", "Example");
+            caddress.Add("addressStnum", "11");
+            caddress.Add("addressStdesig", "Street");
+            caddress.Add("addressUnitnum", "3");
             SetterDeathRecord.CertifierAddress = caddress;
             Assert.Equal("11 Example Street", SetterDeathRecord.CertifierAddress["addressLine1"]);
             Assert.Equal("Line 2", SetterDeathRecord.CertifierAddress["addressLine2"]);
@@ -588,6 +594,12 @@ namespace VRDR.Tests
             Assert.Equal("MA", SetterDeathRecord.CertifierAddress["addressState"]);
             Assert.Equal("01730", SetterDeathRecord.CertifierAddress["addressZip"]);
             Assert.Equal("US", SetterDeathRecord.CertifierAddress["addressCountry"]);
+            Assert.Equal("W", SetterDeathRecord.CertifierAddress["addressPredir"]);
+            Assert.Equal("E", SetterDeathRecord.CertifierAddress["addressPostdir"]);
+            Assert.Equal("Example", SetterDeathRecord.CertifierAddress["addressStname"]);
+            Assert.Equal("11", SetterDeathRecord.CertifierAddress["addressStnum"]);
+            Assert.Equal("Street", SetterDeathRecord.CertifierAddress["addressStdesig"]);
+            Assert.Equal("3", SetterDeathRecord.CertifierAddress["addressUnitnum"]);
         }
 
         [Fact]
@@ -609,43 +621,43 @@ namespace VRDR.Tests
             Assert.Equal("US", ((DeathRecord)XMLRecords[0]).CertifierAddress["addressCountry"]);
         }
 
-        [Fact]
-        public void Set_CertifierQualification()
-        {
-            Dictionary<string, string> qualification = new Dictionary<string, string>();
-            qualification.Add("code", "3060");
-            qualification.Add("system", "urn:oid:2.16.840.1.114222.4.11.7186");
-            qualification.Add("display", "Physicians and surgeons");
-            SetterDeathRecord.CertifierQualification = qualification;
-            Assert.Equal("3060", SetterDeathRecord.CertifierQualification["code"]);
-            Assert.Equal("urn:oid:2.16.840.1.114222.4.11.7186", SetterDeathRecord.CertifierQualification["system"]);
-            Assert.Equal("Physicians and surgeons", SetterDeathRecord.CertifierQualification["display"]);
-        }
+        // [Fact]
+        // public void Set_CertifierQualification()
+        // {
+        //     Dictionary<string, string> qualification = new Dictionary<string, string>();
+        //     qualification.Add("code", "3060");
+        //     qualification.Add("system", "urn:oid:2.16.840.1.114222.4.11.7186");
+        //     qualification.Add("display", "Physicians and surgeons");
+        //     SetterDeathRecord.CertifierQualification = qualification;
+        //     Assert.Equal("3060", SetterDeathRecord.CertifierQualification["code"]);
+        //     Assert.Equal("urn:oid:2.16.840.1.114222.4.11.7186", SetterDeathRecord.CertifierQualification["system"]);
+        //     Assert.Equal("Physicians and surgeons", SetterDeathRecord.CertifierQualification["display"]);
+        // }
 
-        [Fact]
-        public void Get_CertifierQualification()
-        {
-            Assert.Equal("434641000124105", ((DeathRecord)JSONRecords[0]).CertifierQualification["code"]);
-            Assert.Equal(CodeSystems.SCT, ((DeathRecord)XMLRecords[0]).CertifierQualification["system"]);
-            Assert.Equal("Physician", ((DeathRecord)JSONRecords[0]).CertifierQualification["display"]);
-            Assert.Equal("434641000124105", ((DeathRecord)XMLRecords[0]).CertifierQualification["code"]);
-            Assert.Equal(CodeSystems.SCT, ((DeathRecord)JSONRecords[0]).CertifierQualification["system"]);
-            Assert.Equal("Physician", ((DeathRecord)XMLRecords[0]).CertifierQualification["display"]);
-        }
+        // [Fact]
+        // public void Get_CertifierQualification()
+        // {
+        //     Assert.Equal("434641000124105", ((DeathRecord)JSONRecords[0]).CertifierQualification["code"]);
+        //     Assert.Equal(CodeSystems.SCT, ((DeathRecord)XMLRecords[0]).CertifierQualification["system"]);
+        //     Assert.Equal("Physician certified and pronounced death certificate", ((DeathRecord)JSONRecords[0]).CertifierQualification["display"]);
+        //     Assert.Equal("434641000124105", ((DeathRecord)XMLRecords[0]).CertifierQualification["code"]);
+        //     Assert.Equal(CodeSystems.SCT, ((DeathRecord)JSONRecords[0]).CertifierQualification["system"]);
+        //     Assert.Equal("Physician certified and pronounced death certificate", ((DeathRecord)XMLRecords[0]).CertifierQualification["display"]);
+        // }
 
-        [Fact]
-        public void Set_CertifierLicenseNumber()
-        {
-            SetterDeathRecord.CertifierLicenseNumber = "789123456";
-            Assert.Equal("789123456", SetterDeathRecord.CertifierLicenseNumber);
-        }
+        // [Fact]
+        // public void Set_CertifierLicenseNumber()
+        // {
+        //     SetterDeathRecord.CertifierLicenseNumber = "789123456";
+        //     Assert.Equal("789123456", SetterDeathRecord.CertifierLicenseNumber);
+        // }
 
-        [Fact]
-        public void Get_CertifierLicenseNumber()
-        {
-            Assert.Equal("789123456", ((DeathRecord)JSONRecords[0]).CertifierLicenseNumber);
-            Assert.Equal("789123456", ((DeathRecord)XMLRecords[0]).CertifierLicenseNumber);
-        }
+        // [Fact]
+        // public void Get_CertifierLicenseNumber()
+        // {
+        //     Assert.Equal("789123456", ((DeathRecord)JSONRecords[0]).CertifierLicenseNumber);
+        //     Assert.Equal("789123456", ((DeathRecord)XMLRecords[0]).CertifierLicenseNumber);
+        // }
 
         [Fact]
         public void Set_ContributingConditions()

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -376,11 +376,21 @@ namespace VRDR.Tests
             Dictionary<string, string> CertificationRole = new Dictionary<string, string>();
             CertificationRole.Add("code", "434641000124105");
             CertificationRole.Add("system", CodeSystems.SCT);
-            CertificationRole.Add("display", "Physician");
+            CertificationRole.Add("display", "Physician certified and pronounced death certificate");
             SetterDeathRecord.CertificationRole = CertificationRole;
             Assert.Equal("434641000124105", SetterDeathRecord.CertificationRole["code"]);
             Assert.Equal(CodeSystems.SCT, SetterDeathRecord.CertificationRole["system"]);
-            Assert.Equal("Physician", SetterDeathRecord.CertificationRole["display"]);
+            Assert.Equal("Physician certified and pronounced death certificate", SetterDeathRecord.CertificationRole["display"]);
+            SetterDeathRecord.CertificationRoleHelper = VRDR.ValueSets.CertificationRole.Physician_Certified_And_Pronounced_Death_Certificate;
+            Assert.Equal("434641000124105", SetterDeathRecord.CertificationRole["code"]);
+            Assert.Equal(CodeSystems.SCT, SetterDeathRecord.CertificationRole["system"]);
+            Assert.Equal("Physician certified and pronounced death certificate", SetterDeathRecord.CertificationRole["display"]);
+            SetterDeathRecord.CertificationRoleHelper = "Barber";
+            Assert.Equal("OTH", SetterDeathRecord.CertificationRole["code"]);
+            Assert.Equal(CodeSystems.NullFlavor_HL7_V3, SetterDeathRecord.CertificationRole["system"]);
+            Assert.Equal("Other", SetterDeathRecord.CertificationRole["display"]);
+            Assert.Equal("Barber", SetterDeathRecord.CertificationRole["text"]);
+
         }
 
         [Fact]
@@ -394,101 +404,101 @@ namespace VRDR.Tests
             Assert.Equal("Physician certified and pronounced death certificate", ((DeathRecord)XMLRecords[0]).CertificationRole["display"]);
         }
 
-        [Fact]
-        public void Set_InterestedPartyIdentifier()
-        {
-            var id = new Dictionary<string, string>();
-            id["system"] = "foo";
-            id["value"] = "0000000000";
-            SetterDeathRecord.InterestedPartyIdentifier = id;
-            Assert.Equal("foo", SetterDeathRecord.InterestedPartyIdentifier["system"]);
-            Assert.Equal("0000000000", SetterDeathRecord.InterestedPartyIdentifier["value"]);
-        }
+        // [Fact]
+        // public void Set_InterestedPartyIdentifier()
+        // {
+        //     var id = new Dictionary<string, string>();
+        //     id["system"] = "foo";
+        //     id["value"] = "0000000000";
+        //     SetterDeathRecord.InterestedPartyIdentifier = id;
+        //     Assert.Equal("foo", SetterDeathRecord.InterestedPartyIdentifier["system"]);
+        //     Assert.Equal("0000000000", SetterDeathRecord.InterestedPartyIdentifier["value"]);
+        // }
 
-        [Fact]
-        public void Get_InterestedPartyIdentifier()
-        {
-            Assert.Equal("1010101", ((DeathRecord)JSONRecords[0]).InterestedPartyIdentifier["value"]);
-            Assert.Equal("1010101", ((DeathRecord)XMLRecords[0]).InterestedPartyIdentifier["value"]);
-        }
+        // [Fact]
+        // public void Get_InterestedPartyIdentifier()
+        // {
+        //     Assert.Equal("1010101", ((DeathRecord)JSONRecords[0]).InterestedPartyIdentifier["value"]);
+        //     Assert.Equal("1010101", ((DeathRecord)XMLRecords[0]).InterestedPartyIdentifier["value"]);
+        // }
 
-        [Fact]
-        public void Set_InterestedPartyName()
-        {
-            SetterDeathRecord.InterestedPartyName = "123abc123xyz";
-            Assert.Equal("123abc123xyz", SetterDeathRecord.InterestedPartyName);
-        }
+        // [Fact]
+        // public void Set_InterestedPartyName()
+        // {
+        //     SetterDeathRecord.InterestedPartyName = "123abc123xyz";
+        //     Assert.Equal("123abc123xyz", SetterDeathRecord.InterestedPartyName);
+        // }
 
-        [Fact]
-        public void Get_InterestedPartyName()
-        {
-            Assert.Equal("Example Hospital", ((DeathRecord)JSONRecords[0]).InterestedPartyName);
-            Assert.Equal("Example Hospital", ((DeathRecord)XMLRecords[0]).InterestedPartyName);
-        }
+        // [Fact]
+        // public void Get_InterestedPartyName()
+        // {
+        //     Assert.Equal("Example Hospital", ((DeathRecord)JSONRecords[0]).InterestedPartyName);
+        //     Assert.Equal("Example Hospital", ((DeathRecord)XMLRecords[0]).InterestedPartyName);
+        // }
 
-        [Fact]
-        public void Set_InterestedPartyAddress()
-        {
-            Dictionary<string, string> address = new Dictionary<string, string>();
-            address.Add("addressLine1", "12 Example Street");
-            address.Add("addressLine2", "Line 2");
-            address.Add("addressCity", "Bedford");
-            address.Add("addressCounty", "Middlesex");
-            address.Add("addressState", "MA");
-            address.Add("addressZip", "01730");
-            address.Add("addressCountry", "US");
-            SetterDeathRecord.InterestedPartyAddress = address;
-            Assert.Equal("12 Example Street", SetterDeathRecord.InterestedPartyAddress["addressLine1"]);
-            Assert.Equal("Line 2", SetterDeathRecord.InterestedPartyAddress["addressLine2"]);
-            Assert.Equal("Bedford", SetterDeathRecord.InterestedPartyAddress["addressCity"]);
-            Assert.Equal("Middlesex", SetterDeathRecord.InterestedPartyAddress["addressCounty"]);
-            Assert.Equal("MA", SetterDeathRecord.InterestedPartyAddress["addressState"]);
-            Assert.Equal("01730", SetterDeathRecord.InterestedPartyAddress["addressZip"]);
-            Assert.Equal("US", SetterDeathRecord.InterestedPartyAddress["addressCountry"]);
-        }
+        // [Fact]
+        // public void Set_InterestedPartyAddress()
+        // {
+        //     Dictionary<string, string> address = new Dictionary<string, string>();
+        //     address.Add("addressLine1", "12 Example Street");
+        //     address.Add("addressLine2", "Line 2");
+        //     address.Add("addressCity", "Bedford");
+        //     address.Add("addressCounty", "Middlesex");
+        //     address.Add("addressState", "MA");
+        //     address.Add("addressZip", "01730");
+        //     address.Add("addressCountry", "US");
+        //     SetterDeathRecord.InterestedPartyAddress = address;
+        //     Assert.Equal("12 Example Street", SetterDeathRecord.InterestedPartyAddress["addressLine1"]);
+        //     Assert.Equal("Line 2", SetterDeathRecord.InterestedPartyAddress["addressLine2"]);
+        //     Assert.Equal("Bedford", SetterDeathRecord.InterestedPartyAddress["addressCity"]);
+        //     Assert.Equal("Middlesex", SetterDeathRecord.InterestedPartyAddress["addressCounty"]);
+        //     Assert.Equal("MA", SetterDeathRecord.InterestedPartyAddress["addressState"]);
+        //     Assert.Equal("01730", SetterDeathRecord.InterestedPartyAddress["addressZip"]);
+        //     Assert.Equal("US", SetterDeathRecord.InterestedPartyAddress["addressCountry"]);
+        // }
 
-        [Fact]
-        public void Get_InterestedPartyAddress()
-        {
-            Assert.Equal("10 Example Street", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressLine1"]);
-            Assert.Equal("Line 2", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressLine2"]);
-            Assert.Equal("Bedford", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressCity"]);
-            Assert.Equal("Middlesex", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressCounty"]);
-            Assert.Equal("MA", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressState"]);
-            Assert.Equal("01730", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressZip"]);
-            Assert.Equal("US", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressCountry"]);
-            Assert.Equal("10 Example Street", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressLine1"]);
-            Assert.Equal("Line 2", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressLine2"]);
-            Assert.Equal("Bedford", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressCity"]);
-            Assert.Equal("Middlesex", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressCounty"]);
-            Assert.Equal("MA", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressState"]);
-            Assert.Equal("01730", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressZip"]);
-            Assert.Equal("US", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressCountry"]);
-        }
+        // [Fact]
+        // public void Get_InterestedPartyAddress()
+        // {
+        //     Assert.Equal("10 Example Street", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressLine1"]);
+        //     Assert.Equal("Line 2", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressLine2"]);
+        //     Assert.Equal("Bedford", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressCity"]);
+        //     Assert.Equal("Middlesex", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressCounty"]);
+        //     Assert.Equal("MA", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressState"]);
+        //     Assert.Equal("01730", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressZip"]);
+        //     Assert.Equal("US", ((DeathRecord)JSONRecords[0]).InterestedPartyAddress["addressCountry"]);
+        //     Assert.Equal("10 Example Street", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressLine1"]);
+        //     Assert.Equal("Line 2", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressLine2"]);
+        //     Assert.Equal("Bedford", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressCity"]);
+        //     Assert.Equal("Middlesex", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressCounty"]);
+        //     Assert.Equal("MA", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressState"]);
+        //     Assert.Equal("01730", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressZip"]);
+        //     Assert.Equal("US", ((DeathRecord)XMLRecords[0]).InterestedPartyAddress["addressCountry"]);
+        // }
 
-        [Fact]
-        public void Set_InterestedPartyType()
-        {
-            Dictionary<string, string> type = new Dictionary<string, string>();
-            type.Add("code", "prov");
-            type.Add("system", CodeSystems.HL7_organization_type);
-            type.Add("display", "Healthcare Provider");
-            SetterDeathRecord.InterestedPartyType = type;
-            Assert.Equal("prov", SetterDeathRecord.InterestedPartyType["code"]);
-            Assert.Equal(CodeSystems.HL7_organization_type, SetterDeathRecord.InterestedPartyType["system"]);
-            Assert.Equal("Healthcare Provider", SetterDeathRecord.InterestedPartyType["display"]);
-        }
+        // [Fact]
+        // public void Set_InterestedPartyType()
+        // {
+        //     Dictionary<string, string> type = new Dictionary<string, string>();
+        //     type.Add("code", "prov");
+        //     type.Add("system", CodeSystems.HL7_organization_type);
+        //     type.Add("display", "Healthcare Provider");
+        //     SetterDeathRecord.InterestedPartyType = type;
+        //     Assert.Equal("prov", SetterDeathRecord.InterestedPartyType["code"]);
+        //     Assert.Equal(CodeSystems.HL7_organization_type, SetterDeathRecord.InterestedPartyType["system"]);
+        //     Assert.Equal("Healthcare Provider", SetterDeathRecord.InterestedPartyType["display"]);
+        // }
 
-        [Fact]
-        public void Get_InterestedPartyType()
-        {
-            Assert.Equal("prov", ((DeathRecord)JSONRecords[0]).InterestedPartyType["code"]);
-            Assert.Equal(CodeSystems.HL7_organization_type, ((DeathRecord)XMLRecords[0]).InterestedPartyType["system"]);
-            Assert.Equal("Healthcare Provider", ((DeathRecord)JSONRecords[0]).InterestedPartyType["display"]);
-            Assert.Equal("prov", ((DeathRecord)XMLRecords[0]).InterestedPartyType["code"]);
-            Assert.Equal(CodeSystems.HL7_organization_type, ((DeathRecord)JSONRecords[0]).InterestedPartyType["system"]);
-            Assert.Equal("Healthcare Provider", ((DeathRecord)XMLRecords[0]).InterestedPartyType["display"]);
-        }
+        // [Fact]
+        // public void Get_InterestedPartyType()
+        // {
+        //     Assert.Equal("prov", ((DeathRecord)JSONRecords[0]).InterestedPartyType["code"]);
+        //     Assert.Equal(CodeSystems.HL7_organization_type, ((DeathRecord)XMLRecords[0]).InterestedPartyType["system"]);
+        //     Assert.Equal("Healthcare Provider", ((DeathRecord)JSONRecords[0]).InterestedPartyType["display"]);
+        //     Assert.Equal("prov", ((DeathRecord)XMLRecords[0]).InterestedPartyType["code"]);
+        //     Assert.Equal(CodeSystems.HL7_organization_type, ((DeathRecord)JSONRecords[0]).InterestedPartyType["system"]);
+        //     Assert.Equal("Healthcare Provider", ((DeathRecord)XMLRecords[0]).InterestedPartyType["display"]);
+        // }
 
         [Fact]
         public void Set_MannerOfDeathType()

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -168,8 +168,8 @@ namespace VRDR.Tests
             DeathRecord fromijefromjson = ijefromjson.ToDeathRecord();
             DeathRecord fromijefromxml = ijefromjson.ToDeathRecord();
 
-            Assert.Equal("MA", fromijefromjson.DeathLocationJurisdiction);
-            Assert.Equal("MA", fromijefromxml.DeathLocationJurisdiction);
+            Assert.Equal("YC", fromijefromjson.DeathLocationJurisdiction);
+            Assert.Equal("YC", fromijefromxml.DeathLocationJurisdiction);
         }
 
       [Fact]
@@ -188,8 +188,8 @@ namespace VRDR.Tests
             DeathRecord fromijefromjson = ijefromjson.ToDeathRecord();
 
             Assert.NotEqual(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Death_In_Hospice);
-            Assert.Equal(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Death_In_Hospital);
-            Assert.Equal("Death in hospital", fromijefromjson.DeathLocationType["display"]);
+            Assert.Equal(fromijefromjson.DeathLocationTypeHelper, VRDR.ValueSets.PlaceOfDeath.Death_In_Home);
+            Assert.Equal("Death in home", fromijefromjson.DeathLocationType["display"]);
         }
 
         [Fact]
@@ -285,7 +285,7 @@ namespace VRDR.Tests
             Assert.Equal("2diff1xyz", sample2.CertifierFamilyName);
         }
 
-[Fact]
+        [Fact]
         public void Set_DeathLocationTypeHelper()
         {
             SetterDeathRecord.DeathLocationTypeHelper = VRDR.ValueSets.PlaceOfDeath.Death_In_Nursing_Home_Or_Long_Term_Care_Facility;
@@ -294,6 +294,12 @@ namespace VRDR.Tests
             Exception ex = Assert.Throws<System.ArgumentException>(() => SetterDeathRecord.DeathLocationTypeHelper = "NotAValidValue");
         }
 
+       [Fact]
+        public void Get_DeathLocationType()
+        {
+            Assert.Equal(ValueSets.PlaceOfDeath.Death_In_Home, ((DeathRecord)JSONRecords[0]).DeathLocationTypeHelper);
+            Assert.Equal(ValueSets.PlaceOfDeath.Death_In_Home, ((DeathRecord)XMLRecords[0]).DeathLocationTypeHelper);
+        }
         [Fact]
         public void Set_Identifier()
         {
@@ -2404,14 +2410,15 @@ namespace VRDR.Tests
             Assert.Equal("Line 2", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressLine2"]);
             Assert.Equal("Bedford", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressCity"]);
             Assert.Equal("Middlesex", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressCounty"]);
-            Assert.Equal("MA", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressState"]);
+            Assert.Equal("NY", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressState"]);
+            Assert.Equal("YC", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressJurisdiction"]);
             Assert.Equal("01730", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressZip"]);
             Assert.Equal("US", ((DeathRecord)JSONRecords[0]).DeathLocationAddress["addressCountry"]);
             Assert.Equal("671 Example Street", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressLine1"]);
             Assert.Equal("Line 2", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressLine2"]);
             Assert.Equal("Bedford", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressCity"]);
             Assert.Equal("Middlesex", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressCounty"]);
-            Assert.Equal("MA", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressState"]);
+            Assert.Equal("NY", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressState"]);
             Assert.Equal("01730", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressZip"]);
             Assert.Equal("US", ((DeathRecord)XMLRecords[0]).DeathLocationAddress["addressCountry"]);
         }
@@ -2428,6 +2435,8 @@ namespace VRDR.Tests
         {
             SetterDeathRecord.DeathLocationJurisdiction = "MA";
             Assert.Equal("MA", SetterDeathRecord.DeathLocationJurisdiction);
+            SetterDeathRecord.DeathLocationJurisdiction = "YC";
+            Assert.Equal("YC", SetterDeathRecord.DeathLocationJurisdiction);
         }
 
         [Fact]
@@ -2440,8 +2449,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_DeathLocationJurisdiction()
         {
-            Assert.Equal("MA", ((DeathRecord)JSONRecords[0]).DeathLocationJurisdiction);
-            Assert.Equal("MA", ((DeathRecord)XMLRecords[0]).DeathLocationJurisdiction);
+            Assert.Equal("YC", ((DeathRecord)JSONRecords[0]).DeathLocationJurisdiction);
+            Assert.Equal("YC", ((DeathRecord)XMLRecords[0]).DeathLocationJurisdiction);
         }
 
         [Fact]

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -49,17 +49,17 @@ namespace VRDR.Tests
             Assert.Equal((uint)1, submission.CertificateNumber);
             Assert.Equal((uint)2019, submission.DeathYear);
             Assert.Equal("42", submission.StateAuxiliaryIdentifier);
-            Assert.Equal("2018YC000001", submission.NCHSIdentifier);
+            Assert.Equal("2019YC000001", submission.NCHSIdentifier);
 
             record = (DeathRecord)JSONRecords[0];
             submission = new DeathRecordSubmission(record);
             Assert.NotNull(submission.DeathRecord);
-            Assert.Equal("2019-02-20T16:48:06-05:00", submission.DeathRecord.DateOfDeathPronouncement);
+            Assert.Equal("2018-02-20T16:48:06-05:00", submission.DeathRecord.DateOfDeathPronouncement);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", submission.MessageType);
             Assert.Equal((uint)1, submission.CertificateNumber);
             Assert.Equal((uint)2019, submission.DeathYear);
             Assert.Equal("42", submission.StateAuxiliaryIdentifier);
-            Assert.Equal("2018YC000001", submission.NCHSIdentifier);
+            Assert.Equal("2019YC000001", submission.NCHSIdentifier);
 
             record = null;
             submission = new DeathRecordSubmission(record);
@@ -155,7 +155,7 @@ namespace VRDR.Tests
             Assert.Equal((uint)1, update.CertificateNumber);
             Assert.Equal((uint)2019, update.DeathYear);
             Assert.Equal("42", update.StateAuxiliaryIdentifier);
-            Assert.Equal("2018YC000001", update.NCHSIdentifier);
+            Assert.Equal("2019YC000001", update.NCHSIdentifier);
 
             update = new DeathRecordUpdate((DeathRecord)JSONRecords[1]); // no ids in this death record (except jurisdiction id which is required)
             Assert.NotNull(update.DeathRecord);
@@ -896,7 +896,7 @@ namespace VRDR.Tests
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission_void", message.MessageType);
             Assert.Equal((uint)1, message.CertificateNumber);
             Assert.Equal("42", message.StateAuxiliaryIdentifier);
-            Assert.Equal("2018YC000001", message.NCHSIdentifier);
+            Assert.Equal("2019YC000001", message.NCHSIdentifier);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", message.MessageDestination);
             Assert.Null(message.MessageSource);
 

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -49,7 +49,7 @@ namespace VRDR.Tests
             Assert.Equal((uint)1, submission.CertificateNumber);
             Assert.Equal((uint)2019, submission.DeathYear);
             Assert.Equal("42", submission.StateAuxiliaryIdentifier);
-            Assert.Equal("2019MA000001", submission.NCHSIdentifier);
+            Assert.Equal("2018YC000001", submission.NCHSIdentifier);
 
             record = (DeathRecord)JSONRecords[0];
             submission = new DeathRecordSubmission(record);
@@ -59,7 +59,7 @@ namespace VRDR.Tests
             Assert.Equal((uint)1, submission.CertificateNumber);
             Assert.Equal((uint)2019, submission.DeathYear);
             Assert.Equal("42", submission.StateAuxiliaryIdentifier);
-            Assert.Equal("2019MA000001", submission.NCHSIdentifier);
+            Assert.Equal("2018YC000001", submission.NCHSIdentifier);
 
             record = null;
             submission = new DeathRecordSubmission(record);
@@ -155,7 +155,7 @@ namespace VRDR.Tests
             Assert.Equal((uint)1, update.CertificateNumber);
             Assert.Equal((uint)2019, update.DeathYear);
             Assert.Equal("42", update.StateAuxiliaryIdentifier);
-            Assert.Equal("2019MA000001", update.NCHSIdentifier);
+            Assert.Equal("2018YC000001", update.NCHSIdentifier);
 
             update = new DeathRecordUpdate((DeathRecord)JSONRecords[1]); // no ids in this death record (except jurisdiction id which is required)
             Assert.NotNull(update.DeathRecord);
@@ -896,7 +896,7 @@ namespace VRDR.Tests
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission_void", message.MessageType);
             Assert.Equal((uint)1, message.CertificateNumber);
             Assert.Equal("42", message.StateAuxiliaryIdentifier);
-            Assert.Equal("2019MA000001", message.NCHSIdentifier);
+            Assert.Equal("2018YC000001", message.NCHSIdentifier);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", message.MessageDestination);
             Assert.Null(message.MessageSource);
 

--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -296,6 +296,7 @@ namespace VRDR.Tests
         public void HandleDeathLocationIJE()
         {
             IJEMortality ije1 = new IJEMortality(File.ReadAllText(FixturePath("fixtures/ije/DeathLocation.ije")), true);
+            Assert.Equal("4", ije1.DPLACE);
             DeathRecord dr = ije1.ToDeathRecord();
             IJEMortality ije1rt = new IJEMortality(dr);
             Assert.Equal("4", ije1rt.DPLACE);
@@ -353,7 +354,7 @@ namespace VRDR.Tests
             IJEMortality ije1 = new IJEMortality(File.ReadAllText(FixturePath("fixtures/ije/CODandCOUNTYCUnknown.ije")), true);
             Assert.Equal("999", ije1.COD);
             Assert.Equal("999", ije1.COUNTYC);
-    
+
             DeathRecord dr1 = ije1.ToDeathRecord();
             Assert.Equal("999", dr1.DeathLocationAddress["addressCounty"]);
             Assert.Equal("999", dr1.Residence["addressCountyC"]);
@@ -365,7 +366,7 @@ namespace VRDR.Tests
             IJEMortality ije1 = new IJEMortality(File.ReadAllText(FixturePath("fixtures/ije/CODandCOUNTYCOther.ije")), true);
             Assert.Equal("000", ije1.COD);
             Assert.Equal("000", ije1.COUNTYC);
-    
+
             DeathRecord dr1 = ije1.ToDeathRecord();
             Assert.Equal("000", dr1.DeathLocationAddress["addressCounty"]);
             Assert.Equal("000", dr1.Residence["addressCountyC"]);

--- a/VRDR.Tests/fixtures/json/BadConditions.json
+++ b/VRDR.Tests/fixtures/json/BadConditions.json
@@ -1311,40 +1311,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:ca9e1d68-4ee5-474d-97f4-d878005c5510",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:ca9e1d68-4ee5-474d-97f4-d878005c5510",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:9521f45f-d8ca-4c62-9878-0686f1028bf5"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:90122482-37b9-4c40-89ed-c957f454bea9",
       "resource": {
         "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1338,40 +1338,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "257500003",
-              "display": "Passenger"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
       "resource": {
         "resourceType": "Observation",
@@ -1514,20 +1480,16 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
                 }
               ]
             },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-                  "code": "Y",
-                  "display": "Yes"
-                }
-              ]
-            }
+            "valueCodeableConcept": {"coding": [{
+              "system": "http://snomed.info/sct",
+              "code": "257500003",
+              "display": "Passenger"
+          }]}
           },
           {
             "code": {

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1489,8 +1489,7 @@
               "system": "http://snomed.info/sct",
               "code": "257500003",
               "display": "Passenger"
-          }]}
-          },
+          }]}},
           {
             "code": {
               "coding": [
@@ -1503,41 +1502,6 @@
             },
             "valueCodeableConcept": {
               "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "257500003",
-                  "display": "Passenger"
-                }
-              ],
-              "text": "Passenger"
             }
           }
         ]

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1516,20 +1516,6 @@
               ]
             },
             "valueCodeableConcept": {
-              "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1516,6 +1516,20 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1515,9 +1515,18 @@
         "id": "4678efc2-2529-4a7e-8266-fdc907d89e00",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
+            }
+          ]
+        }],
         "extension": [
           {
             "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1489,7 +1489,8 @@
               "system": "http://snomed.info/sct",
               "code": "257500003",
               "display": "Passenger"
-          }]}},
+          }]}
+          },
           {
             "code": {
               "coding": [

--- a/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/BirthAndDeathDateDataAbsent.json
@@ -1540,14 +1540,28 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
               "coding": [
                 {
-                  "system": "urn:oid:2.16.840.1.114222.4.5.320",
-                  "code": "0",
-                  "display": "Home"
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "257500003",
+                  "display": "Passenger"
                 }
               ],
-              "text": "At home, in the kitchen"
+              "text": "Passenger"
             }
           }
         ]

--- a/VRDR.Tests/fixtures/json/DeathLocationType.json
+++ b/VRDR.Tests/fixtures/json/DeathLocationType.json
@@ -1181,29 +1181,7 @@
         },
         "subject": {
           "reference": "urn:uuid:b7cff225-dc4a-45ff-b998-a1f230eb8282"
-        },
-        "component": [
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-                  "code": "N",
-                  "display": "No"
-                }
-              ]
-            }
-          }
-        ]
+        }
       }
     },
     {

--- a/VRDR.Tests/fixtures/json/DeathLocationType.json
+++ b/VRDR.Tests/fixtures/json/DeathLocationType.json
@@ -876,6 +876,26 @@
               ]
             },
             "valueDateTime": "2021-08-11T01:00:00.0000000+00:00"
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "58332-8",
+                  "display": "Location of death"
+                }
+              ]
+            },
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "system" : "http://snomed.info/sct",
+                  "code" : "440081000124100",
+                  "display": "Death in home"
+                }
+              ]
+            }
           }
         ]
       }
@@ -917,36 +937,19 @@
         "id": "c9a372ec-37dc-4194-b225-d420355c109e",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "urn:oid:2.16.840.1.113883.6.92",
-                  "code": "25",
-                  "display": "MA"
-                }
-              ],
-              "text": "MA"
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
             }
-          }
-        ],
+          ]
+        }],
         "name": "Quincy Hospital",
-        "type": [
-          {
-            "coding": [
-              {
-                "system": "http://snomed.info/sct",
-                "code": "16983000",
-                "display": "Death in hospital"
-              }
-            ]
-          }
-        ],
         "address": {
           "line": [
             "525 Huel Extensions"
@@ -954,6 +957,14 @@
           "city": "Quincy",
           "district": "Norfolk",
           "state": "MA",
+          "_state" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
+                "valueString" : "MA"
+              }
+            ]
+          },
           "country": "US"
         }
       }

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -1864,6 +1864,20 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -2017,53 +2017,121 @@
     {
       "fullUrl": "urn:uuid:c1ae4b09-e83a-4b7f-a5ca-5cf9692ff0c6",
       "resource": {
-        "resourceType": "Parameters",
+        "resourceType": "Observation",
         "id": "c1ae4b09-e83a-4b7f-a5ca-5cf9692ff0c6",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-params-for-emerging-issues"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues"
           ]
         },
-        "parameter": [
+        "status" : "final",
+        "code" : {
+          "coding" : [
+            {
+              "code" : "emergingissues"
+            }
+          ]
+        },
+        "component" : [
           {
-            "name": "PLACE1_1",
-            "valueString": "A"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue1_1"
+                }
+              ]
+            },
+            "valueString" : "A"
           },
           {
-            "name": "PLACE1_2",
-            "valueString": "B"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue1_2"
+                }
+              ]
+            },
+            "valueString" : "B"
           },
           {
-            "name": "PLACE1_3",
-            "valueString": "C"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue1_3"
+                }
+              ]
+            },
+            "valueString" : "C"
           },
           {
-            "name": "PLACE1_4",
-            "valueString": "D"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue1_4"
+                }
+              ]
+            },
+            "valueString" : "D"
           },
           {
-            "name": "PLACE1_5",
-            "valueString": "E"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue1_5"
+                }
+              ]
+            },
+            "valueString" : "E"
           },
           {
-            "name": "PLACE1_6",
-            "valueString": "F"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue1_6"
+                }
+              ]
+            },
+            "valueString" : "F"
           },
           {
-            "name": "PLACE8_1",
-            "valueString": "AAAAAAAA"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue8_1"
+                }
+              ]
+            },
+            "valueString" : "AAAAAAAA"
           },
           {
-            "name": "PLACE8_2",
-            "valueString": "BBBBBBBB"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue8_2"
+                }
+              ]
+            },
+            "valueString" : "BBBBBBBB"
           },
           {
-            "name": "PLACE8_3",
-            "valueString": "CCCCCCCC"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue8_3"
+                }
+              ]
+            },
+            "valueString" : "CCCCCCCC"
           },
           {
-            "name": "PLACE20",
-            "valueString": "AAAAAAAAAAAAAAAAAAAA"
+            "code" : {
+              "coding" : [
+                {
+                  "code" : "EmergingIssue20"
+                }
+              ]
+            },
+            "valueString" : "AAAAAAAAAAAAAAAAAAAA"
           }
         ]
       }

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -1702,40 +1702,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "257500003",
-              "display": "Passenger"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
       "resource": {
         "resourceType": "Observation",
@@ -1904,14 +1870,28 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
               "coding": [
                 {
-                  "system": "urn:oid:2.16.840.1.114222.4.5.320",
-                  "code": "0",
-                  "display": "Home"
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "257500003",
+                  "display": "Passenger"
                 }
               ],
-              "text": "At home, in the kitchen"
+              "text": "Passenger"
             }
           }
         ]

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -729,17 +729,15 @@
           ]
         },
         "active": true,
-        "type": [
-          {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                "code": "bus",
-                "display": "Non-Healthcare Business or Corporation"
-              }
-            ]
-          }
-        ],
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs",
+              "code": "funeralhome",
+              "display": "Funeral Home"
+            }
+          ]
+        }],
         "name": "Smith Funeral Home",
         "address": [
           {
@@ -1871,20 +1869,6 @@
             }
           ]
         }],
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "2.16.840.1.113883.6.92",
-                  "code": "25",
-                  "display": "MA"
-                }
-              ]
-            }
-          }
-        ],
 
         "name": "Example Death Location Name",
         "description": "Example Death Location Description",
@@ -1895,7 +1879,15 @@
           ],
           "city": "Bedford",
           "district": "Middlesex",
-          "state": "MA",
+          "state": "NY",
+          "_state": {
+            "extension": [
+              {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
+              "valueString": "YC"
+              }
+            ]
+          },
           "postalCode": "01730",
           "country": "US"
         }
@@ -1942,7 +1934,27 @@
                 }
               ]
             },
-            "valueDateTime": "2019-02-20T16:48:06-05:00"
+            "valueDateTime": "2018-02-20T16:48:06-05:00"
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "58332-8",
+                  "display": "Location of death"
+                }
+              ]
+            },
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "system" : "http://snomed.info/sct",
+                  "code" : "440081000124100",
+                  "display": "Death in home"
+                }
+              ]
+            }
           }
         ]
       }

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -1864,20 +1864,6 @@
               ]
             },
             "valueCodeableConcept": {
-              "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -1844,26 +1844,6 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-                  "code": "Y",
-                  "display": "Yes"
-                }
-              ]
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
                 }

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -719,56 +719,13 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:17e6d6c8-deea-464b-a009-d077ceb30af1",
-      "resource": {
-        "resourceType": "Organization",
-        "id": "17e6d6c8-deea-464b-a009-d077ceb30af1",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party"
-          ]
-        },
-        "identifier": [
-          {
-            "value": "1010101"
-          }
-        ],
-        "active": true,
-        "type": [
-          {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                "code": "prov",
-                "display": "Healthcare Provider"
-              }
-            ]
-          }
-        ],
-        "name": "Example Hospital",
-        "address": [
-          {
-            "line": [
-              "10 Example Street",
-              "Line 2"
-            ],
-            "city": "Bedford",
-            "district": "Middlesex",
-            "state": "MA",
-            "postalCode": "01730",
-            "country": "US"
-          }
-        ]
-      }
-    },
-    {
       "fullUrl": "urn:uuid:cffcc6e0-7324-4898-b876-9107d275eafa",
       "resource": {
         "resourceType": "Organization",
         "id": "cffcc6e0-7324-4898-b876-9107d275eafa",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home"
           ]
         },
         "active": true,
@@ -878,9 +835,18 @@
         "id": "fe696fc7-7683-4268-92d8-b3a7c88b1587",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "disposition",
+              "display": "disposition location"
+            }
+          ]
+        }],
         "name": "Bedford Cemetery",
         "address": {
           "line": [
@@ -1776,9 +1742,18 @@
         "id": "3c1f5202-68de-47e8-813f-43a3f7f29129",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "injury",
+              "display": "injury location"
+            }
+          ]
+        }],
         "name": "Example Injury Location Name",
         "description": "Example Injury Location Description",
         "address": {
@@ -1884,9 +1859,18 @@
         "id": "4678efc2-2529-4a7e-8266-fdc907d89e00",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
+            }
+          ]
+        }],
         "extension": [
           {
             "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
@@ -1901,6 +1885,7 @@
             }
           }
         ],
+
         "name": "Example Death Location Name",
         "description": "Example Death Location Description",
         "address": {

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1506,6 +1506,20 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1509,9 +1509,18 @@
         "id": "4678efc2-2529-4a7e-8266-fdc907d89e00",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
+            }
+          ]
+        }],
         "extension": [
           {
             "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1529,14 +1529,28 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
               "coding": [
                 {
-                  "system": "urn:oid:2.16.840.1.114222.4.5.320",
-                  "code": "0",
-                  "display": "Home"
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "257500003",
+                  "display": "Passenger"
                 }
               ],
-              "text": "At home, in the kitchen"
+              "text": "Passenger"
             }
           }
         ]

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1471,6 +1471,7 @@
                   "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
+<<<<<<< HEAD
                 }
               ]
             },
@@ -1485,6 +1486,8 @@
                   "system": "http://loinc.org",
                   "code": "69451-3",
                   "display": "Transportation role of decedent"
+=======
+>>>>>>> a1c8a93 (got rid of transportation event from tests)
                 }
               ]
             },

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1489,20 +1489,6 @@
               ]
             },
             "valueCodeableConcept": {
-              "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1327,40 +1327,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "257500003",
-              "display": "Passenger"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
       "resource": {
         "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1471,37 +1471,6 @@
                   "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
-<<<<<<< HEAD
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
-=======
->>>>>>> a1c8a93 (got rid of transportation event from tests)
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "text": "At home, in the kitchen"
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69451-3",
-                  "display": "Transportation role of decedent"
                 }
               ]
             },

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1489,6 +1489,20 @@
               ]
             },
             "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
               "coding": [
                 {
                   "system": "http://snomed.info/sct",

--- a/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordBirthRecordDataAbsent.json
@@ -1469,26 +1469,6 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-                  "code": "Y",
-                  "display": "Yes"
-                }
-              ]
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
                 }

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
@@ -1388,26 +1388,6 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-                  "code": "Y",
-                  "display": "Yes"
-                }
-              ]
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
                 }

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
@@ -1382,26 +1382,7 @@
               ]
             }
           },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-                  "code": "Y",
-                  "display": "Yes"
-                }
-              ]
-            }
-          },
+
           {
             "code": {
               "coding": [

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
@@ -1245,40 +1245,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "257500003",
-              "display": "Passenger"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
       "resource": {
         "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
@@ -1388,6 +1388,26 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
+                  "code": "69448-9",
+                  "display": "Injury leading to death associated with transportation event"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                  "code": "Y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
                 }

--- a/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordNoIdentifiers.json
@@ -1421,12 +1421,55 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
+                  "code": "69448-9",
+                  "display": "Injury leading to death associated with transportation event"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                  "code": "Y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
                   "code": "69450-5",
                   "display": "Place of injury Facility"
                 }
               ]
             },
-            "valueString": "home"
+            "valueCodeableConcept": {
+              "text": "At home, in the kitchen"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "69451-3",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "257500003",
+                  "display": "Passenger"
+                }
+              ],
+              "text": "Passenger"
+            }
           }
         ]
       }

--- a/VRDR.Tests/fixtures/json/DeathRecordSubmission.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordSubmission.json
@@ -879,7 +879,8 @@
                                         "code": "69450-5",
                                         "display": "Place of injury Facility"
                                     }]},
-                                    "valueCodeableConcept": {"coding": [{
+                                    "valueCodeableConcept": {
+                                        "coding": [{
                                         "system": "urn:oid:2.16.840.1.114222.4.11.7374",
                                         "code": "0",
                                         "display": "Home"

--- a/VRDR.Tests/fixtures/json/DeathRecordSubmission.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordSubmission.json
@@ -434,7 +434,16 @@
                                 "state": "MA",
                                 "postalCode": "01730",
                                 "country": "US"
-                            }
+                            },
+                            "type": [{
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                                    "code": "disposition",
+                                    "display": "disposition location"
+                                  }
+                                ]
+                              }]
                         }
                     },
                     {
@@ -941,6 +950,15 @@
                             "meta": {"profile": ["http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"]},
                             "name": "Example Injury Location Name",
                             "description": "Example Injury Location Description",
+                            "type": [{
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                                    "code": "injury",
+                                    "display": "injury location"
+                                  }
+                                ]
+                              }],
                             "address": {
                                 "line": [
                                     "781 Example Street",
@@ -973,6 +991,15 @@
                                 "postalCode": "01730",
                                 "country": "US"
                             },
+                            "type": [{
+                                "coding": [
+                                  {
+                                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                                    "code": "death",
+                                    "display": "death location"
+                                  }
+                                ]
+                              }],
                             "extension": [
                                 {
                                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",

--- a/VRDR.Tests/fixtures/json/DeathRecordSubmissionNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordSubmissionNoIdentifiers.json
@@ -768,26 +768,6 @@
                         }
                     },
                     {
-                        "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-                        "resource": {
-                            "resourceType": "Observation",
-                            "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-                            "meta": {"profile": ["http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"]},
-                            "status": "final",
-                            "code": {"coding": [{
-                                "system": "http://loinc.org",
-                                "code": "69451-3",
-                                "display": "Transportation role of decedent"
-                            }]},
-                            "subject": {"reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"},
-                            "valueCodeableConcept": {"coding": [{
-                                "system": "http://snomed.info/sct",
-                                "code": "257500003",
-                                "display": "Passenger"
-                            }]}
-                        }
-                    },
-                    {
                         "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
                         "resource": {
                             "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/DeathRecordUpdateNoIdentifiers.json
+++ b/VRDR.Tests/fixtures/json/DeathRecordUpdateNoIdentifiers.json
@@ -802,26 +802,6 @@
                         }
                     },
                     {
-                        "fullUrl": "urn:uuid:91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-                        "resource": {
-                            "resourceType": "Observation",
-                            "id": "91ad2d6e-3bd7-45f1-b131-e0bf742cfd7f",
-                            "meta": {"profile": ["http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"]},
-                            "status": "final",
-                            "code": {"coding": [{
-                                "system": "http://loinc.org",
-                                "code": "69451-3",
-                                "display": "Transportation role of decedent"
-                            }]},
-                            "subject": {"reference": "urn:uuid:949354d3-9dcf-4c96-8ec4-6be27dd4c65f"},
-                            "valueCodeableConcept": {"coding": [{
-                                "system": "http://snomed.info/sct",
-                                "code": "257500003",
-                                "display": "Passenger"
-                            }]}
-                        }
-                    },
-                    {
                         "fullUrl": "urn:uuid:efbe46f1-522e-4fe9-9a3c-d3a8c1c0810d",
                         "resource": {
                             "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/InvalidJurisdictionId.json
+++ b/VRDR.Tests/fixtures/json/InvalidJurisdictionId.json
@@ -1212,28 +1212,6 @@
                 }
               ]
             }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69444-8",
-                  "display": "Did death result from injury at work"
-                }
-              ]
-            }
-          },
-          {
-            "code": {
-              "coding": [
-                {
-                  "system": "http://loinc.org",
-                  "code": "69448-9",
-                  "display": "Injury leading to death associated with transportation event"
-                }
-              ]
-            }
           }
         ]
       }

--- a/VRDR.Tests/fixtures/json/InvalidJurisdictionId.json
+++ b/VRDR.Tests/fixtures/json/InvalidJurisdictionId.json
@@ -1238,31 +1238,7 @@
         ]
       }
     },
-    {
-      "fullUrl": "urn:uuid:47e67939-fcc6-48a2-803c-3a51b273b1e3",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "47e67939-fcc6-48a2-803c-3a51b273b1e3",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:8d18bab2-bf31-428f-a13c-7a1a962977e9"
-        }
-      }
-    },
+
     {
       "fullUrl": "urn:uuid:3041b25a-9b37-4f8c-84f5-6e0169b9a24f",
       "resource": {

--- a/VRDR.Tests/fixtures/json/MissingAge.json
+++ b/VRDR.Tests/fixtures/json/MissingAge.json
@@ -567,6 +567,15 @@
                     "state": "MA",
                     "country": "US"
                 },
+                "type": [{
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                        "code": "disposition",
+                        "display": "disposition location"
+                      }
+                    ]
+                  }],
                 "physicalType": {
                     "coding": [
                         {
@@ -642,6 +651,15 @@
                         "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
                     ]
                 },
+                "type": [{
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                        "code": "death",
+                        "display": "death location"
+                      }
+                    ]
+                  }],
                 "extension": [
                     {
                         "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
@@ -1260,6 +1278,15 @@
                         "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
                     ]
                 },
+                "type": [{
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                        "code": "injury",
+                        "display": "injury location"
+                      }
+                    ]
+                  }],
                 "address": {
                     "city": "Bedford",
                     "district": "Middlesex",

--- a/VRDR.Tests/fixtures/json/MissingAge.json
+++ b/VRDR.Tests/fixtures/json/MissingAge.json
@@ -1249,40 +1249,7 @@
                 }
             }
         },
-        {
-            "fullUrl": "urn:uuid:d7d87f3f-b76e-48d7-a2e0-1501a009003a",
-            "resource": {
-                "resourceType": "Observation",
-                "id": "d7d87f3f-b76e-48d7-a2e0-1501a009003a",
-                "meta": {
-                    "profile": [
-                        "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-                    ]
-                },
-                "status": "final",
-                "code": {
-                    "coding": [
-                        {
-                            "system": "http://loinc.org",
-                            "code": "69451-3",
-                            "display": "Transportation role of decedent"
-                        }
-                    ]
-                },
-                "subject": {
-                    "reference": "urn:uuid:2d27b2ef-406b-4192-aeb4-4c72eb6b9403"
-                },
-                "valueCodeableConcept": {
-                    "coding": [
-                        {
-                            "system": "http://snomed.info/sct",
-                            "code": "257500003",
-                            "display": "Passenger"
-                        }
-                    ]
-                }
-            }
-        },
+
         {
             "fullUrl": "urn:uuid:288209e5-ef97-4ed9-964b-8708b6e791f9",
             "resource": {

--- a/VRDR.Tests/fixtures/json/MissingCertifier.json
+++ b/VRDR.Tests/fixtures/json/MissingCertifier.json
@@ -1137,40 +1137,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {
         "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/MissingComposition.json
+++ b/VRDR.Tests/fixtures/json/MissingComposition.json
@@ -1028,40 +1028,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {
         "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/MissingCompositionAttestor.json
+++ b/VRDR.Tests/fixtures/json/MissingCompositionAttestor.json
@@ -1178,40 +1178,7 @@
         }
       }
     },
-    {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
+
     {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {

--- a/VRDR.Tests/fixtures/json/MissingCompositionSubject.json
+++ b/VRDR.Tests/fixtures/json/MissingCompositionSubject.json
@@ -1184,40 +1184,7 @@
         }
       }
     },
-    {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
+
     {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {

--- a/VRDR.Tests/fixtures/json/MissingDecedent.json
+++ b/VRDR.Tests/fixtures/json/MissingDecedent.json
@@ -1045,40 +1045,7 @@
         }
       }
     },
-    {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
+
     {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {

--- a/VRDR.Tests/fixtures/json/MissingEthnicityData.json
+++ b/VRDR.Tests/fixtures/json/MissingEthnicityData.json
@@ -773,40 +773,34 @@
               "id": "53c9dd38-892a-4ae4-b92b-adcb0fc1197e",
               "meta": {
                 "profile": [
-                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
                 ]
               },
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-                  "valueCodeableConcept": {
-                    "coding": [
-                      {
-                      "system": "urn:oid:2.16.840.1.113883.6.245",
-                      "code": "975772",
-                      "display": "YC"
-                      }
-                    ]
+              "type": [{
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                    "code": "death",
+                    "display": "death location"
                   }
-                }
-              ],
+                ]
+              }],
               "name": "Testing Hospital (Manhattan)",
-              "type": [
-                {
-                  "coding": [
-                    {
-                      "code": "16983000"
-                    }
-                  ]
-                }
-              ],
               "address": {
                 "line": [
                   "125 Worth St"
                 ],
                 "city": "New York",
                 "district": "New York",
-                "state": "YC",
+                "state": "NY",
+                "_state": {
+                  "extension": [
+                    {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
+                    "valueString": "YC"
+                    }
+                  ]
+                },
                 "postalCode": "10013-4006",
                 "country": "US"
               }
@@ -852,8 +846,8 @@
                 "coding": [
                   {
                     "system": "http://snomed.info/sct",
-                    "code": "455401000124109",
-                    "display": "City Burial (Potter's Field)"
+                    "code": "449971000124106",
+                    "display": "Burial"
                   }
                 ]
               }

--- a/VRDR.Tests/fixtures/json/MissingObservationCode.json
+++ b/VRDR.Tests/fixtures/json/MissingObservationCode.json
@@ -1393,40 +1393,7 @@
         }
       }
     },
-    {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
+
     {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {

--- a/VRDR.Tests/fixtures/json/MissingRelatedPersonRelationshipCode.json
+++ b/VRDR.Tests/fixtures/json/MissingRelatedPersonRelationshipCode.json
@@ -1184,40 +1184,6 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-      "resource": {
-        "resourceType": "Observation",
-        "id": "urn:uuid:f68f89e5-062c-4bac-8412-ae552254f152",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
-          ]
-        },
-        "status": "final",
-        "code": {
-          "coding": [
-            {
-              "system": "http://loinc.org",
-              "code": "69451-3",
-              "display": "Transportation role of decedent"
-            }
-          ]
-        },
-        "subject": {
-          "reference": "urn:uuid:c83bc94c-cf3f-4062-aa1c-dd86894a3b31"
-        },
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/stu3/valueset-TransportationRelationships",
-              "code": "example-code",
-              "display": "Example Code"
-            }
-          ]
-        }
-      }
-    },
-    {
       "fullUrl": "urn:uuid:c496b4ff-e65c-441e-9764-4a48becf3f9f",
       "resource": {
         "resourceType": "Observation",

--- a/VRDR.Tests/fixtures/json/RaceEthnicityCaseRecord.json
+++ b/VRDR.Tests/fixtures/json/RaceEthnicityCaseRecord.json
@@ -875,28 +875,23 @@
         "id": "2a0fd386-c1e5-45af-96d9-62a3368fe9cc",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
+            }
+          ]
+        }],
         "name": "Pecan Grove Nursing Home",
         "address": {
           "state": "MA",
           "country": "US"
-        },
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-            "valueCodeableConcept": {
-              "coding": [ {
-                "system": "urn:oid:2.16.840.1.113883.6.92",
-                "code": "25",
-                "display": "MA"
-              }
-              ]
-            }
-          }
-        ]
-      }
+        }      }
     },
     {
       "fullUrl": "urn:uuid:971737dd-d96d-4c1f-95c3-8f5f99147918",

--- a/VRDR.Tests/fixtures/json/RaceEthnicityCaseRecord2.json
+++ b/VRDR.Tests/fixtures/json/RaceEthnicityCaseRecord2.json
@@ -886,23 +886,18 @@
         "id": "2a0fd386-c1e5-45af-96d9-62a3368fe9cc",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
           ]
         },
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id",
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                "system": "2.16.840.1.113883.6.92",
-                "code": "25",
-                "display": "MA"
-                }
-              ]
+        "type": [{
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+              "code": "death",
+              "display": "death location"
             }
-          }
-        ],
+          ]
+        }],
         "name": "Pecan Grove Nursing Home",
         "address": {
           "state": "MA",

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -255,7 +255,7 @@
             <system value="http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"/>
             <code value="S"/>
             <display value="Never Married"/>
-          </coding> 
+          </coding>
           <text value="Single"/>
         </maritalStatus>
         <contact>
@@ -1634,52 +1634,109 @@
   <entry>
     <fullUrl value="urn:uuid:7895ab5b-d0f6-4425-b5d9-5335529e4010"/>
     <resource>
-      <Parameters>
+      <Observation>
         <id value="7895ab5b-d0f6-4425-b5d9-5335529e4010"/>
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-params-for-emerging-issues"/>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues"/>
         </meta>
-        <parameter>
-          <name value="PLACE1_1"/>
+        <status value="final"/>
+        <code>
+          <coding>
+            <code value="emergingissues"/>
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated"/>
+        </subject>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_1"/>
+            </coding>
+          </code>
           <valueString value="A"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE1_2"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_1"/>
+            </coding>
+          </code>
+          <valueString value="A"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_2"/>
+            </coding>
+          </code>
           <valueString value="B"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE1_3"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_3"/>
+            </coding>
+          </code>
           <valueString value="C"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE1_4"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_4"/>
+            </coding>
+          </code>
           <valueString value="D"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE1_5"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_5"/>
+            </coding>
+          </code>
           <valueString value="E"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE1_6"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue1_6"/>
+            </coding>
+          </code>
           <valueString value="F"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE8_1"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue8_1"/>
+            </coding>
+          </code>
           <valueString value="AAAAAAAA"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE8_2"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue8_2"/>
+            </coding>
+          </code>
           <valueString value="BBBBBBBB"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE8_3"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue8_3"/>
+            </coding>
+          </code>
           <valueString value="CCCCCCCC"/>
-        </parameter>
-        <parameter>
-          <name value="PLACE20"/>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <code value="EmergingIssue20"/>
+            </coding>
+          </code>
           <valueString value="AAAAAAAAAAAAAAAAAAAA"/>
-        </parameter>
-      </Parameters>
+        </component>
+      </Observation>
     </resource>
   </entry>
 </Bundle>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -1500,15 +1500,15 @@
           <code>
             <coding>
               <system value="http://loinc.org" />
-              <code value="69448-9" />
-              <display value="Injury leading to death associated with transportation event" />
+              <code value="69451-3" />
+              <display value="Transportation role of decedent" />
             </coding>
           </code>
           <valueCodeableConcept>
             <coding>
-              <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
-              <code value="Y" />
-              <display value="Yes" />
+              <system value="http://snomed.info/sct" />
+              <code value="257500003" />
+              <display value="Passenger" />
             </coding>
           </valueCodeableConcept>
         </component>
@@ -1521,11 +1521,6 @@
             </coding>
           </code>
           <valueCodeableConcept>
-            <coding>
-              <system value="urn:oid:2.16.840.1.114222.4.5.320" />
-              <code value="0" />
-              <display value="Home" />
-            </coding>
             <text value="At home, in the kitchen" />
           </valueCodeableConcept>
         </component>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -575,14 +575,14 @@
       <Organization>
         <id value="b2b3e7ce-5abc-4f22-a76f-d6e39dc8991c" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home" />
         </meta>
         <active value="true" />
         <type>
           <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/organization-type" />
-            <code value="bus" />
-            <display value="Non-Healthcare Business or Corporation" />
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs" />
+            <code value="funeralhome" />
+            <display value="Funeral Home" />
           </coding>
         </type>
         <name value="Smith Funeral Home" />
@@ -1518,15 +1518,6 @@
         <meta>
           <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" />
         </meta>
-        <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id">
-          <valueCodeableConcept>
-            <coding>
-              <system value="2.16.840.1.113883.6.92"/>
-              <code value="25"/>
-              <display value="MA"/>
-            </coding>
-          </valueCodeableConcept>
-        </extension>
         <name value="Example Death Location Name" />
         <description value="Example Death Location Description" />
         <type>
@@ -1541,7 +1532,11 @@
           <line value="Line 2" />
           <city value="Bedford" />
           <district value="Middlesex" />
-          <state value="MA" />
+          <state value="NY">
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id">
+          <valueString value="YC"/>
+          </extension>
+         </state>
           <postalCode value="01730" />
           <country value="US" />
         </address>
@@ -1581,6 +1576,22 @@
             </coding>
           </code>
           <valueDateTime value="2019-02-20T16:48:06-05:00" />
+        </component>
+       <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="58332-8" />
+              <display value="Location of death" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="440081000124100"/>
+              <display value="Death in home"/>
+            </coding>
+          </valueCodeableConcept>
         </component>
       </Observation>
     </resource>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -399,38 +399,6 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:6828566f-bfa8-40a9-8870-62f3c888de86" />
-    <resource>
-      <Organization>
-        <id value="6828566f-bfa8-40a9-8870-62f3c888de86" />
-        <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" />
-        </meta>
-        <identifier>
-          <value value="1010101" />
-        </identifier>
-        <active value="true" />
-        <type>
-          <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/organization-type" />
-            <code value="prov" />
-            <display value="Healthcare Provider" />
-          </coding>
-        </type>
-        <name value="Example Hospital" />
-        <address>
-          <line value="10 Example Street" />
-          <line value="Line 2" />
-          <city value="Bedford" />
-          <district value="Middlesex" />
-          <state value="MA" />
-          <postalCode value="01730" />
-          <country value="US" />
-        </address>
-      </Organization>
-    </resource>
-  </entry>
-  <entry>
     <fullUrl value="urn:uuid:20bc94bb-cdad-4daf-8e04-8304ea217e96" />
     <resource>
       <Observation xmlns="http://hl7.org/fhir">
@@ -700,9 +668,16 @@
       <Location>
         <id value="9bebc631-70b1-4052-bb61-7909caa7f5d4" />
         <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" />
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location" />
         </meta>
         <name value="Bedford Cemetery" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="disposition" />
+            <display value="disposition location" />
+          </coding>
+        </type>
         <address>
           <line value="603 Example Street" />
           <line value="Line 2" />
@@ -1448,6 +1423,13 @@
         </meta>
         <name value="Example Injury Location Name" />
         <description value="Example Injury Location Description" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="injury" />
+            <display value="injury location" />
+          </coding>
+        </type>
         <address>
           <line value="781 Example Street" />
           <line value="Line 2" />
@@ -1457,6 +1439,7 @@
           <postalCode value="01730" />
           <country value="US" />
         </address>
+
       </Location>
     </resource>
   </entry>
@@ -1546,6 +1529,13 @@
         </extension>
         <name value="Example Death Location Name" />
         <description value="Example Death Location Description" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="death" />
+            <display value="death location" />
+          </coding>
+        </type>
         <address>
           <line value="671 Example Street" />
           <line value="Line 2" />

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -188,13 +188,13 @@ namespace VRDR
             record.FuneralHomeName = "Pecan Street Funeral Home and Crematory";
             // record.FuneralDirectorPhone = "000-000-0000";    // unknown property?????
 
-            Dictionary<string, string> morticianId = new Dictionary<string, string>();
-            morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
-            morticianId.Add("value", "111111AB");
-            record.MorticianIdentifier = morticianId;
+            // Dictionary<string, string> morticianId = new Dictionary<string, string>();
+            // morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+            // morticianId.Add("value", "111111AB");
+            // record.MorticianIdentifier = morticianId;
 
-            record.MorticianGivenNames = new string[] { "Maureen", "P" };
-            record.MorticianFamilyName = "Winston";
+            // record.MorticianGivenNames = new string[] { "Maureen", "P" };
+            // record.MorticianFamilyName = "Winston";
 
             Dictionary<string, string> dladdress = new Dictionary<string, string>();
             dladdress.Add("addressLine1", "15 Pecan Street");
@@ -390,13 +390,13 @@ namespace VRDR
             record.FuneralHomeAddress = fdaddress;
             record.FuneralHomeName = "Rosewood Funeral Home";
 
-            Dictionary<string, string> morticianId = new Dictionary<string, string>();
-            morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
-            morticianId.Add("value", "212222AB");
-            record.MorticianIdentifier = morticianId;
+            // Dictionary<string, string> morticianId = new Dictionary<string, string>();
+            // morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+            // morticianId.Add("value", "212222AB");
+            // record.MorticianIdentifier = morticianId;
 
-            record.MorticianGivenNames = new string[] { "Ronald", "Q" };
-            record.MorticianFamilyName = "Smith";
+            // record.MorticianGivenNames = new string[] { "Ronald", "Q" };
+            // record.MorticianFamilyName = "Smith";
 
             Dictionary<string, string> dladdress = new Dictionary<string, string>();
             dladdress.Add("addressLine1", "303 Rosewood Ave");
@@ -568,13 +568,13 @@ namespace VRDR
             record.AutopsyPerformedIndicatorHelper = "Y";
             record.AutopsyResultsAvailableHelper = "Y";
 
-            Dictionary<string, string> morticianId = new Dictionary<string, string>();
-            morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
-            morticianId.Add("value", "414444AB");
-            record.MorticianIdentifier = morticianId;
+            // Dictionary<string, string> morticianId = new Dictionary<string, string>();
+            // morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+            // morticianId.Add("value", "414444AB");
+            // record.MorticianIdentifier = morticianId;
 
-            record.MorticianGivenNames = new string[] { "Joseph", "M" };
-            record.MorticianFamilyName = "Clark";
+            // record.MorticianGivenNames = new string[] { "Joseph", "M" };
+            // record.MorticianFamilyName = "Clark";
 
             Dictionary<string, string> fdaddress = new Dictionary<string, string>();
             fdaddress.Add("addressLine1", "211 High Street");
@@ -813,13 +813,13 @@ namespace VRDR
                 record.FuneralHomeAddress = fdaddress;
                 record.FuneralHomeName = "River Funeral Home";
 
-                Dictionary<string, string> morticianId = new Dictionary<string, string>();
-                morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
-                morticianId.Add("value", "313333AB");
-                record.MorticianIdentifier = morticianId;
+                // Dictionary<string, string> morticianId = new Dictionary<string, string>();
+                // morticianId.Add("system", VRDR.CodeSystems.US_NPI_HL7);
+                // morticianId.Add("value", "313333AB");
+                // record.MorticianIdentifier = morticianId;
 
-                record.MorticianGivenNames = new string[] { "Pedro", "A" };
-                record.MorticianFamilyName = "Jimenez";
+                // record.MorticianGivenNames = new string[] { "Pedro", "A" };
+                // record.MorticianFamilyName = "Jimenez";
 
                 Dictionary<string, string> dladdress = new Dictionary<string, string>();
                 dladdress.Add("addressLine1", "15 Furnace Drive");

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -418,7 +418,7 @@ namespace VRDR
             pregnancyStatus.Add("system", VRDR.CodeSystems.PH_PHINVS_CDC);
             pregnancyStatus.Add("display", "Not pregnant within the past year");
             record.PregnancyStatus = pregnancyStatus;
-            record.TransportationEventBoolean = false;
+            // record.TransportationEventBoolean = false;
             record.TobaccoUse = new Dictionary<string, string>() {
                 { "code", "373067005" },
                 { "system", VRDR.CodeSystems.SCT },
@@ -799,7 +799,7 @@ namespace VRDR
             codeT.Add("system", VRDR.CodeSystems.SCT);
             codeT.Add("display", "Vehicle driver");
             record.TransportationRole = codeT;
-            record.TransportationEventBoolean = true;
+            // record.TransportationEventBoolean = true;
             record.AutopsyPerformedIndicatorHelper = "N";
             record.AutopsyResultsAvailableHelper = "N";
             if (fullRecord)

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -230,8 +230,23 @@ namespace VRDR
         /// <summary>The Funeral Home Director.</summary>
         private PractitionerRole FuneralHomeDirector;
 
+
         /// <summary>Disposition Location.</summary>
         private Location DispositionLocation;
+
+        /// <summary>Create Disposition Location.</summary>
+        private void CreateDispositionLocation(){
+            DispositionLocation = new Location();
+            DispositionLocation.Id = Guid.NewGuid().ToString();
+            DispositionLocation.Meta = new Meta();
+            string[] dispositionlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" };
+            DispositionLocation.Meta.Profile = dispositionlocation_profile;
+            Coding pt = new Coding(CodeSystems.HL7_location_physical_type, "si", "Site");
+            DispositionLocation.PhysicalType = new CodeableConcept();
+            DispositionLocation.PhysicalType.Coding.Add(pt);
+            DispositionLocation.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "disposition", "disposition location", null));
+            LinkObservationToLocation(DispositionMethod, DispositionLocation);
+        }
 
         /// <summary>Disposition Method.</summary>
         private Observation DispositionMethod;
@@ -335,6 +350,7 @@ namespace VRDR
             InjuryLocationLoc.Meta = new Meta();
             string[] injurylocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location" };
             InjuryLocationLoc.Meta.Profile = injurylocation_profile;
+            InjuryLocationLoc.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "injury", "injury location", null));
         }
 
         /// <summary>Injury Incident.</summary>
@@ -361,11 +377,13 @@ namespace VRDR
             DeathLocationLoc = new Location();
             DeathLocationLoc.Id = Guid.NewGuid().ToString();
             DeathLocationLoc.Meta = new Meta();
-            string[] deathlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" };
+            string[] deathlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location" };
             DeathLocationLoc.Meta.Profile = deathlocation_profile;
+            DeathLocationLoc.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "death", "death location", null));
             LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
             AddReferenceToComposition(DeathLocationLoc.Id);
             Bundle.AddResourceEntry(DeathLocationLoc, "urn:uuid:" + DeathLocationLoc.Id);
+
         }
 
         /// <summary>Date Of Death.</summary>
@@ -437,14 +455,15 @@ namespace VRDR
             FuneralHomeDirector.Organization = new ResourceReference("urn:uuid:" + FuneralHome.Id);
 
             // Location of Disposition
-            DispositionLocation = new Location();
-            DispositionLocation.Id = Guid.NewGuid().ToString();
-            DispositionLocation.Meta = new Meta();
-            string[] dispositionlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" };
-            DispositionLocation.Meta.Profile = dispositionlocation_profile;
-            Coding pt = new Coding(CodeSystems.HL7_location_physical_type, "si", "Site");
-            DispositionLocation.PhysicalType = new CodeableConcept();
-            DispositionLocation.PhysicalType.Coding.Add(pt);
+            CreateDispositionLocation();
+            // DispositionLocation = new Location();
+            // DispositionLocation.Id = Guid.NewGuid().ToString();
+            // DispositionLocation.Meta = new Meta();
+            // string[] dispositionlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" };
+            // DispositionLocation.Meta.Profile = dispositionlocation_profile;
+            // Coding pt = new Coding(CodeSystems.HL7_location_physical_type, "si", "Site");
+            // DispositionLocation.PhysicalType = new CodeableConcept();
+            // DispositionLocation.PhysicalType.Coding.Add(pt);
 
             // Add Composition to bundle. As the record is filled out, new entries will be added to this element.
             Composition = new Composition();
@@ -4729,7 +4748,7 @@ namespace VRDR
         /// <para>  Console.WriteLine($"\FuneralHomeAddress key: {pair.Key}: value: {pair.Value}");</para>
         /// <para>};</para>
         /// </example>
-        [Property("Funeral Home Address", Property.Types.Dictionary, "Decedent Disposition", "Funeral Home Address.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Funeral-Home.html", false, 93)]
+        [Property("Funeral Home Address", Property.Types.Dictionary, "Decedent Disposition", "Funeral Home Address.", true, IGURL.FuneralHome, false, 93)]
         [PropertyParam("addressLine1", "address, line one")]
         [PropertyParam("addressLine2", "address, line two")]
         [PropertyParam("addressCity", "address, city")]
@@ -4761,20 +4780,12 @@ namespace VRDR
             {
                 if (FuneralHome == null)
                 {
-                    FuneralHome = new Organization();
-                    FuneralHome.Id = Guid.NewGuid().ToString();
-                    FuneralHome.Meta = new Meta();
-                    string[] funeralhome_profile = { ProfileURL.FuneralHome };
-                    FuneralHome.Meta.Profile = funeralhome_profile;
-                    FuneralHome.Type.Add(new CodeableConcept(CodeSystems.HL7_organization_type, "bus", "Non-Healthcare Business or Corporation", null));
-                    FuneralHome.Active = true;
-                    FuneralHome.Address.Add(DictToAddress(value));
+                    CreateFuneralHome();
                 }
-                else
-                {
-                    FuneralHome.Address.Clear();
-                    FuneralHome.Address.Add(DictToAddress(value));
-                }
+
+                FuneralHome.Address.Clear();
+                FuneralHome.Address.Add(DictToAddress(value));
+
             }
         }
 
@@ -4802,73 +4813,63 @@ namespace VRDR
             {
                 if (FuneralHome == null)
                 {
-                    FuneralHome = new Organization();
-                    FuneralHome.Id = Guid.NewGuid().ToString();
-                    FuneralHome.Meta = new Meta();
-                    string[] funeralhome_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" };
-                    FuneralHome.Meta.Profile = funeralhome_profile;
-                    FuneralHome.Type.Add(new CodeableConcept(CodeSystems.HL7_organization_type, "bus", "Non-Healthcare Business or Corporation", null));
-                    FuneralHome.Active = true;
-                    FuneralHome.Name = value;
+                    CreateFuneralHome();
                 }
-                else
-                {
-                    FuneralHome.Name = value;
-                }
+                FuneralHome.Name = value;
             }
         }
 
-        /// <summary>Funeral Director Phone.</summary>
-        /// <value>the funeral director phone number.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.FuneralDirectorPhone = "000-000-0000";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Funeral Director Phone: {ExampleDeathRecord.FuneralDirectorPhone}");</para>
-        /// </example>
-        [Property("Funeral Director Phone", Property.Types.String, "Decedent Disposition", "Funeral Director Phone.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Funeral-Service-Licensee.html", false, 95)]
-        [FHIRPath("Bundle.entry.resource.where($this is PractitionerRole)", "telecom")]
-        public string FuneralDirectorPhone
-        {
-            get
-            {
-                string value = null;
-                if (FuneralHomeDirector != null)
-                {
-                    ContactPoint cp = FuneralHomeDirector.Telecom.FirstOrDefault(entry => entry.System == ContactPoint.ContactPointSystem.Phone);
-                    if (cp != null)
-                    {
-                        value = cp.Value;
-                    }
-                }
-                return value;
-            }
-            set
-            {
-                if (FuneralHomeDirector == null)
-                {
-                    FuneralHomeDirector = new PractitionerRole();
-                    FuneralHomeDirector.Id = Guid.NewGuid().ToString();
-                    FuneralHomeDirector.Meta = new Meta();
-                    string[] funeralhomedirector_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Service-Licensee" };
-                    FuneralHomeDirector.Meta.Profile = funeralhomedirector_profile;
-                    AddReferenceToComposition(FuneralHomeDirector.Id);
-                    Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
-                }
-                ContactPoint cp = FuneralHomeDirector.Telecom.FirstOrDefault(entry => entry.System == ContactPoint.ContactPointSystem.Phone);
-                if (cp != null)
-                {
-                    cp.Value = value;
-                }
-                else
-                {
-                    cp = new ContactPoint();
-                    cp.System = ContactPoint.ContactPointSystem.Phone;
-                    cp.Value = value;
-                    FuneralHomeDirector.Telecom.Add(cp);
-                }
-            }
-        }
+        // /// <summary>Funeral Director Phone.</summary>
+        // /// <value>the funeral director phone number.</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.FuneralDirectorPhone = "000-000-0000";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Funeral Director Phone: {ExampleDeathRecord.FuneralDirectorPhone}");</para>
+        // /// </example>
+        // [Property("Funeral Director Phone", Property.Types.String, "Decedent Disposition", "Funeral Director Phone.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Funeral-Service-Licensee.html", false, 95)]
+        // [FHIRPath("Bundle.entry.resource.where($this is PractitionerRole)", "telecom")]
+        // public string FuneralDirectorPhone
+        // {
+        //     get
+        //     {
+        //         string value = null;
+        //         if (FuneralHomeDirector != null)
+        //         {
+        //             ContactPoint cp = FuneralHomeDirector.Telecom.FirstOrDefault(entry => entry.System == ContactPoint.ContactPointSystem.Phone);
+        //             if (cp != null)
+        //             {
+        //                 value = cp.Value;
+        //             }
+        //         }
+        //         return value;
+        //     }
+        //     set
+        //     {
+        //         if (FuneralHomeDirector == null)
+        //         {
+        //             FuneralHomeDirector = new PractitionerRole();
+        //             FuneralHomeDirector.Id = Guid.NewGuid().ToString();
+        //             FuneralHomeDirector.Meta = new Meta();
+        //             string[] funeralhomedirector_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Service-Licensee" };
+        //             FuneralHomeDirector.Meta.Profile = funeralhomedirector_profile;
+        //             AddReferenceToComposition(FuneralHomeDirector.Id);
+        //             Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
+        //         }
+        //         ContactPoint cp = FuneralHomeDirector.Telecom.FirstOrDefault(entry => entry.System == ContactPoint.ContactPointSystem.Phone);
+        //         if (cp != null)
+        //         {
+        //             cp.Value = value;
+        //         }
+        //         else
+        //         {
+        //             cp = new ContactPoint();
+        //             cp.System = ContactPoint.ContactPointSystem.Phone;
+        //             cp.Value = value;
+        //             FuneralHomeDirector.Telecom.Add(cp);
+        //         }
+        //     }
+        // }
 
         /// <summary>Disposition Location Address.</summary>
         /// <value>the disposition location address. A Dictionary representing an address, containing the following key/value pairs:
@@ -4897,7 +4898,7 @@ namespace VRDR
         /// <para>  Console.WriteLine($"\DispositionLocationAddress key: {pair.Key}: value: {pair.Value}");</para>
         /// <para>};</para>
         /// </example>
-        [Property("Disposition Location Address", Property.Types.Dictionary, "Decedent Disposition", "Disposition Location Address.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Disposition-Location.html", true, 91)]
+        [Property("Disposition Location Address", Property.Types.Dictionary, "Decedent Disposition", "Disposition Location Address.", true, IGURL.DispositionLocation, true, 91)]
         [PropertyParam("addressLine1", "address, line one")]
         [PropertyParam("addressLine2", "address, line two")]
         [PropertyParam("addressCity", "address, city")]
@@ -4905,7 +4906,7 @@ namespace VRDR
         [PropertyParam("addressState", "address, state")]
         [PropertyParam("addressZip", "address, zip")]
         [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location')", "address")]
+        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location')", "address")]
         public Dictionary<string, string> DispositionLocationAddress
         {
             get
@@ -4920,21 +4921,10 @@ namespace VRDR
             {
                 if (DispositionLocation == null)
                 {
-                    DispositionLocation = new Location();
-                    DispositionLocation.Id = Guid.NewGuid().ToString();
-                    DispositionLocation.Meta = new Meta();
-                    string[] dispositionlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" };
-                    DispositionLocation.Meta.Profile = dispositionlocation_profile;
-                    DispositionLocation.Address = DictToAddress(value);
-                    Coding pt = new Coding(CodeSystems.HL7_location_physical_type, "si", "Site");
-                    DispositionLocation.PhysicalType = new CodeableConcept();
-                    DispositionLocation.PhysicalType.Coding.Add(pt);
-                    LinkObservationToLocation(DispositionMethod, DispositionLocation);
+                    CreateDispositionLocation();
                 }
-                else
-                {
-                    DispositionLocation.Address = DictToAddress(value);
-                }
+
+                DispositionLocation.Address = DictToAddress(value);
             }
         }
 
@@ -4946,7 +4936,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Disposition Location Name: {ExampleDeathRecord.DispositionLocationName}");</para>
         /// </example>
-        [Property("Disposition Location Name", Property.Types.String, "Decedent Disposition", "Name of Disposition Location.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Disposition-Location.html", false, 92)]
+        [Property("Disposition Location Name", Property.Types.String, "Decedent Disposition", "Name of Disposition Location.", true, IGURL.DispositionLocation, false, 92)]
         [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location')", "name")]
         public string DispositionLocationName
         {
@@ -4962,21 +4952,10 @@ namespace VRDR
             {
                 if (DispositionLocation == null)
                 {
-                    DispositionLocation = new Location();
-                    DispositionLocation.Id = Guid.NewGuid().ToString();
-                    DispositionLocation.Meta = new Meta();
-                    string[] dispositionlocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" };
-                    DispositionLocation.Meta.Profile = dispositionlocation_profile;
-                    Coding pt = new Coding(CodeSystems.HL7_location_physical_type, "si", "Site");
-                    DispositionLocation.PhysicalType = new CodeableConcept();
-                    DispositionLocation.PhysicalType.Coding.Add(pt);
-                    DispositionLocation.Name = value;
-                    LinkObservationToLocation(DispositionMethod, DispositionLocation);
+                    CreateDispositionLocation();
                 }
-                else
-                {
-                    DispositionLocation.Name = value;
-                }
+
+                DispositionLocation.Name = value;
             }
         }
 
@@ -4996,7 +4975,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Disposition Method: {ExampleDeathRecord.DecedentDispositionMethod['display']}");</para>
         /// </example>
-        [Property("Decedent Disposition Method", Property.Types.Dictionary, "Decedent Disposition", "Decedent's Disposition Method.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Disposition-Location.html", true, 1)]
+        [Property("Decedent Disposition Method", Property.Types.Dictionary, "Decedent Disposition", "Decedent's Disposition Method.", true, IGURL.DispositionLocation, true, 1)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -5042,10 +5021,10 @@ namespace VRDR
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.DecedentDispositionMethodHelper = dmethod;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Death Location Type: {ExampleDeathRecord.DeathLocationTypeHelper}");</para>
+        /// <para>Console.WriteLine($"Decedent Disposition Method: {ExampleDeathRecord.DecedentDispositionMethodHelper}");</para>
         /// </example>
         /// </value>
-        [Property("Decedent Disposition Method", Property.Types.String, "Decedent Disposition", "Decedent's Disposition Method.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Disposition-Location.html", true, 1)]
+        [Property("Decedent Disposition Method", Property.Types.String, "Decedent Disposition", "Decedent's Disposition Method.", true, IGURL.DispositionLocation, true, 1)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80905-3')", "")]
         public string DecedentDispositionMethodHelper
@@ -5725,6 +5704,7 @@ namespace VRDR
                     string[] deathlocation_profile = { locationJurisdictionExtPath };
                     DeathLocationLoc.Meta.Profile = deathlocation_profile;
                     DeathLocationLoc.Description = value;
+                    DeathLocationLoc.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "death", "death location", null));
                     LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
                     AddReferenceToComposition(DeathLocationLoc.Id);
                     Bundle.AddResourceEntry(DeathLocationLoc, "urn:uuid:" + DeathLocationLoc.Id);
@@ -5778,6 +5758,7 @@ namespace VRDR
                     string[] deathlocation_profile = { locationJurisdictionExtPath };
                     DeathLocationLoc.Meta.Profile = deathlocation_profile;
                     DeathLocationLoc.Type.Add(DictToCodeableConcept(value));
+                    DeathLocationLoc.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "death", "death location", null));
                     LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
                     AddReferenceToComposition(DeathLocationLoc.Id);
                     Bundle.AddResourceEntry(DeathLocationLoc, "urn:uuid:" + DeathLocationLoc.Id);
@@ -7075,19 +7056,20 @@ namespace VRDR
                 StateDocumentReference = (DocumentReference)stateDocumentReferenceEntry.Resource;
             }
 
-            // Grab Funeral Home
-            var funeralHome = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Organization );
+            // Grab Funeral Home  **** SHould be able to find this without resort to meta.profile.  May need a reference from somewhere.  Or perhaps Locations and Organizations should require a profile.
+            var funeralHome = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Organization
+               && ((Organization)entry.Resource).Meta.Profile.FirstOrDefault() != null && MatchesProfile("vrdr-funeral-home", ((Organization)entry.Resource).Meta.Profile.FirstOrDefault()));
             if (funeralHome != null)
             {
                 FuneralHome = (Organization)funeralHome.Resource;
             }
 
-            // Grab Funeral Home Director
-            var funeralHomeDirector = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.PractitionerRole );
-            if (funeralHomeDirector != null)
-            {
-                FuneralHomeDirector = (PractitionerRole)funeralHomeDirector.Resource;
-            }
+            // // Grab Funeral Home Director
+            // var funeralHomeDirector = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.PractitionerRole );
+            // if (funeralHomeDirector != null)
+            // {
+            //     FuneralHomeDirector = (PractitionerRole)funeralHomeDirector.Resource;
+            // }
 
             // Scan through all Observations to make sure they all have codes!
             foreach (var ob in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Observation ))
@@ -7237,8 +7219,8 @@ namespace VRDR
             }
 
             // Grab Disposition Location
-            // IMPROVEMENT: Move away from using meta profile to find this exact Location.
-            var dispositionLocation = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Meta.Profile.FirstOrDefault() != null && MatchesProfile("VRDR-Disposition-Location", ((Location)entry.Resource).Meta.Profile.FirstOrDefault()));
+            var dispositionLocation = Bundle.Entry.FirstOrDefault( entry => (entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Type.FirstOrDefault() != null ) &&
+               (CodeableConceptToDict(((Location)entry.Resource).Type.First())["code"] == "disposition"));
             if (dispositionLocation != null)
             {
                 DispositionLocation = (Location)dispositionLocation.Resource;
@@ -7246,15 +7228,17 @@ namespace VRDR
 
             // Grab Injury Location
             // IMPROVEMENT: Move away from using meta profile to find this exact Location.
-            var injuryLocation = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Meta.Profile.FirstOrDefault() != null && MatchesProfile("VRDR-Injury-Location", ((Location)entry.Resource).Meta.Profile.FirstOrDefault()));
+            var injuryLocation = Bundle.Entry.FirstOrDefault( entry => (entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Type.FirstOrDefault() != null ) &&
+               (CodeableConceptToDict(((Location)entry.Resource).Type.First())["code"] == "injury"));
+             // Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Meta.Profile.FirstOrDefault() != null && MatchesProfile("vrdr-injury-location", ((Location)entry.Resource).Meta.Profile.FirstOrDefault()));
             if (injuryLocation != null)
             {
                 InjuryLocationLoc = (Location)injuryLocation.Resource;
             }
 
             // Grab Death Location
-            // IMPROVEMENT: Move away from using meta profile to find this exact Location.
-            var deathLocation = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Meta.Profile.FirstOrDefault() != null && MatchesProfile("VRDR-Death-Location", ((Location)entry.Resource).Meta.Profile.FirstOrDefault()));
+            var deathLocation = Bundle.Entry.FirstOrDefault( entry => (entry.Resource.ResourceType == ResourceType.Location && ((Location)entry.Resource).Type.FirstOrDefault() != null ) &&
+               (CodeableConceptToDict(((Location)entry.Resource).Type.First())["code"] == "death"));
             if (deathLocation != null)
             {
                 DeathLocationLoc = (Location)deathLocation.Resource;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -72,9 +72,6 @@ namespace VRDR
             DeathCertification.Code = new CodeableConcept(CodeSystems.SCT, "308646001", "Death certification", null);
         }
 
-        /// <summary>The Interested Party.</summary>
-        private Organization InterestedParty;
-
         /// <summary>The Manner of Death Observation.</summary>
         private Observation MannerOfDeath;
 
@@ -427,14 +424,6 @@ namespace VRDR
             // Start with an empty certification.
             CreateEmptyDeathCertification();
 
-            // Start with an empty interested party.
-            InterestedParty = new Organization();
-            InterestedParty.Id = Guid.NewGuid().ToString();
-            InterestedParty.Meta = new Meta();
-            string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
-            InterestedParty.Meta.Profile = interestedparty_profile;
-            InterestedParty.Active = true;
-
             // Start with an empty funeral home.
             CreateFuneralHome();
 
@@ -496,7 +485,6 @@ namespace VRDR
             AddReferenceToComposition(Pronouncer.Id);
             AddReferenceToComposition(Mortician.Id);
             AddReferenceToComposition(DeathCertification.Id);
-            AddReferenceToComposition(InterestedParty.Id);
             AddReferenceToComposition(FuneralHome.Id);
             AddReferenceToComposition(FuneralHomeDirector.Id);
             AddReferenceToComposition(CauseOfDeathConditionPathway.Id);
@@ -507,7 +495,6 @@ namespace VRDR
             Bundle.AddResourceEntry(Pronouncer, "urn:uuid:" + Pronouncer.Id);
             Bundle.AddResourceEntry(Mortician, "urn:uuid:" + Mortician.Id);
             Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
-            Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
             Bundle.AddResourceEntry(FuneralHome, "urn:uuid:" + FuneralHome.Id);
             Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
             Bundle.AddResourceEntry(CauseOfDeathConditionPathway, "urn:uuid:" + CauseOfDeathConditionPathway.Id);
@@ -755,10 +742,6 @@ namespace VRDR
                     Identifier identifier = new Identifier();
                     identifier.Value = value;
                     StateDocumentReference.Identifier.Add(identifier);
-                    if (InterestedParty != null)
-                    {
-                        StateDocumentReference.Author.Add(new ResourceReference("urn:uuid:" + InterestedParty.Id));
-                    }
                     StateDocumentReference.Date = new DateTimeOffset(DateTime.Now);
                     Attachment attachment = new Attachment();
                     attachment.Url = "urn:uuid:" + Bundle.Id;
@@ -930,193 +913,6 @@ namespace VRDR
                 }
             }
         }
-
-        // /// <summary>Interested Party Identifier.</summary>
-        // /// <value>the interested party identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
-        // /// <para>"system" - the identifier system, e.g. US NPI</para>
-        // /// <para>"value" - the identifier value, e.g. US NPI number</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
-        // /// <para>identifier.Add("value", "1234567890");</para>
-        // /// <para>ExampleDeathRecord.InterestedPartyIdentifier = identifier;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"\tPronouncer Identifier: {ExampleDeathRecord.InterestedPartyIdentifier['value']}");</para>
-        // /// </example>
-        // [Property("Interested Party Identifier", Property.Types.Dictionary, "Death Certification", "Interested Party Identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        // [PropertyParam("system", "The identifier system.")]
-        // [PropertyParam("value", "The identifier value.")]
-        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "identifier")]
-        // public Dictionary<string, string> InterestedPartyIdentifier
-        // {
-        //     get
-        //     {
-        //         Identifier identifier = InterestedParty?.Identifier?.FirstOrDefault();
-        //         var result = new Dictionary<string, string>();
-        //         if (identifier != null)
-        //         {
-        //             result["system"] = identifier.System;
-        //             result["value"] = identifier.Value;
-        //         }
-        //         return result;
-        //     }
-        //     set
-        //     {
-        //         if (InterestedParty == null)
-        //         {
-        //             InterestedParty = new Organization();
-        //             InterestedParty.Id = Guid.NewGuid().ToString();
-        //             InterestedParty.Meta = new Meta();
-        //             string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
-        //             InterestedParty.Meta.Profile = interestedparty_profile;
-        //             InterestedParty.Active = true;
-        //             AddReferenceToComposition(InterestedParty.Id);
-        //             Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
-        //         }
-        //         if (InterestedParty.Identifier.Count > 0)
-        //         {
-        //             InterestedParty.Identifier.Clear();
-        //         }
-        //         if(value.ContainsKey("system") && value.ContainsKey("value")) {
-        //             Identifier identifier = new Identifier();
-        //             identifier.System = value["system"];
-        //             identifier.Value = value["value"];
-        //             InterestedParty.Identifier.Add(identifier);
-        //         }
-        //     }
-        // }
-
-        // /// <summary>Interested Party Name.</summary>
-        // /// <value>an interested party name string.</value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>ExampleDeathRecord.InterestedPartyName = "Fourty Two";</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"Interested Party name: {ExampleDeathRecord.InterestedPartyName}");</para>
-        // /// </example>
-        // [Property("Interested Party Name", Property.Types.String, "Death Certification", "Interested Party Name.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "name")]
-        // public string InterestedPartyName
-        // {
-        //     get
-        //     {
-        //         if (InterestedParty != null)
-        //         {
-        //             return InterestedParty.Name;
-        //         }
-        //         return null;
-        //     }
-        //     set
-        //     {
-        //         if (InterestedParty == null)
-        //         {
-        //             InterestedParty = new Organization();
-        //             InterestedParty.Id = Guid.NewGuid().ToString();
-        //             InterestedParty.Meta = new Meta();
-        //             string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
-        //             InterestedParty.Meta.Profile = interestedparty_profile;
-        //             InterestedParty.Active = true;
-        //             InterestedParty.Name = value;
-        //             AddReferenceToComposition(InterestedParty.Id);
-        //             Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
-        //         }
-        //         else
-        //         {
-        //             InterestedParty.Name = value;
-        //         }
-        //     }
-        // }
-
-        // /// <summary>Interested Party's address.</summary>
-        // /// <value>Interested Party's address. A Dictionary representing an address, containing the following key/value pairs:
-        // /// <para>"addressLine1" - address, line one</para>
-        // /// <para>"addressLine2" - address, line two</para>
-        // /// <para>"addressCity" - address, city</para>
-        // /// <para>"addressCounty" - address, county</para>
-        // /// <para>"addressState" - address, state</para>
-        // /// <para>"addressZip" - address, zip</para>
-        // /// <para>"addressCountry" - address, country</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; address = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>address.Add("addressLine1", "9 Example Street");</para>
-        // /// <para>address.Add("addressLine2", "Line 2");</para>
-        // /// <para>address.Add("addressCity", "Bedford");</para>
-        // /// <para>address.Add("addressCounty", "Middlesex");</para>
-        // /// <para>address.Add("addressState", "MA");</para>
-        // /// <para>address.Add("addressZip", "12345");</para>
-        // /// <para>address.Add("addressCountry", "US");</para>
-        // /// <para>ExampleDeathRecord.InterestedPartyAddress = address;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"Interested Party state: {ExampleDeathRecord.InterestedPartyAddress["addressState"]}");</para>
-        // /// </example>
-        // [Property("Interested Party Address", Property.Types.Dictionary, "Death Certification", "Interested Party's address.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        // [PropertyParam("addressLine1", "address, line one")]
-        // [PropertyParam("addressLine2", "address, line two")]
-        // [PropertyParam("addressCity", "address, city")]
-        // [PropertyParam("addressCounty", "address, county")]
-        // [PropertyParam("addressState", "address, state")]
-        // [PropertyParam("addressZip", "address, zip")]
-        // [PropertyParam("addressCountry", "address, country")]
-        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "address")]
-        // public Dictionary<string, string> InterestedPartyAddress
-        // {
-        //     get
-        //     {
-        //         if (InterestedParty != null && InterestedParty.Address != null && InterestedParty.Address.Count() > 0)
-        //         {
-        //             return AddressToDict(InterestedParty.Address.First());
-        //         }
-        //         return EmptyAddrDict();
-        //     }
-        //     set
-        //     {
-        //         InterestedParty.Address.Clear();
-        //         InterestedParty.Address.Add(DictToAddress(value));
-        //     }
-        // }
-
-        // /// <summary>Interested Party Type.</summary>
-        // /// <value>the interested party type. A Dictionary representing a code, containing the following key/value pairs:
-        // /// <para>"code" - the code</para>
-        // /// <para>"system" - the code system this code belongs to</para>
-        // /// <para>"display" - a human readable meaning of the code</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; type = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>type.Add("code", "prov");</para>
-        // /// <para>type.Add("system",CodeSystems.HL7_organization_type);</para>
-        // /// <para>type.Add("display", "Healthcare Provider");</para>
-        // /// <para>ExampleDeathRecord.InterestedPartyType = type;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"Interested Party Type: {ExampleDeathRecord.InterestedPartyType['display']}");</para>
-        // /// </example>
-        // [Property("Interested Party Type", Property.Types.Dictionary, "Death Certification", "Interested Party Type.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "type")]
-        // public Dictionary<string, string> InterestedPartyType
-        // {
-        //     get
-        //     {
-        //         if (InterestedParty != null && InterestedParty.Type != null && InterestedParty.Type.Count() > 0)
-        //         {
-        //             return CodeableConceptToDict(InterestedParty.Type.First());
-        //         }
-        //         return EmptyCodeDict();
-        //     }
-        //     set
-        //     {
-        //         InterestedParty.Type.Clear();
-        //         InterestedParty.Type.Add(DictToCodeableConcept(value));
-        //     }
-        // }
-
         /// <summary>Manner of Death Type.</summary>
         /// <value>the manner of death type. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
@@ -7326,15 +7122,8 @@ namespace VRDR
                 StateDocumentReference = (DocumentReference)stateDocumentReferenceEntry.Resource;
             }
 
-            // Grab Interested Party
-            var interestedParty = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Organization && ((Organization)entry.Resource).Active != null );
-            if (interestedParty != null)
-            {
-                InterestedParty = (Organization)interestedParty.Resource;
-            }
-
             // Grab Funeral Home
-            var funeralHome = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Organization && (InterestedParty == null || ((Organization)entry.Resource).Id != InterestedParty.Id) );
+            var funeralHome = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Organization );
             if (funeralHome != null)
             {
                 FuneralHome = (Organization)funeralHome.Resource;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -1230,7 +1230,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Certifier Given Name(s): {string.Join(", ", ExampleDeathRecord.CertifierGivenNames)}");</para>
         /// </example>
-        [Property("Certifier Given Names", Property.Types.StringArr, "Death Certification", "Given name(s) of certifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", true, 5)]
+        [Property("Certifier Given Names", Property.Types.StringArr, "Death Certification", "Given name(s) of certifier.", true, IGURL.Certifier, true, 5)]
         [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "name")]
         public string[] CertifierGivenNames
         {
@@ -1362,15 +1362,21 @@ namespace VRDR
         /// <para>  Console.WriteLine($"\tCertifierAddress key: {pair.Key}: value: {pair.Value}");</para>
         /// <para>};</para>
         /// </example>
-        [Property("Certifier Address", Property.Types.Dictionary, "Death Certification", "Certifier's Address.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", true, 8)]
+        [Property("Certifier Address", Property.Types.Dictionary, "Death Certification", "Certifier's Address.", true, IGURL.Certifier, true, 8)]
         [PropertyParam("addressLine1", "address, line one")]
         [PropertyParam("addressLine2", "address, line two")]
         [PropertyParam("addressCity", "address, city")]
         [PropertyParam("addressCounty", "address, county")]
         [PropertyParam("addressState", "address, state")]
+        [PropertyParam("addressStnum", "address, stnum")]
+        [PropertyParam("addressPredir", "address, predir")]
+        [PropertyParam("addressPostdir", "address, postdir")]
+        [PropertyParam("addressStname", "address, stname")]
+        [PropertyParam("addressStrdesig", "address, strdesig")]
+        [PropertyParam("addressUnitnum", "address, unitnum")]
         [PropertyParam("addressZip", "address, zip")]
         [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "address")]
+        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-certifier')", "address")]
         public Dictionary<string, string> CertifierAddress
         {
             get
@@ -1384,67 +1390,67 @@ namespace VRDR
             }
         }
 
-        /// <summary>Certifier Qualification.</summary>
-        /// <value>the certifier qualification. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; qualification = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>qualification.Add("code", "434641000124105");</para>
-        /// <para>qualification.Add("system", CodeSystems.SCT);</para>
-        /// <para>qualification.Add("display", "Physician certified and pronounced death certificate");</para>
-        /// <para>ExampleDeathRecord.CertifierQualification = qualification;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCertifier Qualification: {ExampleDeathRecord.CertifierQualification['display']}");</para>
-        /// </example>
-        [Property("Certifier Qualification", Property.Types.Dictionary, "Death Certification", "Certifier Qualification.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", false, 9)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "qualification")]
-        public Dictionary<string, string> CertifierQualification
-        {
-            get
-            {
-                Practitioner.QualificationComponent qualification = Certifier.Qualification.FirstOrDefault();
-                if (qualification != null && qualification.Code != null && qualification.Code.Coding.FirstOrDefault() != null)
-                {
-                    return CodeableConceptToDict(qualification.Code);
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                if (Certifier.Qualification.FirstOrDefault() == null)
-                {
-                    Practitioner.QualificationComponent qualification = new Practitioner.QualificationComponent();
-                    qualification.Code = DictToCodeableConcept(value);
-                    Certifier.Qualification.Add(qualification);
-                }
-                else
-                {
-                    Certifier.Qualification.First().Code = DictToCodeableConcept(value);
-                }
-            }
-        }
+        // /// <summary>Certifier Qualification.</summary>
+        // /// <value>the certifier qualification. A Dictionary representing a code, containing the following key/value pairs:
+        // /// <para>"code" - the code</para>
+        // /// <para>"system" - the code system this code belongs to</para>
+        // /// <para>"display" - a human readable meaning of the code</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; qualification = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>qualification.Add("code", "434641000124105");</para>
+        // /// <para>qualification.Add("system", CodeSystems.SCT);</para>
+        // /// <para>qualification.Add("display", "Physician certified and pronounced death certificate");</para>
+        // /// <para>ExampleDeathRecord.CertifierQualification = qualification;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tCertifier Qualification: {ExampleDeathRecord.CertifierQualification['display']}");</para>
+        // /// </example>
+        // [Property("Certifier Qualification", Property.Types.Dictionary, "Death Certification", "Certifier Qualification.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", false, 9)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "qualification")]
+        // public Dictionary<string, string> CertifierQualification
+        // {
+        //     get
+        //     {
+        //         Practitioner.QualificationComponent qualification = Certifier.Qualification.FirstOrDefault();
+        //         if (qualification != null && qualification.Code != null && qualification.Code.Coding.FirstOrDefault() != null)
+        //         {
+        //             return CodeableConceptToDict(qualification.Code);
+        //         }
+        //         return EmptyCodeDict();
+        //     }
+        //     set
+        //     {
+        //         if (Certifier.Qualification.FirstOrDefault() == null)
+        //         {
+        //             Practitioner.QualificationComponent qualification = new Practitioner.QualificationComponent();
+        //             qualification.Code = DictToCodeableConcept(value);
+        //             Certifier.Qualification.Add(qualification);
+        //         }
+        //         else
+        //         {
+        //             Certifier.Qualification.First().Code = DictToCodeableConcept(value);
+        //         }
+        //     }
+        // }
 
-        /// <summary>Certifier Identifier.</summary>
-        /// <value>the certifier identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
-        /// <para>"system" - the identifier system, e.g. US NPI</para>
-        /// <para>"value" - the idetifier value, e.g. US NPI number</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
-        /// <para>identifier.Add("value", "1234567890");</para>
-        /// <para>ExampleDeathRecord.CertifierIdentifier = identifier;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCertifier Identifier: {ExampleDeathRecord.CertifierIdentifier['value']}");</para>
-        /// </example>
+        // /// <summary>Certifier Identifier.</summary>
+        // /// <value>the certifier identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
+        // /// <para>"system" - the identifier system, e.g. US NPI</para>
+        // /// <para>"value" - the idetifier value, e.g. US NPI number</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
+        // /// <para>identifier.Add("value", "1234567890");</para>
+        // /// <para>ExampleDeathRecord.CertifierIdentifier = identifier;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tCertifier Identifier: {ExampleDeathRecord.CertifierIdentifier['value']}");</para>
+        // /// </example>
         [Property("Certifier Identifier", Property.Types.Dictionary, "Death Certification", "Certifier Identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", false, 10)]
         [PropertyParam("system", "The identifier system.")]
         [PropertyParam("value", "The identifier value.")]
@@ -1477,50 +1483,50 @@ namespace VRDR
             }
         }
 
-        /// <summary>Certifier License Number.</summary>
-        /// <value>A string containing the certifier license number.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.CertifierQualification = qualification;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tCertifier Qualification: {ExampleDeathRecord.CertifierQualification['display']}");</para>
-        /// </example>
-        [Property("Certifier License Number", Property.Types.String, "Death Certification", "Certifier License Number.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", false, 11)]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "qualification")]
-        public string CertifierLicenseNumber
-        {
-            get
-            {
-                Practitioner.QualificationComponent qualification = Certifier.Qualification.FirstOrDefault();
-                if (qualification != null && qualification.Identifier.FirstOrDefault() != null)
-                {
-                    if (!String.IsNullOrWhiteSpace(qualification.Identifier.First().Value))
-                    {
-                        return qualification.Identifier.First().Value;
-                    }
-                    return null;
-                }
-                return null;
-            }
-            set
-            {
-                if (Certifier.Qualification.FirstOrDefault() == null)
-                {
-                    Practitioner.QualificationComponent qualification = new Practitioner.QualificationComponent();
-                    Identifier identifier = new Identifier();
-                    identifier.Value = value;
-                    qualification.Identifier.Add(identifier);
-                    Certifier.Qualification.Add(qualification);
-                }
-                else
-                {
-                    Certifier.Qualification.First().Identifier.Clear();
-                    Identifier identifier = new Identifier();
-                    identifier.Value = value;
-                    Certifier.Qualification.First().Identifier.Add(identifier);
-                }
-            }
-        }
+        // /// <summary>Certifier License Number.</summary>
+        // /// <value>A string containing the certifier license number.</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.CertifierQualification = qualification;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tCertifier Qualification: {ExampleDeathRecord.CertifierQualification['display']}");</para>
+        // /// </example>
+        // [Property("Certifier License Number", Property.Types.String, "Death Certification", "Certifier License Number.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", false, 11)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "qualification")]
+        // public string CertifierLicenseNumber
+        // {
+        //     get
+        //     {
+        //         Practitioner.QualificationComponent qualification = Certifier.Qualification.FirstOrDefault();
+        //         if (qualification != null && qualification.Identifier.FirstOrDefault() != null)
+        //         {
+        //             if (!String.IsNullOrWhiteSpace(qualification.Identifier.First().Value))
+        //             {
+        //                 return qualification.Identifier.First().Value;
+        //             }
+        //             return null;
+        //         }
+        //         return null;
+        //     }
+        //     set
+        //     {
+        //         if (Certifier.Qualification.FirstOrDefault() == null)
+        //         {
+        //             Practitioner.QualificationComponent qualification = new Practitioner.QualificationComponent();
+        //             Identifier identifier = new Identifier();
+        //             identifier.Value = value;
+        //             qualification.Identifier.Add(identifier);
+        //             Certifier.Qualification.Add(qualification);
+        //         }
+        //         else
+        //         {
+        //             Certifier.Qualification.First().Identifier.Clear();
+        //             Identifier identifier = new Identifier();
+        //             identifier.Value = value;
+        //             Certifier.Qualification.First().Identifier.Add(identifier);
+        //         }
+        //     }
+        // }
 
         /// <summary>Significant conditions that contributed to death but did not result in the underlying cause.
         /// Corresponds to part 2 of item 32 of the U.S. Standard Certificate of Death.</summary>
@@ -2470,7 +2476,7 @@ namespace VRDR
             }
         }
 
-        
+
         /// <summary>Decedent's Date of Birth Date Part Absent Extension.</summary>
         /// <value>the decedent's date of birth date part absent reason</value>
         /// <example>
@@ -2577,8 +2583,8 @@ namespace VRDR
                 }
                 Decedent.Address.Clear();
                 Decedent.Address.Add(DictToAddress(value));
-                
-            
+
+
                 // Now encode -
                 //        Address.Country as PH_Country_GEC
                 //        Adress.County as PHVS_DivisionVitalStatistics__County
@@ -2802,7 +2808,7 @@ namespace VRDR
         /// <summary>Decedent's Ethnicity 1 Helper</summary>
         /// <value>Decedent's Ethnicity 1.</value>
         /// <example>
-        /// <para>// Setter:</para> 
+        /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity1Helper}");</para>
@@ -2881,7 +2887,7 @@ namespace VRDR
         /// <summary>Decedent's Ethnicity 2 Helper</summary>
         /// <value>Decedent's Ethnicity 2.</value>
         /// <example>
-        /// <para>// Setter:</para> 
+        /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.Ethnicity2Helper = "Y";</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity1Helper}");</para>
@@ -2960,7 +2966,7 @@ namespace VRDR
         /// <summary>Decedent's Ethnicity 3 Helper</summary>
         /// <value>Decedent's Ethnicity 3.</value>
         /// <example>
-        /// <para>// Setter:</para> 
+        /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.Ethnicity3Helper = "Y";</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity3Helper}");</para>
@@ -3039,7 +3045,7 @@ namespace VRDR
         /// <summary>Decedent's Ethnicity 4 Helper</summary>
         /// <value>Decedent's Ethnicity 4.</value>
         /// <example>
-        /// <para>// Setter:</para> 
+        /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.Ethnicity4Helper = "Y";</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity4Helper}");</para>
@@ -3147,7 +3153,7 @@ namespace VRDR
                             string raceBool = ((FhirBoolean)component.Value).ToString();
 
                             if (Convert.ToBoolean(raceBool))
-                            {   
+                            {
                                 var race = Tuple.Create(raceCode, "Y");
                                 races.Add(race);
                             }
@@ -3155,7 +3161,7 @@ namespace VRDR
                             {
                                 var race = Tuple.Create(raceCode, "N");
                                 races.Add(race);
-                            } 
+                            }
                         }
                         else
                         {
@@ -3279,7 +3285,7 @@ namespace VRDR
                 SetCodeValue("RaceMissingValueReason", value, VRDR.ValueSets.RaceMissingValueReason.Codes);
             }
         }
-       
+
         /// <summary>Decedent's Place Of Birth.</summary>
         /// <value>decedent's Place Of Birth. A Dictionary representing residence address, containing the following key/value pairs:
         /// <para>"addressLine1" - address, line one</para>
@@ -3411,7 +3417,7 @@ namespace VRDR
                 {
                     Decedent.MaritalStatus = DictToCodeableConcept(value);
                 }
-                else 
+                else
                 {
                     string text = Decedent.MaritalStatus.Text;
                     Extension bypass = Decedent.MaritalStatus.Extension.FirstOrDefault();
@@ -3419,7 +3425,7 @@ namespace VRDR
                     Decedent.MaritalStatus.Extension.Add(bypass);
                     Decedent.MaritalStatus.Text = text;
                 }
-                
+
             }
         }
 
@@ -3558,7 +3564,7 @@ namespace VRDR
                 {
                     Decedent.MaritalStatus = new CodeableConcept();
                 }
-                Decedent.MaritalStatus.Text = value;  
+                Decedent.MaritalStatus.Text = value;
             }
         }
 
@@ -7839,7 +7845,7 @@ namespace VRDR
                     {
                         address.City = dict["addressCity"];
                     }
-                    
+
                 }
                 if (dict.ContainsKey("addressCountyC") && !String.IsNullOrEmpty(dict["addressCountyC"]))
                 {
@@ -8026,9 +8032,9 @@ namespace VRDR
                     Extension districtCode = addr.DistrictElement.Extension.Where(ext => ext.Url == ExtensionURL.DistrictCode).FirstOrDefault();
                     if (districtCode != null){
                         dictionary["addressCountyC"] = districtCode.Value.ToString();
-                    } 
+                    }
                 }
-                
+
                 Extension stnum = addr.Extension.Where(ext => ext.Url == ExtensionURL.StreetNumber).FirstOrDefault();
                 if (stnum != null)
                 {
@@ -8046,34 +8052,34 @@ namespace VRDR
                 {
                     dictionary["addressStname"] = stname.Value.ToString();
                 }
-                
+
                 Extension stdesig = addr.Extension.Where(ext => ext.Url == ExtensionURL.StreetDesignator).FirstOrDefault();
                 if (stdesig != null)
                 {
                     dictionary["addressStdesig"] = stdesig.Value.ToString();
                 }
-                
+
                 Extension postdir = addr.Extension.Where(ext => ext.Url == ExtensionURL.PostDirectional).FirstOrDefault();
                 if (postdir != null)
                 {
                     dictionary["addressPostdir"] = postdir.Value.ToString();
                 }
-                
+
                 Extension unitnum = addr.Extension.Where(ext => ext.Url == ExtensionURL.UnitOrAptNumber).FirstOrDefault();
                 if (unitnum != null)
                 {
                     dictionary["addressUnitnum"] = unitnum.Value.ToString();
                 }
-                
+
                 //Check for possible state extension
                 dictionary["addressState"] = addr.State;
-                if (addr.StateElement != null) 
+                if (addr.StateElement != null)
                 {
                     Extension stateExt = addr.StateElement.Extension.Where(ext => ext.Url == ExtensionURL.LocationJurisdictionId).FirstOrDefault();
                     if (stateExt != null)
                     {
                         dictionary["addressState"] = stateExt.Value.ToString();
-                    } 
+                    }
                 }
                 if (addr.City != null)
                 {
@@ -8121,7 +8127,7 @@ namespace VRDR
             dictionary.Add("display", "");
             return dictionary;
         }
-        
+
         /// <summary>Returns an empty "code" Dictionary for race and ethnicity.</summary>
         /// <returns>an empty "code" Dictionary.</returns>
         private Dictionary<string, string> EmptyRaceEthnicityCodeDict()

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -348,8 +348,9 @@ namespace VRDR
             InjuryLocationLoc = new Location();
             InjuryLocationLoc.Id = Guid.NewGuid().ToString();
             InjuryLocationLoc.Meta = new Meta();
-            string[] injurylocation_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location" };
+            string[] injurylocation_profile = {ProfileURL.InjuryLocation };
             InjuryLocationLoc.Meta.Profile = injurylocation_profile;
+            InjuryLocationLoc.Address = DictToAddress(EmptyAddrDict());
             InjuryLocationLoc.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "injury", "injury location", null));
         }
 
@@ -6214,15 +6215,17 @@ namespace VRDR
         /// <para>  Console.WriteLine($"\InjuryLocationAddress key: {pair.Key}: value: {pair.Value}");</para>
         /// <para>};</para>
         /// </example>
-        [Property("Injury Location Address", Property.Types.Dictionary, "Death Investigation", "Location of Injury.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Injury-Location.html", true, 34)]
+        [Property("Injury Location Address", Property.Types.Dictionary, "Death Investigation", "Location of Injury.", true, IGURL.InjuryLocation, true, 34)]
         [PropertyParam("addressLine1", "address, line one")]
         [PropertyParam("addressLine2", "address, line two")]
         [PropertyParam("addressCity", "address, city")]
+        [PropertyParam("addressCityC", "address, city code")]
         [PropertyParam("addressCounty", "address, county")]
+        [PropertyParam("addressCountyC", "address, county code")]
         [PropertyParam("addressState", "address, state")]
         [PropertyParam("addressZip", "address, zip")]
         [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location')", "address")]
+        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-location')", "address")]
         public Dictionary<string, string> InjuryLocationAddress
         {
             get

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -1173,53 +1173,6 @@ namespace VRDR
             }
         }
 
-        // /// <summary>Certifier Qualification.</summary>
-        // /// <value>the certifier qualification. A Dictionary representing a code, containing the following key/value pairs:
-        // /// <para>"code" - the code</para>
-        // /// <para>"system" - the code system this code belongs to</para>
-        // /// <para>"display" - a human readable meaning of the code</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; qualification = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>qualification.Add("code", "434641000124105");</para>
-        // /// <para>qualification.Add("system", CodeSystems.SCT);</para>
-        // /// <para>qualification.Add("display", "Physician certified and pronounced death certificate");</para>
-        // /// <para>ExampleDeathRecord.CertifierQualification = qualification;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"\tCertifier Qualification: {ExampleDeathRecord.CertifierQualification['display']}");</para>
-        // /// </example>
-        // [Property("Certifier Qualification", Property.Types.Dictionary, "Death Certification", "Certifier Qualification.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Certifier.html", false, 9)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier')", "qualification")]
-        // public Dictionary<string, string> CertifierQualification
-        // {
-        //     get
-        //     {
-        //         Practitioner.QualificationComponent qualification = Certifier.Qualification.FirstOrDefault();
-        //         if (qualification != null && qualification.Code != null && qualification.Code.Coding.FirstOrDefault() != null)
-        //         {
-        //             return CodeableConceptToDict(qualification.Code);
-        //         }
-        //         return EmptyCodeDict();
-        //     }
-        //     set
-        //     {
-        //         if (Certifier.Qualification.FirstOrDefault() == null)
-        //         {
-        //             Practitioner.QualificationComponent qualification = new Practitioner.QualificationComponent();
-        //             qualification.Code = DictToCodeableConcept(value);
-        //             Certifier.Qualification.Add(qualification);
-        //         }
-        //         else
-        //         {
-        //             Certifier.Qualification.First().Code = DictToCodeableConcept(value);
-        //         }
-        //     }
-        // }
-
         /// <summary>Certifier Identifier ** not mapped to IJE **.</summary>
         /// <value>the certifier identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
         /// <para>"system" - the identifier system, e.g. US NPI</para>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -219,6 +219,17 @@ namespace VRDR
         /// <summary>The Funeral Home.</summary>
         private Organization FuneralHome;
 
+
+        // <summary> Create Funeral Home. </summary>
+        private void CreateFuneralHome(){
+            FuneralHome = new Organization();
+            FuneralHome.Id = Guid.NewGuid().ToString();
+            FuneralHome.Meta = new Meta();
+            string[] funeralhome_profile = { ProfileURL.FuneralHome };
+            FuneralHome.Meta.Profile = funeralhome_profile;
+            FuneralHome.Type.Add(new CodeableConcept(CodeSystems.HL7_organization_type, "bus", "Non-Healthcare Business or Corporation", null));
+            FuneralHome.Active = true;
+        }
         /// <summary>The Funeral Home Director.</summary>
         private PractitionerRole FuneralHomeDirector;
 
@@ -443,13 +454,7 @@ namespace VRDR
             InterestedParty.Active = true;
 
             // Start with an empty funeral home.
-            FuneralHome = new Organization();
-            FuneralHome.Id = Guid.NewGuid().ToString();
-            FuneralHome.Meta = new Meta();
-            string[] funeralhome_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" };
-            FuneralHome.Meta.Profile = funeralhome_profile;
-            FuneralHome.Active = true;
-            FuneralHome.Type.Add(new CodeableConcept(CodeSystems.HL7_organization_type, "bus", "Non-Healthcare Business or Corporation", null));
+            CreateFuneralHome();
 
             // FuneralHomeLicensee Points to Mortician and FuneralHome
             FuneralHomeDirector = new PractitionerRole();
@@ -4999,6 +5004,12 @@ namespace VRDR
         [PropertyParam("addressCity", "address, city")]
         [PropertyParam("addressCounty", "address, county")]
         [PropertyParam("addressState", "address, state")]
+        [PropertyParam("addressStnum", "address, stnum")]
+        [PropertyParam("addressStdesig", "address, stdesig")]
+        [PropertyParam("addressPredir", "address, predir")]
+        [PropertyParam("addressPostDir", "address, postdir")]
+        [PropertyParam("addressStname", "address, stname")]
+        [PropertyParam("addressUnitnum", "address, unitnum")]
         [PropertyParam("addressZip", "address, zip")]
         [PropertyParam("addressCountry", "address, country")]
         [FHIRPath("Bundle.entry.resource.where($this is Organization).where(type.coding.code='bus')", "address")]
@@ -5022,7 +5033,7 @@ namespace VRDR
                     FuneralHome = new Organization();
                     FuneralHome.Id = Guid.NewGuid().ToString();
                     FuneralHome.Meta = new Meta();
-                    string[] funeralhome_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" };
+                    string[] funeralhome_profile = { ProfileURL.FuneralHome };
                     FuneralHome.Meta.Profile = funeralhome_profile;
                     FuneralHome.Type.Add(new CodeableConcept(CodeSystems.HL7_organization_type, "bus", "Non-Healthcare Business or Corporation", null));
                     FuneralHome.Active = true;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -224,7 +224,7 @@ namespace VRDR
             FuneralHome.Meta = new Meta();
             string[] funeralhome_profile = { ProfileURL.FuneralHome };
             FuneralHome.Meta.Profile = funeralhome_profile;
-            FuneralHome.Type.Add(new CodeableConcept(CodeSystems.HL7_organization_type, "bus", "Non-Healthcare Business or Corporation", null));
+            FuneralHome.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs", "funeralhome", "Funeral Home",null));
             FuneralHome.Active = true;
         }
         /// <summary>The Funeral Home Director.</summary>
@@ -437,7 +437,7 @@ namespace VRDR
             Pronouncer.Meta.Profile = pronouncer_profile;
 
             // Start with an empty mortician.
-            InitializeMorticianIfNull();
+           // InitializeMorticianIfNull();
 
             // Start with an empty certification.
             CreateEmptyDeathCertification();
@@ -446,13 +446,13 @@ namespace VRDR
             CreateFuneralHome();
 
             // FuneralHomeLicensee Points to Mortician and FuneralHome
-            FuneralHomeDirector = new PractitionerRole();
-            FuneralHomeDirector.Id = Guid.NewGuid().ToString();
-            FuneralHomeDirector.Meta = new Meta();
-            string[] funeralhomedirector_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Service-Licensee" };
-            FuneralHomeDirector.Meta.Profile = funeralhomedirector_profile;
-            FuneralHomeDirector.Practitioner = new ResourceReference("urn:uuid:" + Mortician.Id);
-            FuneralHomeDirector.Organization = new ResourceReference("urn:uuid:" + FuneralHome.Id);
+            // FuneralHomeDirector = new PractitionerRole();
+            // FuneralHomeDirector.Id = Guid.NewGuid().ToString();
+            // FuneralHomeDirector.Meta = new Meta();
+            // string[] funeralhomedirector_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Service-Licensee" };
+            // FuneralHomeDirector.Meta.Profile = funeralhomedirector_profile;
+            // FuneralHomeDirector.Practitioner = new ResourceReference("urn:uuid:" + Mortician.Id);
+            // FuneralHomeDirector.Organization = new ResourceReference("urn:uuid:" + FuneralHome.Id);
 
             // Location of Disposition
             CreateDispositionLocation();
@@ -502,20 +502,20 @@ namespace VRDR
             AddReferenceToComposition(InputRaceandEthnicity.Id);
             AddReferenceToComposition(Certifier.Id);
             AddReferenceToComposition(Pronouncer.Id);
-            AddReferenceToComposition(Mortician.Id);
+            //AddReferenceToComposition(Mortician.Id);
             AddReferenceToComposition(DeathCertification.Id);
             AddReferenceToComposition(FuneralHome.Id);
-            AddReferenceToComposition(FuneralHomeDirector.Id);
+            //AddReferenceToComposition(FuneralHomeDirector.Id);
             AddReferenceToComposition(CauseOfDeathConditionPathway.Id);
             AddReferenceToComposition(DispositionLocation.Id);
             Bundle.AddResourceEntry(Decedent, "urn:uuid:" + Decedent.Id);
             Bundle.AddResourceEntry(InputRaceandEthnicity, "urn:uuid:" + InputRaceandEthnicity.Id);
             Bundle.AddResourceEntry(Certifier, "urn:uuid:" + Certifier.Id);
             Bundle.AddResourceEntry(Pronouncer, "urn:uuid:" + Pronouncer.Id);
-            Bundle.AddResourceEntry(Mortician, "urn:uuid:" + Mortician.Id);
+            //Bundle.AddResourceEntry(Mortician, "urn:uuid:" + Mortician.Id);
             Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
             Bundle.AddResourceEntry(FuneralHome, "urn:uuid:" + FuneralHome.Id);
-            Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
+            //Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
             Bundle.AddResourceEntry(CauseOfDeathConditionPathway, "urn:uuid:" + CauseOfDeathConditionPathway.Id);
             Bundle.AddResourceEntry(DispositionLocation, "urn:uuid:" + DispositionLocation.Id);
 
@@ -4554,172 +4554,172 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Mortician Given Name(s): {string.Join(", ", ExampleDeathRecord.MorticianGivenNames)}");</para>
         /// </example>
-        [Property("Mortician Given Names", Property.Types.StringArr, "Decedent Disposition", "Given name(s) of mortician.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 96)]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "name")]
-        public string[] MorticianGivenNames
-        {
-            get
-            {
-                if (Mortician != null && Mortician.Name.Count() > 0)
-                {
-                    return Mortician.Name.First().Given.ToArray();
-                }
-                return new string[0];
-            }
-            set
-            {
-                InitializeMorticianIfNull();
-                HumanName name = Mortician.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                if (name != null)
-                {
-                    name.Given = value;
-                }
-                else
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Given = value;
-                    Mortician.Name.Add(name);
-                }
-            }
-        }
+        // [Property("Mortician Given Names", Property.Types.StringArr, "Decedent Disposition", "Given name(s) of mortician.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 96)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "name")]
+        // public string[] MorticianGivenNames
+        // {
+        //     get
+        //     {
+        //         if (Mortician != null && Mortician.Name.Count() > 0)
+        //         {
+        //             return Mortician.Name.First().Given.ToArray();
+        //         }
+        //         return new string[0];
+        //     }
+        //     set
+        //     {
+        //         InitializeMorticianIfNull();
+        //         HumanName name = Mortician.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+        //         if (name != null)
+        //         {
+        //             name.Given = value;
+        //         }
+        //         else
+        //         {
+        //             name = new HumanName();
+        //             name.Use = HumanName.NameUse.Official;
+        //             name.Given = value;
+        //             Mortician.Name.Add(name);
+        //         }
+        //     }
+        // }
 
-        /// <summary>Family name of mortician.</summary>
-        /// <value>the mortician's family name (i.e. last name)</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.MorticianFamilyName = "Last";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mortician's Last Name: {ExampleDeathRecord.MorticianFamilyName}");</para>
-        /// </example>
-        [Property("Mortician Family Name", Property.Types.String, "Decedent Disposition", "Family name of mortician.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 97)]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "name")]
-        public string MorticianFamilyName
-        {
-            get
-            {
-                if (Mortician != null && Mortician.Name.Count() > 0)
-                {
-                    return Mortician.Name.First().Family;
-                }
-                return null;
-            }
-            set
-            {
-                InitializeMorticianIfNull();
-                HumanName name = Mortician.Name.FirstOrDefault();
-                if (name != null && !String.IsNullOrEmpty(value))
-                {
-                    name.Family = value;
-                }
-                else if (!String.IsNullOrEmpty(value))
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Family = value;
-                    Mortician.Name.Add(name);
-                }
-            }
-        }
+        // /// <summary>Family name of mortician.</summary>
+        // /// <value>the mortician's family name (i.e. last name)</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.MorticianFamilyName = "Last";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Mortician's Last Name: {ExampleDeathRecord.MorticianFamilyName}");</para>
+        // /// </example>
+        // [Property("Mortician Family Name", Property.Types.String, "Decedent Disposition", "Family name of mortician.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 97)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "name")]
+        // public string MorticianFamilyName
+        // {
+        //     get
+        //     {
+        //         if (Mortician != null && Mortician.Name.Count() > 0)
+        //         {
+        //             return Mortician.Name.First().Family;
+        //         }
+        //         return null;
+        //     }
+        //     set
+        //     {
+        //         InitializeMorticianIfNull();
+        //         HumanName name = Mortician.Name.FirstOrDefault();
+        //         if (name != null && !String.IsNullOrEmpty(value))
+        //         {
+        //             name.Family = value;
+        //         }
+        //         else if (!String.IsNullOrEmpty(value))
+        //         {
+        //             name = new HumanName();
+        //             name.Use = HumanName.NameUse.Official;
+        //             name.Family = value;
+        //             Mortician.Name.Add(name);
+        //         }
+        //     }
+        // }
 
-        /// <summary>Mortician's Suffix.</summary>
-        /// <value>the mortician's suffix</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.MorticianSuffix = "Jr.";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mortician Suffix: {ExampleDeathRecord.MorticianSuffix}");</para>
-        /// </example>
-        [Property("Mortician Suffix", Property.Types.String, "Decedent Disposition", "Mortician's Suffix.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 98)]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "suffix")]
-        public string MorticianSuffix
-        {
-            get
-            {
-                if (Mortician != null && Mortician.Name.Count() > 0 && Mortician.Name.First().Suffix.Count() > 0)
-                {
-                    return Mortician.Name.First().Suffix.First();
-                }
-                return null;
-            }
-            set
-            {
-                InitializeMorticianIfNull();
-                HumanName name = Mortician.Name.FirstOrDefault();
-                if (name != null && !String.IsNullOrEmpty(value))
-                {
-                    string[] suffix = { value };
-                    name.Suffix = suffix;
-                }
-                else if (!String.IsNullOrEmpty(value))
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    string[] suffix = { value };
-                    name.Suffix = suffix;
-                    Mortician.Name.Add(name);
-                }
-            }
-        }
+        // /// <summary>Mortician's Suffix.</summary>
+        // /// <value>the mortician's suffix</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.MorticianSuffix = "Jr.";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Mortician Suffix: {ExampleDeathRecord.MorticianSuffix}");</para>
+        // /// </example>
+        // [Property("Mortician Suffix", Property.Types.String, "Decedent Disposition", "Mortician's Suffix.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 98)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "suffix")]
+        // public string MorticianSuffix
+        // {
+        //     get
+        //     {
+        //         if (Mortician != null && Mortician.Name.Count() > 0 && Mortician.Name.First().Suffix.Count() > 0)
+        //         {
+        //             return Mortician.Name.First().Suffix.First();
+        //         }
+        //         return null;
+        //     }
+        //     set
+        //     {
+        //         InitializeMorticianIfNull();
+        //         HumanName name = Mortician.Name.FirstOrDefault();
+        //         if (name != null && !String.IsNullOrEmpty(value))
+        //         {
+        //             string[] suffix = { value };
+        //             name.Suffix = suffix;
+        //         }
+        //         else if (!String.IsNullOrEmpty(value))
+        //         {
+        //             name = new HumanName();
+        //             name.Use = HumanName.NameUse.Official;
+        //             string[] suffix = { value };
+        //             name.Suffix = suffix;
+        //             Mortician.Name.Add(name);
+        //         }
+        //     }
+        // }
 
-        /// <summary>Mortician Identifier.</summary>
-        /// <value>the mortician identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
-        /// <para>"system" - the identifier system, e.g. US NPI</para>
-        /// <para>"value" - the idetifier value, e.g. US NPI number</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
-        /// <para>identifier.Add("value", "1234567890");</para>
-        /// <para>ExampleDeathRecord.MorticianIdentifier = identifier;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tMortician Identifier: {ExampleDeathRecord.MorticianIdentifier['value']}");</para>
-        /// </example>
-        [Property("Mortician Identifier", Property.Types.Dictionary, "Decedent Disposition", "Mortician Identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 99)]
-        [PropertyParam("system", "The identifier system.")]
-        [PropertyParam("value", "The identifier value.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "identifier")]
-        public Dictionary<string, string> MorticianIdentifier
-        {
-            get
-            {
-                Identifier identifier = Mortician?.Identifier?.FirstOrDefault();
-                var result = new Dictionary<string, string>();
-                if (identifier != null)
-                {
-                    result["system"] = identifier.System;
-                    result["value"] = identifier.Value;
-                }
-                return result;
-            }
-            set
-            {
-                InitializeMorticianIfNull();
-                if (Mortician.Identifier.Count > 0)
-                {
-                    Mortician.Identifier.Clear();
-                }
-                if(value.ContainsKey("system") && value.ContainsKey("value")) {
-                    Identifier identifier = new Identifier();
-                    identifier.System = value["system"];
-                    identifier.Value = value["value"];
-                    Mortician.Identifier.Add(identifier);
-                }
-            }
-        }
+        // /// <summary>Mortician Identifier.</summary>
+        // /// <value>the mortician identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
+        // /// <para>"system" - the identifier system, e.g. US NPI</para>
+        // /// <para>"value" - the idetifier value, e.g. US NPI number</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
+        // /// <para>identifier.Add("value", "1234567890");</para>
+        // /// <para>ExampleDeathRecord.MorticianIdentifier = identifier;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tMortician Identifier: {ExampleDeathRecord.MorticianIdentifier['value']}");</para>
+        // /// </example>
+        // [Property("Mortician Identifier", Property.Types.Dictionary, "Decedent Disposition", "Mortician Identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Mortician.html", false, 99)]
+        // [PropertyParam("system", "The identifier system.")]
+        // [PropertyParam("value", "The identifier value.")]
+        // [FHIRPath("Bundle.entry.resource.where($this is Practitioner).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician')", "identifier")]
+        // public Dictionary<string, string> MorticianIdentifier
+        // {
+        //     get
+        //     {
+        //         Identifier identifier = Mortician?.Identifier?.FirstOrDefault();
+        //         var result = new Dictionary<string, string>();
+        //         if (identifier != null)
+        //         {
+        //             result["system"] = identifier.System;
+        //             result["value"] = identifier.Value;
+        //         }
+        //         return result;
+        //     }
+        //     set
+        //     {
+        //         InitializeMorticianIfNull();
+        //         if (Mortician.Identifier.Count > 0)
+        //         {
+        //             Mortician.Identifier.Clear();
+        //         }
+        //         if(value.ContainsKey("system") && value.ContainsKey("value")) {
+        //             Identifier identifier = new Identifier();
+        //             identifier.System = value["system"];
+        //             identifier.Value = value["value"];
+        //             Mortician.Identifier.Add(identifier);
+        //         }
+        //     }
+        // }
 
-        private void InitializeMorticianIfNull()
-        {
-            if (Mortician == null)
-            {
-                Mortician = new Practitioner();
-                Mortician.Id = Guid.NewGuid().ToString();
-                Mortician.Meta = new Meta();
-                string[] mortician_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician" };
-                Mortician.Meta.Profile = mortician_profile;
-            }
-        }
+        // private void InitializeMorticianIfNull()
+        // {
+        //     if (Mortician == null)
+        //     {
+        //         Mortician = new Practitioner();
+        //         Mortician.Id = Guid.NewGuid().ToString();
+        //         Mortician.Meta = new Meta();
+        //         string[] mortician_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician" };
+        //         Mortician.Meta.Profile = mortician_profile;
+        //     }
+        // }
 
         /// <summary>Funeral Home Address.</summary>
         /// <value>the funeral home address. A Dictionary representing an address, containing the following key/value pairs:
@@ -5002,7 +5002,7 @@ namespace VRDR
                     DispositionMethod.Status = ObservationStatus.Final;
                     DispositionMethod.Code = new CodeableConcept(CodeSystems.LOINC, "80905-3", "Body disposition method", null);
                     DispositionMethod.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    DispositionMethod.Performer.Add(new ResourceReference("urn:uuid:" + Mortician.Id));
+//                    DispositionMethod.Performer.Add(new ResourceReference("urn:uuid:" + Mortician.Id));
                     DispositionMethod.Value = DictToCodeableConcept(value);
                     LinkObservationToLocation(DispositionMethod, DispositionLocation);
                     AddReferenceToComposition(DispositionMethod.Id);

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -328,26 +328,8 @@ namespace VRDR
         /// <summary>Tobacco Use Contributed To Death.</summary>
         private Observation TobaccoUseObs;
 
-        // <summary>Transportation Role.</summary>
-        // private Observation TransportationRoleObs;
-
-        // /// <summary>Create Transportation Role. </summary>
-        // private void CreateTransportationRoleObs(){
-        //     TransportationRoleObs = new Observation();
-        //     TransportationRoleObs.Id = Guid.NewGuid().ToString();
-        //     TransportationRoleObs.Meta = new Meta();
-        //     string[] t_profile = { VRDR.ProfileURL.DecedentTransportationRole };
-        //     TransportationRoleObs.Meta.Profile = t_profile;
-        //     TransportationRoleObs.Status = ObservationStatus.Final;
-        //     TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
-        //     TransportationRoleObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-        //     AddReferenceToComposition(TransportationRoleObs.Id);
-        //     Bundle.AddResourceEntry(TransportationRoleObs, "urn:uuid:" + TransportationRoleObs.Id);
-        // }
-
         /// <summary>Injury Location.</summary>
         private Location InjuryLocationLoc;
-
 
           /// <summary>Create Injury Location.</summary>
           private void CreateInjuryLocationLoc(){
@@ -6789,116 +6771,6 @@ namespace VRDR
             }
         }
 
-        // /// <summary>Transportation Event?</summary>
-        // /// <value>was the injury associated with a transportation event? A Dictionary representing a code, containing the following key/value pairs:
-        // /// <para>"code" - the code</para>
-        // /// <para>"system" - the code system this code belongs to</para>
-        // /// <para>"display" - a human readable meaning of the code</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>code.Add("code", "N");</para>
-        // /// <para>code.Add("system", CodeSystems.PH_YesNo_HL7_2x);</para>
-        // /// <para>code.Add("display", "No");</para>
-        // /// <para>ExampleDeathRecord.TransportationEvent = code;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEvent['display']}");</para>
-        // /// </example>
-        // [Property("Transportation Event?", Property.Types.Dictionary, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 43)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // [PropertyParam("text", "Additional descriptive text.")]
-        // [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        // public Dictionary<string, string> TransportationEvent
-        // {
-        //     get  //TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
-        //     {
-        //         if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
-        //         {
-        //             // Find correct component
-        //             var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-        //             ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69448-9" );
-        //             if (transportComp != null && transportComp.Value != null && transportComp.Value as CodeableConcept != null)
-        //             {
-        //                 return CodeableConceptToDict((CodeableConcept)transportComp.Value);
-        //             }
-        //         }
-        //         return EmptyCodeableDict();
-        //     }
-        //     set
-        //     {
-        //         if (InjuryIncidentObs == null)
-        //         {
-        //             CreateInjuryIncidentObs();
-        //         }
-        //         // Find correct component; if doesn't exist add another
-        //         var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69448-9" );
-        //         if (transportComp != null)
-        //         {
-        //             ((Observation.ComponentComponent)transportComp).Value = DictToCodeableConcept(value);
-        //         }
-        //         else
-        //         {
-        //             Observation.ComponentComponent component = new Observation.ComponentComponent();
-        //             component.Code = new CodeableConcept(CodeSystems.LOINC, "69448-9", "Injury leading to death associated with transportation event", null);
-        //             component.Value = DictToCodeableConcept(value);
-        //             InjuryIncidentObs.Component.Add(component);
-        //             }
-        //     }
-        // }
-
-        // /// <summary>Transportation Event Boolean?</summary>
-        // /// <value>was the injury associated with a transportation event? A null value indicates "unknown"</value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>ExampleDeathRecord.TransportationEventBoolean = true;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEventBoolean}");</para>
-        // /// </example>
-        // [Property("Transportation Event Boolean?", Property.Types.Bool, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 44)]
-        // [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        // public bool? TransportationEventBoolean
-        // {
-        //     get
-        //     {
-        //         var code = this.TransportationEvent;
-        //         switch (code["code"])
-        //         {
-        //             case "Y": // Yes
-        //                 return true;
-        //             case "N": // No
-        //                 return false;
-        //             default: // Unknown
-        //                 return null;
-        //         }
-        //     }
-        //     set
-        //     {
-        //         var code = EmptyCodeDict();
-        //         switch(value)
-        //         {
-        //             case true:
-        //                 code["code"] = "Y";
-        //                 code["display"] = "Yes";
-        //                 code["system"] = CodeSystems.PH_YesNo_HL7_2x;
-        //                 break;
-        //             case false:
-        //                 code["code"] = "N";
-        //                 code["display"] = "No";
-        //                 code["system"] = CodeSystems.PH_YesNo_HL7_2x;
-        //                 break;
-        //             default:
-        //                 code["code"] = "UNK";
-        //                 code["display"] = "unknown";
-        //                 code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
-        //                 break;
-        //         }
-        //         this.TransportationEvent = code;
-        //     }
-        // }
-
         /// <summary>Transportation Role in death.</summary>
         /// <value>transportation role in death. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
@@ -7491,13 +7363,6 @@ namespace VRDR
             {
                 MannerOfDeath = (Observation)mannerOfDeath.Resource;
             }
-
-            // // Grab Transportation Role Observation
-            // var transportationRole = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && ((Observation)entry.Resource).Code.Coding.First().Code == "69451-3" );
-            // if (transportationRole != null)
-            // {
-            //     TransportationRoleObs = (Observation)transportationRole.Resource;
-            // }
 
             // Grab Disposition Method
             var dispositionMethod = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && ((Observation)entry.Resource).Code.Coding.First().Code == "80905-3" );

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -317,22 +317,22 @@ namespace VRDR
         /// <summary>Tobacco Use Contributed To Death.</summary>
         private Observation TobaccoUseObs;
 
-        /// <summary>Transportation Role.</summary>
-        private Observation TransportationRoleObs;
+        // <summary>Transportation Role.</summary>
+        // private Observation TransportationRoleObs;
 
-        /// <summary>Create Transportation Role. </summary>
-        private void CreateTransportationRoleObs(){
-            TransportationRoleObs = new Observation();
-            TransportationRoleObs.Id = Guid.NewGuid().ToString();
-            TransportationRoleObs.Meta = new Meta();
-            string[] t_profile = { VRDR.ProfileURL.DecedentTransportationRole };
-            TransportationRoleObs.Meta.Profile = t_profile;
-            TransportationRoleObs.Status = ObservationStatus.Final;
-            TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
-            TransportationRoleObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-            AddReferenceToComposition(TransportationRoleObs.Id);
-            Bundle.AddResourceEntry(TransportationRoleObs, "urn:uuid:" + TransportationRoleObs.Id);
-        }
+        // /// <summary>Create Transportation Role. </summary>
+        // private void CreateTransportationRoleObs(){
+        //     TransportationRoleObs = new Observation();
+        //     TransportationRoleObs.Id = Guid.NewGuid().ToString();
+        //     TransportationRoleObs.Meta = new Meta();
+        //     string[] t_profile = { VRDR.ProfileURL.DecedentTransportationRole };
+        //     TransportationRoleObs.Meta.Profile = t_profile;
+        //     TransportationRoleObs.Status = ObservationStatus.Final;
+        //     TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
+        //     TransportationRoleObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+        //     AddReferenceToComposition(TransportationRoleObs.Id);
+        //     Bundle.AddResourceEntry(TransportationRoleObs, "urn:uuid:" + TransportationRoleObs.Id);
+        // }
 
         /// <summary>Injury Location.</summary>
         private Location InjuryLocationLoc;
@@ -398,7 +398,7 @@ namespace VRDR
             Decedent = new Patient();
             Decedent.Id = Guid.NewGuid().ToString();
             Decedent.Meta = new Meta();
-            string[] decedent_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent" };
+            string[] decedent_profile = { IGURL.Decedent  };
             Decedent.Meta.Profile = decedent_profile;
 
             // Start with an empty race and ethinicity observation
@@ -418,14 +418,14 @@ namespace VRDR
             Certifier = new Practitioner();
             Certifier.Id = Guid.NewGuid().ToString();
             Certifier.Meta = new Meta();
-            string[] certifier_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier" };
+            string[] certifier_profile = { IGURL.Certifier  };
             Certifier.Meta.Profile = certifier_profile;
 
             // Start with an empty pronouncer.
             Pronouncer = new Practitioner();
             Pronouncer.Id = Guid.NewGuid().ToString();
             Pronouncer.Meta = new Meta();
-            string[] pronouncer_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Pronouncement-Performer" };
+            string[] pronouncer_profile = { OtherURL.USCorePractitioner };
             Pronouncer.Meta.Profile = pronouncer_profile;
 
             // Start with an empty mortician.
@@ -944,191 +944,191 @@ namespace VRDR
             }
         }
 
-        /// <summary>Interested Party Identifier.</summary>
-        /// <value>the interested party identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
-        /// <para>"system" - the identifier system, e.g. US NPI</para>
-        /// <para>"value" - the identifier value, e.g. US NPI number</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
-        /// <para>identifier.Add("value", "1234567890");</para>
-        /// <para>ExampleDeathRecord.InterestedPartyIdentifier = identifier;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"\tPronouncer Identifier: {ExampleDeathRecord.InterestedPartyIdentifier['value']}");</para>
-        /// </example>
-        [Property("Interested Party Identifier", Property.Types.Dictionary, "Death Certification", "Interested Party Identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        [PropertyParam("system", "The identifier system.")]
-        [PropertyParam("value", "The identifier value.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "identifier")]
-        public Dictionary<string, string> InterestedPartyIdentifier
-        {
-            get
-            {
-                Identifier identifier = InterestedParty?.Identifier?.FirstOrDefault();
-                var result = new Dictionary<string, string>();
-                if (identifier != null)
-                {
-                    result["system"] = identifier.System;
-                    result["value"] = identifier.Value;
-                }
-                return result;
-            }
-            set
-            {
-                if (InterestedParty == null)
-                {
-                    InterestedParty = new Organization();
-                    InterestedParty.Id = Guid.NewGuid().ToString();
-                    InterestedParty.Meta = new Meta();
-                    string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
-                    InterestedParty.Meta.Profile = interestedparty_profile;
-                    InterestedParty.Active = true;
-                    AddReferenceToComposition(InterestedParty.Id);
-                    Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
-                }
-                if (InterestedParty.Identifier.Count > 0)
-                {
-                    InterestedParty.Identifier.Clear();
-                }
-                if(value.ContainsKey("system") && value.ContainsKey("value")) {
-                    Identifier identifier = new Identifier();
-                    identifier.System = value["system"];
-                    identifier.Value = value["value"];
-                    InterestedParty.Identifier.Add(identifier);
-                }
-            }
-        }
+        // /// <summary>Interested Party Identifier.</summary>
+        // /// <value>the interested party identification. A Dictionary representing a system (e.g. NPI) and a value, containing the following key/value pairs:
+        // /// <para>"system" - the identifier system, e.g. US NPI</para>
+        // /// <para>"value" - the identifier value, e.g. US NPI number</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; identifier = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>identifier.Add("system", "http://hl7.org/fhir/sid/us-npi");</para>
+        // /// <para>identifier.Add("value", "1234567890");</para>
+        // /// <para>ExampleDeathRecord.InterestedPartyIdentifier = identifier;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"\tPronouncer Identifier: {ExampleDeathRecord.InterestedPartyIdentifier['value']}");</para>
+        // /// </example>
+        // [Property("Interested Party Identifier", Property.Types.Dictionary, "Death Certification", "Interested Party Identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
+        // [PropertyParam("system", "The identifier system.")]
+        // [PropertyParam("value", "The identifier value.")]
+        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "identifier")]
+        // public Dictionary<string, string> InterestedPartyIdentifier
+        // {
+        //     get
+        //     {
+        //         Identifier identifier = InterestedParty?.Identifier?.FirstOrDefault();
+        //         var result = new Dictionary<string, string>();
+        //         if (identifier != null)
+        //         {
+        //             result["system"] = identifier.System;
+        //             result["value"] = identifier.Value;
+        //         }
+        //         return result;
+        //     }
+        //     set
+        //     {
+        //         if (InterestedParty == null)
+        //         {
+        //             InterestedParty = new Organization();
+        //             InterestedParty.Id = Guid.NewGuid().ToString();
+        //             InterestedParty.Meta = new Meta();
+        //             string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
+        //             InterestedParty.Meta.Profile = interestedparty_profile;
+        //             InterestedParty.Active = true;
+        //             AddReferenceToComposition(InterestedParty.Id);
+        //             Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
+        //         }
+        //         if (InterestedParty.Identifier.Count > 0)
+        //         {
+        //             InterestedParty.Identifier.Clear();
+        //         }
+        //         if(value.ContainsKey("system") && value.ContainsKey("value")) {
+        //             Identifier identifier = new Identifier();
+        //             identifier.System = value["system"];
+        //             identifier.Value = value["value"];
+        //             InterestedParty.Identifier.Add(identifier);
+        //         }
+        //     }
+        // }
 
-        /// <summary>Interested Party Name.</summary>
-        /// <value>an interested party name string.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.InterestedPartyName = "Fourty Two";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interested Party name: {ExampleDeathRecord.InterestedPartyName}");</para>
-        /// </example>
-        [Property("Interested Party Name", Property.Types.String, "Death Certification", "Interested Party Name.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "name")]
-        public string InterestedPartyName
-        {
-            get
-            {
-                if (InterestedParty != null)
-                {
-                    return InterestedParty.Name;
-                }
-                return null;
-            }
-            set
-            {
-                if (InterestedParty == null)
-                {
-                    InterestedParty = new Organization();
-                    InterestedParty.Id = Guid.NewGuid().ToString();
-                    InterestedParty.Meta = new Meta();
-                    string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
-                    InterestedParty.Meta.Profile = interestedparty_profile;
-                    InterestedParty.Active = true;
-                    InterestedParty.Name = value;
-                    AddReferenceToComposition(InterestedParty.Id);
-                    Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
-                }
-                else
-                {
-                    InterestedParty.Name = value;
-                }
-            }
-        }
+        // /// <summary>Interested Party Name.</summary>
+        // /// <value>an interested party name string.</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.InterestedPartyName = "Fourty Two";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Interested Party name: {ExampleDeathRecord.InterestedPartyName}");</para>
+        // /// </example>
+        // [Property("Interested Party Name", Property.Types.String, "Death Certification", "Interested Party Name.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "name")]
+        // public string InterestedPartyName
+        // {
+        //     get
+        //     {
+        //         if (InterestedParty != null)
+        //         {
+        //             return InterestedParty.Name;
+        //         }
+        //         return null;
+        //     }
+        //     set
+        //     {
+        //         if (InterestedParty == null)
+        //         {
+        //             InterestedParty = new Organization();
+        //             InterestedParty.Id = Guid.NewGuid().ToString();
+        //             InterestedParty.Meta = new Meta();
+        //             string[] interestedparty_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" };
+        //             InterestedParty.Meta.Profile = interestedparty_profile;
+        //             InterestedParty.Active = true;
+        //             InterestedParty.Name = value;
+        //             AddReferenceToComposition(InterestedParty.Id);
+        //             Bundle.AddResourceEntry(InterestedParty, "urn:uuid:" + InterestedParty.Id);
+        //         }
+        //         else
+        //         {
+        //             InterestedParty.Name = value;
+        //         }
+        //     }
+        // }
 
-        /// <summary>Interested Party's address.</summary>
-        /// <value>Interested Party's address. A Dictionary representing an address, containing the following key/value pairs:
-        /// <para>"addressLine1" - address, line one</para>
-        /// <para>"addressLine2" - address, line two</para>
-        /// <para>"addressCity" - address, city</para>
-        /// <para>"addressCounty" - address, county</para>
-        /// <para>"addressState" - address, state</para>
-        /// <para>"addressZip" - address, zip</para>
-        /// <para>"addressCountry" - address, country</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; address = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>address.Add("addressLine1", "9 Example Street");</para>
-        /// <para>address.Add("addressLine2", "Line 2");</para>
-        /// <para>address.Add("addressCity", "Bedford");</para>
-        /// <para>address.Add("addressCounty", "Middlesex");</para>
-        /// <para>address.Add("addressState", "MA");</para>
-        /// <para>address.Add("addressZip", "12345");</para>
-        /// <para>address.Add("addressCountry", "US");</para>
-        /// <para>ExampleDeathRecord.InterestedPartyAddress = address;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interested Party state: {ExampleDeathRecord.InterestedPartyAddress["addressState"]}");</para>
-        /// </example>
-        [Property("Interested Party Address", Property.Types.Dictionary, "Death Certification", "Interested Party's address.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        [PropertyParam("addressLine1", "address, line one")]
-        [PropertyParam("addressLine2", "address, line two")]
-        [PropertyParam("addressCity", "address, city")]
-        [PropertyParam("addressCounty", "address, county")]
-        [PropertyParam("addressState", "address, state")]
-        [PropertyParam("addressZip", "address, zip")]
-        [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "address")]
-        public Dictionary<string, string> InterestedPartyAddress
-        {
-            get
-            {
-                if (InterestedParty != null && InterestedParty.Address != null && InterestedParty.Address.Count() > 0)
-                {
-                    return AddressToDict(InterestedParty.Address.First());
-                }
-                return EmptyAddrDict();
-            }
-            set
-            {
-                InterestedParty.Address.Clear();
-                InterestedParty.Address.Add(DictToAddress(value));
-            }
-        }
+        // /// <summary>Interested Party's address.</summary>
+        // /// <value>Interested Party's address. A Dictionary representing an address, containing the following key/value pairs:
+        // /// <para>"addressLine1" - address, line one</para>
+        // /// <para>"addressLine2" - address, line two</para>
+        // /// <para>"addressCity" - address, city</para>
+        // /// <para>"addressCounty" - address, county</para>
+        // /// <para>"addressState" - address, state</para>
+        // /// <para>"addressZip" - address, zip</para>
+        // /// <para>"addressCountry" - address, country</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; address = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>address.Add("addressLine1", "9 Example Street");</para>
+        // /// <para>address.Add("addressLine2", "Line 2");</para>
+        // /// <para>address.Add("addressCity", "Bedford");</para>
+        // /// <para>address.Add("addressCounty", "Middlesex");</para>
+        // /// <para>address.Add("addressState", "MA");</para>
+        // /// <para>address.Add("addressZip", "12345");</para>
+        // /// <para>address.Add("addressCountry", "US");</para>
+        // /// <para>ExampleDeathRecord.InterestedPartyAddress = address;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Interested Party state: {ExampleDeathRecord.InterestedPartyAddress["addressState"]}");</para>
+        // /// </example>
+        // [Property("Interested Party Address", Property.Types.Dictionary, "Death Certification", "Interested Party's address.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
+        // [PropertyParam("addressLine1", "address, line one")]
+        // [PropertyParam("addressLine2", "address, line two")]
+        // [PropertyParam("addressCity", "address, city")]
+        // [PropertyParam("addressCounty", "address, county")]
+        // [PropertyParam("addressState", "address, state")]
+        // [PropertyParam("addressZip", "address, zip")]
+        // [PropertyParam("addressCountry", "address, country")]
+        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "address")]
+        // public Dictionary<string, string> InterestedPartyAddress
+        // {
+        //     get
+        //     {
+        //         if (InterestedParty != null && InterestedParty.Address != null && InterestedParty.Address.Count() > 0)
+        //         {
+        //             return AddressToDict(InterestedParty.Address.First());
+        //         }
+        //         return EmptyAddrDict();
+        //     }
+        //     set
+        //     {
+        //         InterestedParty.Address.Clear();
+        //         InterestedParty.Address.Add(DictToAddress(value));
+        //     }
+        // }
 
-        /// <summary>Interested Party Type.</summary>
-        /// <value>the interested party type. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; type = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>type.Add("code", "prov");</para>
-        /// <para>type.Add("system",CodeSystems.HL7_organization_type);</para>
-        /// <para>type.Add("display", "Healthcare Provider");</para>
-        /// <para>ExampleDeathRecord.InterestedPartyType = type;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Interested Party Type: {ExampleDeathRecord.InterestedPartyType['display']}");</para>
-        /// </example>
-        [Property("Interested Party Type", Property.Types.Dictionary, "Death Certification", "Interested Party Type.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "type")]
-        public Dictionary<string, string> InterestedPartyType
-        {
-            get
-            {
-                if (InterestedParty != null && InterestedParty.Type != null && InterestedParty.Type.Count() > 0)
-                {
-                    return CodeableConceptToDict(InterestedParty.Type.First());
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                InterestedParty.Type.Clear();
-                InterestedParty.Type.Add(DictToCodeableConcept(value));
-            }
-        }
+        // /// <summary>Interested Party Type.</summary>
+        // /// <value>the interested party type. A Dictionary representing a code, containing the following key/value pairs:
+        // /// <para>"code" - the code</para>
+        // /// <para>"system" - the code system this code belongs to</para>
+        // /// <para>"display" - a human readable meaning of the code</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; type = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>type.Add("code", "prov");</para>
+        // /// <para>type.Add("system",CodeSystems.HL7_organization_type);</para>
+        // /// <para>type.Add("display", "Healthcare Provider");</para>
+        // /// <para>ExampleDeathRecord.InterestedPartyType = type;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Interested Party Type: {ExampleDeathRecord.InterestedPartyType['display']}");</para>
+        // /// </example>
+        // [Property("Interested Party Type", Property.Types.Dictionary, "Death Certification", "Interested Party Type.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Interested-Party.html", false, 101)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // [FHIRPath("Bundle.entry.resource.where($this is Organization).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party')", "type")]
+        // public Dictionary<string, string> InterestedPartyType
+        // {
+        //     get
+        //     {
+        //         if (InterestedParty != null && InterestedParty.Type != null && InterestedParty.Type.Count() > 0)
+        //         {
+        //             return CodeableConceptToDict(InterestedParty.Type.First());
+        //         }
+        //         return EmptyCodeDict();
+        //     }
+        //     set
+        //     {
+        //         InterestedParty.Type.Clear();
+        //         InterestedParty.Type.Add(DictToCodeableConcept(value));
+        //     }
+        // }
 
         /// <summary>Manner of Death Type.</summary>
         /// <value>the manner of death type. A Dictionary representing a code, containing the following key/value pairs:
@@ -1168,7 +1168,7 @@ namespace VRDR
                     MannerOfDeath = new Observation();
                     MannerOfDeath.Id = Guid.NewGuid().ToString();
                     MannerOfDeath.Meta = new Meta();
-                    string[] mannerofdeath_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death" };
+                    string[] mannerofdeath_profile = { IGURL.MannerOfDeath };
                     MannerOfDeath.Meta.Profile = mannerofdeath_profile;
                     MannerOfDeath.Status = ObservationStatus.Final;
                     MannerOfDeath.Code = new CodeableConcept(CodeSystems.LOINC, "69449-7", "Manner of death", null);
@@ -6772,114 +6772,115 @@ namespace VRDR
             }
         }
 
-        /// <summary>Transportation Event?</summary>
-        /// <value>was the injury associated with a transportation event? A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "N");</para>
-        /// <para>code.Add("system", CodeSystems.PH_YesNo_HL7_2x);</para>
-        /// <para>code.Add("display", "No");</para>
-        /// <para>ExampleDeathRecord.TransportationEvent = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEvent['display']}");</para>
-        /// </example>
-        [Property("Transportation Event?", Property.Types.Dictionary, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 43)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        public Dictionary<string, string> TransportationEvent
-        {
-            get
-            {
-                if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
-                {
-                    // Find correct component
-                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69448-9" );
-                    if (transportComp != null && transportComp.Value != null && transportComp.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)transportComp.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (InjuryIncidentObs == null)
-                {
-                    CreateInjuryIncidentObs();
-                }
-                // Find correct component; if doesn't exist add another
-                var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69448-9" );
-                if (transportComp != null)
-                {
-                    ((Observation.ComponentComponent)transportComp).Value = DictToCodeableConcept(value);
-                }
-                else
-                {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69448-9", "Injury leading to death associated with transportation event", null);
-                    component.Value = DictToCodeableConcept(value);
-                    InjuryIncidentObs.Component.Add(component);
-                    }
-            }
-        }
+        // /// <summary>Transportation Event?</summary>
+        // /// <value>was the injury associated with a transportation event? A Dictionary representing a code, containing the following key/value pairs:
+        // /// <para>"code" - the code</para>
+        // /// <para>"system" - the code system this code belongs to</para>
+        // /// <para>"display" - a human readable meaning of the code</para>
+        // /// </value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        // /// <para>code.Add("code", "N");</para>
+        // /// <para>code.Add("system", CodeSystems.PH_YesNo_HL7_2x);</para>
+        // /// <para>code.Add("display", "No");</para>
+        // /// <para>ExampleDeathRecord.TransportationEvent = code;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEvent['display']}");</para>
+        // /// </example>
+        // [Property("Transportation Event?", Property.Types.Dictionary, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 43)]
+        // [PropertyParam("code", "The code used to describe this concept.")]
+        // [PropertyParam("system", "The relevant code system.")]
+        // [PropertyParam("display", "The human readable version of this code.")]
+        // [PropertyParam("text", "Additional descriptive text.")]
+        // [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
+        // public Dictionary<string, string> TransportationEvent
+        // {
+        //     get  //TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
+        //     {
+        //         if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
+        //         {
+        //             // Find correct component
+        //             var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+        //             ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69448-9" );
+        //             if (transportComp != null && transportComp.Value != null && transportComp.Value as CodeableConcept != null)
+        //             {
+        //                 return CodeableConceptToDict((CodeableConcept)transportComp.Value);
+        //             }
+        //         }
+        //         return EmptyCodeableDict();
+        //     }
+        //     set
+        //     {
+        //         if (InjuryIncidentObs == null)
+        //         {
+        //             CreateInjuryIncidentObs();
+        //         }
+        //         // Find correct component; if doesn't exist add another
+        //         var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69448-9" );
+        //         if (transportComp != null)
+        //         {
+        //             ((Observation.ComponentComponent)transportComp).Value = DictToCodeableConcept(value);
+        //         }
+        //         else
+        //         {
+        //             Observation.ComponentComponent component = new Observation.ComponentComponent();
+        //             component.Code = new CodeableConcept(CodeSystems.LOINC, "69448-9", "Injury leading to death associated with transportation event", null);
+        //             component.Value = DictToCodeableConcept(value);
+        //             InjuryIncidentObs.Component.Add(component);
+        //             }
+        //     }
+        // }
 
-        /// <summary>Transportation Event Boolean?</summary>
-        /// <value>was the injury associated with a transportation event? A null value indicates "unknown"</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.TransportationEventBoolean = true;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEventBoolean}");</para>
-        /// </example>
-        [Property("Transportation Event Boolean?", Property.Types.Bool, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 44)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        public bool? TransportationEventBoolean
-        {
-            get
-            {
-                var code = this.TransportationEvent;
-                switch (code["code"])
-                {
-                    case "Y": // Yes
-                        return true;
-                    case "N": // No
-                        return false;
-                    default: // Unknown
-                        return null;
-                }
-            }
-            set
-            {
-                var code = EmptyCodeDict();
-                switch(value)
-                {
-                    case true:
-                        code["code"] = "Y";
-                        code["display"] = "Yes";
-                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
-                        break;
-                    case false:
-                        code["code"] = "N";
-                        code["display"] = "No";
-                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
-                        break;
-                    default:
-                        code["code"] = "UNK";
-                        code["display"] = "unknown";
-                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
-                        break;
-                }
-                this.TransportationEvent = code;
-            }
-        }
+        // /// <summary>Transportation Event Boolean?</summary>
+        // /// <value>was the injury associated with a transportation event? A null value indicates "unknown"</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.TransportationEventBoolean = true;</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEventBoolean}");</para>
+        // /// </example>
+        // [Property("Transportation Event Boolean?", Property.Types.Bool, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 44)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
+        // public bool? TransportationEventBoolean
+        // {
+        //     get
+        //     {
+        //         var code = this.TransportationEvent;
+        //         switch (code["code"])
+        //         {
+        //             case "Y": // Yes
+        //                 return true;
+        //             case "N": // No
+        //                 return false;
+        //             default: // Unknown
+        //                 return null;
+        //         }
+        //     }
+        //     set
+        //     {
+        //         var code = EmptyCodeDict();
+        //         switch(value)
+        //         {
+        //             case true:
+        //                 code["code"] = "Y";
+        //                 code["display"] = "Yes";
+        //                 code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+        //                 break;
+        //             case false:
+        //                 code["code"] = "N";
+        //                 code["display"] = "No";
+        //                 code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+        //                 break;
+        //             default:
+        //                 code["code"] = "UNK";
+        //                 code["display"] = "unknown";
+        //                 code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
+        //                 break;
+        //         }
+        //         this.TransportationEvent = code;
+        //     }
+        // }
 
         /// <summary>Transportation Role in death.</summary>
         /// <value>transportation role in death. A Dictionary representing a code, containing the following key/value pairs:
@@ -6906,20 +6907,38 @@ namespace VRDR
         {
             get
             {
-                if (TransportationRoleObs?.Value != null && TransportationRoleObs.Value as CodeableConcept != null)
+                if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
                 {
-                    return CodeableConceptToDict((CodeableConcept)TransportationRoleObs.Value);
+                    // Find correct component
+                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                    ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3" );
+                    if (transportComp != null && transportComp.Value != null && transportComp.Value as CodeableConcept != null)
+                    {
+                        return CodeableConceptToDict((CodeableConcept)transportComp.Value);
+                    }
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
-                if (TransportationRoleObs == null)
+                if (InjuryIncidentObs == null)
                 {
-                    CreateTransportationRoleObs();
+                    CreateInjuryIncidentObs();
                 }
-                TransportationRoleObs.Value = DictToCodeableConcept(value);
-
+                // Find correct component; if doesn't exist add another
+                var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3" );
+                if (transportComp != null)
+                {
+                    ((Observation.ComponentComponent)transportComp).Value = DictToCodeableConcept(value);
+                }
+                else
+                {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent", null);
+                    component.Value = DictToCodeableConcept(value);
+                    InjuryIncidentObs.Component.Add(component);
+                    }
             }
         }
         /// <summary>Transportation Role in death helper.</summary>
@@ -6953,12 +6972,18 @@ namespace VRDR
             }
             set
             {
-                if ((value != null) && !VRDR.Mappings.TransportationIncidentRole.FHIRToIJE.ContainsKey(value)){ //other
-                    if (TransportationRoleObs == null)
+                if ((value != null) && !VRDR.Mappings.TransportationIncidentRole.FHIRToIJE.ContainsKey(value))
+                { //other
+                    //Find the component, or create it
+                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
+                    ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3" );
+                    if (transportComp == null)
                     {
-                        CreateTransportationRoleObs();
+                        transportComp = new Observation.ComponentComponent();
+                        transportComp.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent", null);
+                        InjuryIncidentObs.Component.Add(transportComp);
                     }
-                    TransportationRoleObs.Value = new CodeableConcept(CodeSystems.NullFlavor_HL7_V3, "OTH", "Other", value);
+                    transportComp.Value = new CodeableConcept(CodeSystems.NullFlavor_HL7_V3, "OTH", "Other", value);
                 }
                 else
                 { // normal path
@@ -7431,12 +7456,12 @@ namespace VRDR
                 MannerOfDeath = (Observation)mannerOfDeath.Resource;
             }
 
-            // Grab Transportation Role Observation
-            var transportationRole = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && ((Observation)entry.Resource).Code.Coding.First().Code == "69451-3" );
-            if (transportationRole != null)
-            {
-                TransportationRoleObs = (Observation)transportationRole.Resource;
-            }
+            // // Grab Transportation Role Observation
+            // var transportationRole = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && ((Observation)entry.Resource).Code.Coding.First().Code == "69451-3" );
+            // if (transportationRole != null)
+            // {
+            //     TransportationRoleObs = (Observation)transportationRole.Resource;
+            // }
 
             // Grab Disposition Method
             var dispositionMethod = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && ((Observation)entry.Resource).Code.Coding.First().Code == "80905-3" );

--- a/VRDR/DeathRecord.txt
+++ b/VRDR/DeathRecord.txt
@@ -37,9 +37,6 @@ namespace VRDR
         /// <summary>The Decedent.</summary>
         private Patient Decedent;
 
-        /// <summary>The Decedent's Demographics.</summary>
-        private Observation InputRaceandEthnicity;
-
         /// <summary>The Pronouncer of death.</summary>
         private Practitioner Pronouncer;
 
@@ -52,15 +49,8 @@ namespace VRDR
         /// <summary>The Certification.</summary>
         private Procedure DeathCertification;
 
-        /// <summary>Create Death Certification.</summary>
-        private void CreateDeathCertification(){
-            CreateEmptyDeathCertification();
-            AddReferenceToComposition(DeathCertification.Id);
-            Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
-        }
-
         /// <summary>Create Empty Death Certification.</summary>
-        private void CreateEmptyDeathCertification(){
+        private void CreateDeathCertification(){
             DeathCertification = new Procedure();
             DeathCertification.Id = Guid.NewGuid().ToString();
             DeathCertification.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
@@ -70,6 +60,8 @@ namespace VRDR
             DeathCertification.Status = EventStatus.Completed;
             DeathCertification.Category = new CodeableConcept(CodeSystems.SCT, "103693007", "Diagnostic procedure", null);
             DeathCertification.Code = new CodeableConcept(CodeSystems.SCT, "308646001", "Death certification", null);
+                    // AddReferenceToComposition(DeathCertification.Id);
+                    // Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
         }
 
         /// <summary>The Interested Party.</summary>
@@ -79,26 +71,26 @@ namespace VRDR
         private Observation MannerOfDeath;
 
         /// <summary>Condition Contributing to Death.</summary>
-        private Observation ConditionContributingToDeath;
+        private Condition ConditionContributingToDeath;
 
         /// <summary>Create a Cause Of Death Condition </summary>
-        private Observation CauseOfDeathCondition(int index){
-                    Observation CodCondition;
-                    CodCondition = new Observation();
+        private Condition CauseOfDeathCondition(int index){
+                    Condition CodCondition;
+                    CodCondition = new Condition();
                     CodCondition.Id = Guid.NewGuid().ToString();
                     CodCondition.Meta = new Meta();
-                    string[] condition_profile = { ProfileURL.CauseOfDeathPart1 };
+                    string[] condition_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" };
                     CodCondition.Meta.Profile = condition_profile;
-                    CodCondition.Code = new CodeableConcept(CodeSystems.LOINC, "69453-9", "Cause of death [US Standard Certificate of Death]", null);
+                    CodCondition.Category.Add (new CodeableConcept(CodeSystems.SCT, "16100001", "Death Diagnosis", null));
                     CodCondition.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    CodCondition.Performer.Add (new ResourceReference("urn:uuid:" + Certifier.Id));
+                    CodCondition.Asserter = new ResourceReference("urn:uuid:" + Certifier.Id);
                     AddReferenceToComposition(CodCondition.Id);
                     Bundle.AddResourceEntry(CodCondition, "urn:uuid:" + CodCondition.Id);
                     List.EntryComponent entry = new List.EntryComponent();
                     entry.Item = new ResourceReference("urn:uuid:" + CodCondition.Id);
-                    if (CauseOfDeathConditionPathway.Entry.Count() != 4)
+                    if (CauseOfDeathConditionPathway.Entry.Count() != 10)
                     {
-                        foreach (var i in Enumerable.Range(0, 4)) { CauseOfDeathConditionPathway.Entry.Add(null); }
+                        foreach (var i in Enumerable.Range(0, 10)) { CauseOfDeathConditionPathway.Entry.Add(null); }
                     }
                     CauseOfDeathConditionPathway.Entry[index] = entry;
                     return (CodCondition);
@@ -106,16 +98,34 @@ namespace VRDR
 
 
         /// <summary>Cause Of Death Condition Line A (#1).</summary>
-        private Observation CauseOfDeathConditionA;
+        private Condition CauseOfDeathConditionA;
 
         /// <summary>Cause Of Death Condition Line B (#2).</summary>
-        private Observation CauseOfDeathConditionB;
+        private Condition CauseOfDeathConditionB;
 
         /// <summary>Cause Of Death Condition Line C (#3).</summary>
-        private Observation CauseOfDeathConditionC;
+        private Condition CauseOfDeathConditionC;
 
         /// <summary>Cause Of Death Condition Line D (#4).</summary>
-        private Observation CauseOfDeathConditionD;
+        private Condition CauseOfDeathConditionD;
+
+        /// <summary>Cause Of Death Condition Line E (#5).</summary>
+        private Condition CauseOfDeathConditionE;
+
+        /// <summary>Cause Of Death Condition Line F (#6).</summary>
+        private Condition CauseOfDeathConditionF;
+
+        /// <summary>Cause Of Death Condition Line G (#7).</summary>
+        private Condition CauseOfDeathConditionG;
+
+        /// <summary>Cause Of Death Condition Line H (#8).</summary>
+        private Condition CauseOfDeathConditionH;
+
+        /// <summary>Cause Of Death Condition Line I (#9).</summary>
+        private Condition CauseOfDeathConditionI;
+
+        /// <summary>Cause Of Death Condition Line J (#10).</summary>
+        private Condition CauseOfDeathConditionJ;
 
         /// <summary>Cause Of Death Condition Pathway.</summary>
         private List CauseOfDeathConditionPathway;
@@ -197,22 +207,6 @@ namespace VRDR
         /// <summary>Usual Work.</summary>
         private Observation UsualWork;
 
-        /// <summary>Create Usual Work.</summary>
-        private void CreateUsualWork(){
-            UsualWork = new Observation();
-            UsualWork.Id = Guid.NewGuid().ToString();
-            UsualWork.Meta = new Meta();
-            string[] usualwork_profile = { ProfileURL.DecedentUsualWork };
-            UsualWork.Meta.Profile = usualwork_profile;
-            UsualWork.Status = ObservationStatus.Final;
-            UsualWork.Code = new CodeableConcept(CodeSystems.LOINC, "21843-8", "History of Usual occupation", null);
-            UsualWork.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory,"social-history",null, null));
-            UsualWork.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-            UsualWork.Effective = new Period();
-            AddReferenceToComposition(UsualWork.Id);
-            Bundle.AddResourceEntry(UsualWork, "urn:uuid:" + UsualWork.Id);
-        }
-
         /// <summary>Whether the decedent served in the military</summary>
         private Observation MilitaryServiceObs;
 
@@ -230,20 +224,6 @@ namespace VRDR
 
         /// <summary>Autopsy Performed.</summary>
         private Observation AutopsyPerformed;
-
-        /// <summary>Create Autopsy Performed </summary>
-        private void CreateAutopsyPerformed(){
-            AutopsyPerformed = new Observation();
-            AutopsyPerformed.Id = Guid.NewGuid().ToString();
-            AutopsyPerformed.Meta = new Meta();
-            string[] autopsyperformed_profile = { ProfileURL.AutopsyPerformedIndicator };
-            AutopsyPerformed.Meta.Profile = autopsyperformed_profile;
-            AutopsyPerformed.Status = ObservationStatus.Final;
-            AutopsyPerformed.Code = new CodeableConcept(CodeSystems.LOINC, "85699-7", "Autopsy was performed", null);
-            AutopsyPerformed.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-            AddReferenceToComposition(AutopsyPerformed.Id);
-            Bundle.AddResourceEntry(AutopsyPerformed, "urn:uuid:" + AutopsyPerformed.Id);
-        }
 
         /// <summary>Age At Death.</summary>
         private Observation AgeAtDeathObs;
@@ -278,38 +258,8 @@ namespace VRDR
             Bundle.AddResourceEntry(DeathDateObs, "urn:uuid:" + DeathDateObs.Id);
         }
 
-        private void CreateRaceEthnicityObs() {
-            InputRaceandEthnicity = new Observation();
-            InputRaceandEthnicity.Id = Guid.NewGuid().ToString();
-            InputRaceandEthnicity.Meta = new Meta();
-            string[] raceethnicity_profile = { ProfileURL.InputRaceAndEthnicity };
-            InputRaceandEthnicity.Meta.Profile = raceethnicity_profile;
-            InputRaceandEthnicity.Status = ObservationStatus.Final;
-            Dictionary<string, string> coding = new Dictionary<string, string>();
-            coding.Add("code", "inputraceandethnicity");
-            coding.Add("system", "Input Race and Ethnicity");
-            InputRaceandEthnicity.Code = DictToCodeableConcept(coding);
-            InputRaceandEthnicity.Subject = new ResourceReference("urn:uuid:" + InputRaceandEthnicity.Id);
-            AddReferenceToComposition(InputRaceandEthnicity.Id);
-            Bundle.AddResourceEntry(InputRaceandEthnicity, "urn:uuid:" + InputRaceandEthnicity.Id);
-        }
-
         /// <summary>Decedent Pregnancy Status.</summary>
         private Observation PregnancyObs;
-
-        /// <summary> Create Pregnancy Status. </summary>
-        private void CreatePregnancyObs(){
-            PregnancyObs = new Observation();
-            PregnancyObs.Id = Guid.NewGuid().ToString();
-            PregnancyObs.Meta = new Meta();
-            string[] p_profile = { IGURL.DecedentPregnancyStatus };
-            PregnancyObs.Meta.Profile = p_profile;
-            PregnancyObs.Status = ObservationStatus.Final;
-            PregnancyObs.Code = new CodeableConcept(CodeSystems.LOINC, "69442-2", "Timing of recent pregnancy in relation to death", null);
-            PregnancyObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-            AddReferenceToComposition(PregnancyObs.Id);
-            Bundle.AddResourceEntry(PregnancyObs, "urn:uuid:" + PregnancyObs.Id);
-        }
 
         /// <summary>Examiner Contacted.</summary>
         private Observation ExaminerContactedObs;
@@ -319,20 +269,6 @@ namespace VRDR
 
         /// <summary>Transportation Role.</summary>
         private Observation TransportationRoleObs;
-
-        /// <summary>Create Transportation Role. </summary>
-        private void CreateTransportationRoleObs(){
-            TransportationRoleObs = new Observation();
-            TransportationRoleObs.Id = Guid.NewGuid().ToString();
-            TransportationRoleObs.Meta = new Meta();
-            string[] t_profile = { VRDR.ProfileURL.DecedentTransportationRole };
-            TransportationRoleObs.Meta.Profile = t_profile;
-            TransportationRoleObs.Status = ObservationStatus.Final;
-            TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
-            TransportationRoleObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-            AddReferenceToComposition(TransportationRoleObs.Id);
-            Bundle.AddResourceEntry(TransportationRoleObs, "urn:uuid:" + TransportationRoleObs.Id);
-        }
 
         /// <summary>Injury Location.</summary>
         private Location InjuryLocationLoc;
@@ -355,7 +291,7 @@ namespace VRDR
                     InjuryIncidentObs = new Observation();
                     InjuryIncidentObs.Id = Guid.NewGuid().ToString();
                     InjuryIncidentObs.Meta = new Meta();
-                    string[] iio_profile = { ProfileURL.InjuryIncident };
+                    string[] iio_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-InjuryIncident" };
                     InjuryIncidentObs.Meta.Profile = iio_profile;
                     InjuryIncidentObs.Status = ObservationStatus.Final;
                     InjuryIncidentObs.Code = new CodeableConcept(CodeSystems.LOINC, "11374-6", "Injury incident description Narrative", null);
@@ -401,19 +337,6 @@ namespace VRDR
             string[] decedent_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent" };
             Decedent.Meta.Profile = decedent_profile;
 
-            // Start with an empty race and ethinicity observation
-            InputRaceandEthnicity = new Observation();
-            InputRaceandEthnicity.Id = Guid.NewGuid().ToString();
-            InputRaceandEthnicity.Meta = new Meta();
-            string[] raceethnicity_profile = { ProfileURL.InputRaceAndEthnicity };
-            InputRaceandEthnicity.Meta.Profile = raceethnicity_profile;
-            InputRaceandEthnicity.Status = ObservationStatus.Final;
-            Dictionary<string, string> coding = new Dictionary<string, string>();
-            coding.Add("code", "inputraceandethnicity");
-            coding.Add("system", "Input Race and Ethnicity");
-            InputRaceandEthnicity.Code = DictToCodeableConcept(coding);
-            InputRaceandEthnicity.Subject = new ResourceReference("urn:uuid:" + InputRaceandEthnicity.Id);
-
             // Start with an empty certifier.
             Certifier = new Practitioner();
             Certifier.Id = Guid.NewGuid().ToString();
@@ -432,7 +355,7 @@ namespace VRDR
             InitializeMorticianIfNull();
 
             // Start with an empty certification.
-            CreateEmptyDeathCertification();
+            CreateDeathCertification();
 
             // Start with an empty interested party.
             InterestedParty = new Organization();
@@ -495,7 +418,7 @@ namespace VRDR
             CauseOfDeathConditionPathway = new List();
             CauseOfDeathConditionPathway.Id = Guid.NewGuid().ToString();
             CauseOfDeathConditionPathway.Meta = new Meta();
-            string[] causeofdeathconditionpathway_profile = { ProfileURL.CauseOfDeathPathway };
+            string[] causeofdeathconditionpathway_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway" };
             CauseOfDeathConditionPathway.Meta.Profile = causeofdeathconditionpathway_profile;
             CauseOfDeathConditionPathway.Status = List.ListStatus.Current;
             CauseOfDeathConditionPathway.Mode = Hl7.Fhir.Model.ListMode.Snapshot;
@@ -504,7 +427,6 @@ namespace VRDR
 
             // Add references back to the Decedent, Certifier, Certification, etc.
             AddReferenceToComposition(Decedent.Id);
-            AddReferenceToComposition(InputRaceandEthnicity.Id);
             AddReferenceToComposition(Certifier.Id);
             AddReferenceToComposition(Pronouncer.Id);
             AddReferenceToComposition(Mortician.Id);
@@ -515,7 +437,6 @@ namespace VRDR
             AddReferenceToComposition(CauseOfDeathConditionPathway.Id);
             AddReferenceToComposition(DispositionLocation.Id);
             Bundle.AddResourceEntry(Decedent, "urn:uuid:" + Decedent.Id);
-            Bundle.AddResourceEntry(InputRaceandEthnicity, "urn:uuid:" + InputRaceandEthnicity.Id);
             Bundle.AddResourceEntry(Certifier, "urn:uuid:" + Certifier.Id);
             Bundle.AddResourceEntry(Pronouncer, "urn:uuid:" + Pronouncer.Id);
             Bundle.AddResourceEntry(Mortician, "urn:uuid:" + Mortician.Id);
@@ -820,6 +741,17 @@ namespace VRDR
                 if (DeathCertification == null)
                 {
                     CreateDeathCertification();
+                    // DeathCertification = new Procedure();
+                    // DeathCertification.Id = Guid.NewGuid().ToString();
+                    // DeathCertification.Meta = new Meta();
+                    // string[] deathcertification_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification" };
+                    // DeathCertification.Meta.Profile = deathcertification_profile;
+                    // DeathCertification.Status = EventStatus.Completed;
+                    // DeathCertification.Category = new CodeableConcept(CodeSystems.SCT, "103693007", "Diagnostic procedure", null);
+                    // DeathCertification.Code = new CodeableConcept(CodeSystems.SCT, "308646001", "Death certification", null);
+                    // AddReferenceToComposition(DeathCertification.Id);
+                    // Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
+
                 }
 
                 Composition.Attester.First().Time = value;
@@ -889,7 +821,7 @@ namespace VRDR
             {
                 if (DeathCertification == null)
                 {
-                    CreateDeathCertification();
+                   CreateDeathCertification();
                 }
                 Hl7.Fhir.Model.Procedure.PerformerComponent performer = new Hl7.Fhir.Model.Procedure.PerformerComponent();
                 performer.Function = DictToCodeableConcept(value);
@@ -918,29 +850,13 @@ namespace VRDR
             {
                 if (CertificationRole.ContainsKey("code"))
                 {
-                    string code = CertificationRole["code"] ;
-                    if (code == "OTH"){
-                        if (CertificationRole.ContainsKey("text")){
-                            return (CertificationRole["text"]);
-                        }
-                        return("Other");
-                    }
+                    return CertificationRole["code"];
                 }
                 return null;
             }
             set
             {
-                if ((value != null) && !VRDR.Mappings.CertifierTypes.FHIRToIJE.ContainsKey(value)){ //other
-                    if (DeathCertification == null)
-                    {
-                        CreateDeathCertification();
-                    }
-                    CertificationRole = CodeableConceptToDict(new CodeableConcept(CodeSystems.NullFlavor_HL7_V3, "OTH", "Other", value));
-                }
-                else
-                { // normal path
-                    SetCodeValue("CertificationRole", value, VRDR.ValueSets.CertificationRole.Codes);
-                }
+                SetCodeValue("CertificationRole", value, VRDR.ValueSets.CertificationRole.Codes);
             }
         }
 
@@ -1538,9 +1454,9 @@ namespace VRDR
         {
             get
             {
-                if (ConditionContributingToDeath != null && ConditionContributingToDeath.Value != null)
+                if (ConditionContributingToDeath != null && ConditionContributingToDeath.Code != null && ConditionContributingToDeath.Code.Text != null)
                 {
-                    return (CodeableConceptToDict((CodeableConcept)ConditionContributingToDeath.Value))["text"];
+                    return ConditionContributingToDeath.Code.Text;
                 }
                 return null;
             }
@@ -1548,19 +1464,21 @@ namespace VRDR
             {
                 if (ConditionContributingToDeath != null)
                 {
-                    ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
+                    ConditionContributingToDeath.Code.Text = value;
                 }
                 else
                 {
-                    ConditionContributingToDeath = new Observation();
+                    ConditionContributingToDeath = new Condition();
                     ConditionContributingToDeath.Id = Guid.NewGuid().ToString();
                     ConditionContributingToDeath.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    ConditionContributingToDeath.Performer.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
+                    ConditionContributingToDeath.Asserter = new ResourceReference("urn:uuid:" + Certifier.Id);
                     ConditionContributingToDeath.Meta = new Meta();
-                    string[] condition_profile = { ProfileURL.CauseOfDeathPart2 };
+                    string[] condition_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death" };
                     ConditionContributingToDeath.Meta.Profile = condition_profile;
-                    ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
-                    ConditionContributingToDeath.Value= new CodeableConcept(null, null, null, value);
+                    ConditionContributingToDeath.Category.Add (new CodeableConcept(CodeSystems.SCT, "16100001", "Death diagnosis", null));
+                    ConditionContributingToDeath.Code = new CodeableConcept();
+                    ConditionContributingToDeath.Category.Add (new CodeableConcept(CodeSystems.SCT, "16100001", "Death Diagnosis", null));
+                    ConditionContributingToDeath.Code.Text = value;
                     AddReferenceToComposition(ConditionContributingToDeath.Id);
                     Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
                 }
@@ -1593,30 +1511,53 @@ namespace VRDR
         /// <para>    Console.WriteLine($"Cause: {cause.Item1}, Onset: {cause.Item2}, Code: {cause.Item3}");</para>
         /// <para>}</para>
         /// </example>
-        [Property("Causes Of Death", Property.Types.TupleCOD, "Death Certification", "Conditions that resulted in the cause of death.", true, IGURL.CauseOfDeathPathway, true, 50)]
+        [Property("Causes Of Death", Property.Types.TupleCOD, "Death Certification", "Conditions that resulted in the cause of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-of-Death-Pathway.html", true, 50)]
         [FHIRPath("Bundle.entry.resource.where($this is Condition).where(onset.empty().not())", "")]
-        public Tuple<string, string /*, Dictionary<string, string>*/>[] CausesOfDeath
+        public Tuple<string, string, Dictionary<string, string>>[] CausesOfDeath
         {
             get
             {
-                List<Tuple<string, string/*, Dictionary<string, string>*/>> results = new List<Tuple<string, string /*, Dictionary<string, string>*/>>();
-                if (!String.IsNullOrEmpty(COD1A) || !String.IsNullOrEmpty(INTERVAL1A) /*|| (CODE1A != null && !String.IsNullOrEmpty(CODE1A["code"]))*/ )
+                List<Tuple<string, string, Dictionary<string, string>>> results = new List<Tuple<string, string, Dictionary<string, string>>>();
+                if (!String.IsNullOrEmpty(COD1A) || !String.IsNullOrEmpty(INTERVAL1A) || (CODE1A != null && !String.IsNullOrEmpty(CODE1A["code"])))
                 {
-                    results.Add(Tuple.Create(COD1A, INTERVAL1A /*, CODE1A)*/));
+                    results.Add(Tuple.Create(COD1A, INTERVAL1A, CODE1A));
                 }
-                if (!String.IsNullOrEmpty(COD1B) || !String.IsNullOrEmpty(INTERVAL1B) /*|| (CODE1B != null && !String.IsNullOrEmpty(CODE1B["code"])) */)
+                if (!String.IsNullOrEmpty(COD1B) || !String.IsNullOrEmpty(INTERVAL1B) || (CODE1B != null && !String.IsNullOrEmpty(CODE1B["code"])))
                 {
-                    results.Add(Tuple.Create(COD1B, INTERVAL1B/* , CODE1B*/));
+                    results.Add(Tuple.Create(COD1B, INTERVAL1B, CODE1B));
                 }
-                if (!String.IsNullOrEmpty(COD1C) || !String.IsNullOrEmpty(INTERVAL1C) /*|| (CODE1C != null && !String.IsNullOrEmpty(CODE1C["code"])) */)
+                if (!String.IsNullOrEmpty(COD1C) || !String.IsNullOrEmpty(INTERVAL1C) || (CODE1C != null && !String.IsNullOrEmpty(CODE1C["code"])))
                 {
-                    results.Add(Tuple.Create(COD1C, INTERVAL1C /*, CODE1C */));
+                    results.Add(Tuple.Create(COD1C, INTERVAL1C, CODE1C));
                 }
-                if (!String.IsNullOrEmpty(COD1D) || !String.IsNullOrEmpty(INTERVAL1D) /*||  (CODE1D != null && !String.IsNullOrEmpty(CODE1D["code"])) */)
+                if (!String.IsNullOrEmpty(COD1D) || !String.IsNullOrEmpty(INTERVAL1D) || (CODE1D != null && !String.IsNullOrEmpty(CODE1D["code"])))
                 {
-                    results.Add(Tuple.Create(COD1D, INTERVAL1D  /*, CODE1D */));
+                    results.Add(Tuple.Create(COD1D, INTERVAL1D, CODE1D));
                 }
-
+                if (!String.IsNullOrEmpty(COD1E) || !String.IsNullOrEmpty(INTERVAL1E) || (CODE1E != null && !String.IsNullOrEmpty(CODE1E["code"])))
+                {
+                    results.Add(Tuple.Create(COD1E, INTERVAL1E, CODE1E));
+                }
+                if (!String.IsNullOrEmpty(COD1F) || !String.IsNullOrEmpty(INTERVAL1F) || (CODE1F != null && !String.IsNullOrEmpty(CODE1F["code"])))
+                {
+                    results.Add(Tuple.Create(COD1F, INTERVAL1F, CODE1F));
+                }
+                if (!String.IsNullOrEmpty(COD1G) || !String.IsNullOrEmpty(INTERVAL1G) || (CODE1G != null && !String.IsNullOrEmpty(CODE1G["code"])))
+                {
+                    results.Add(Tuple.Create(COD1G, INTERVAL1G, CODE1G));
+                }
+                if (!String.IsNullOrEmpty(COD1H) || !String.IsNullOrEmpty(INTERVAL1H) || (CODE1H != null && !String.IsNullOrEmpty(CODE1H["code"])))
+                {
+                    results.Add(Tuple.Create(COD1H, INTERVAL1H, CODE1H));
+                }
+                if (!String.IsNullOrEmpty(COD1I) || !String.IsNullOrEmpty(INTERVAL1I) || (CODE1I != null && !String.IsNullOrEmpty(CODE1I["code"])))
+                {
+                    results.Add(Tuple.Create(COD1I, INTERVAL1I, CODE1I));
+                }
+                if (!String.IsNullOrEmpty(COD1J) || !String.IsNullOrEmpty(INTERVAL1J) || (CODE1J != null && !String.IsNullOrEmpty(CODE1J["code"])))
+                {
+                    results.Add(Tuple.Create(COD1J, INTERVAL1J, CODE1J));
+                }
                 return results.ToArray();
             }
             set
@@ -1627,27 +1568,62 @@ namespace VRDR
                     {
                         COD1A = value[0].Item1;
                         INTERVAL1A = value[0].Item2;
-                        // CODE1A = value[0].Item3;
+                        CODE1A = value[0].Item3;
                     }
                     if (value.Length > 1)
                     {
                         COD1B = value[1].Item1;
                         INTERVAL1B = value[1].Item2;
-                        // CODE1B = value[1].Item3;
+                        CODE1B = value[1].Item3;
                     }
                     if (value.Length > 2)
                     {
                         COD1C = value[2].Item1;
                         INTERVAL1C = value[2].Item2;
-                        // CODE1C = value[2].Item3;
+                        CODE1C = value[2].Item3;
                     }
                     if (value.Length > 3)
                     {
                         COD1D = value[3].Item1;
                         INTERVAL1D = value[3].Item2;
-                        // CODE1D = value[3].Item3;
+                        CODE1D = value[3].Item3;
                     }
-
+                    if (value.Length > 4)
+                    {
+                        COD1E = value[4].Item1;
+                        INTERVAL1E = value[4].Item2;
+                        CODE1E = value[4].Item3;
+                    }
+                    if (value.Length > 5)
+                    {
+                        COD1F = value[5].Item1;
+                        INTERVAL1F = value[5].Item2;
+                        CODE1F = value[5].Item3;
+                    }
+                    if (value.Length > 6)
+                    {
+                        COD1G = value[6].Item1;
+                        INTERVAL1G = value[6].Item2;
+                        CODE1G = value[6].Item3;
+                    }
+                    if (value.Length > 7)
+                    {
+                        COD1H = value[7].Item1;
+                        INTERVAL1H = value[7].Item2;
+                        CODE1H = value[7].Item3;
+                    }
+                    if (value.Length > 8)
+                    {
+                        COD1I = value[8].Item1;
+                        INTERVAL1I = value[8].Item2;
+                        CODE1I = value[8].Item3;
+                    }
+                    if (value.Length > 9)
+                    {
+                        COD1J = value[9].Item1;
+                        INTERVAL1J = value[9].Item2;
+                        CODE1J = value[9].Item3;
+                    }
                 }
             }
         }
@@ -1660,14 +1636,14 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1A}");</para>
         /// </example>
-        [Property("COD1A", Property.Types.String, "Death Certification", "Cause of Death Part I, Line a.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("COD1A", Property.Types.String, "Death Certification", "Cause of Death Part I, Line a.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string COD1A
         {
             get
             {
-                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Value != null)
+                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Code != null)
                 {
-                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionA.Value))["text"];
+                    return CauseOfDeathConditionA.Code.Text;
                 }
                 return null;
             }
@@ -1677,7 +1653,15 @@ namespace VRDR
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
-                CauseOfDeathConditionA.Value= new CodeableConcept(null, null, null, value);
+                if (CauseOfDeathConditionA.Code != null)
+                {
+                    CauseOfDeathConditionA.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionA.Code = new CodeableConcept();
+                    CauseOfDeathConditionA.Code.Text = value;
+                }
             }
         }
 
@@ -1689,21 +1673,16 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1A}");</para>
         /// </example>
-        [Property("INTERVAL1A", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line a.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("INTERVAL1A", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line a.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string INTERVAL1A
         {
             get
             {
-                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Component != null)
+                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Onset != null)
                 {
-                    var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
-                    {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
-                    }
+                    return CauseOfDeathConditionA.Onset.ToString();
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1711,73 +1690,58 @@ namespace VRDR
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
-                // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
-
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
-                    }
-                    else
-                    {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
-                    CauseOfDeathConditionA.Component.Add(component);
-                }
+                CauseOfDeathConditionA.Onset = new FhirString(value);
             }
-
         }
 
-        // /// <summary>Cause of Death Part I Code, Line a.</summary>
-        // /// <value>the immediate cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        // /// <para>"code" - the code</para>
-        // /// <para>"system" - the code system this code belongs to</para>
-        // /// <para>"display" - a human readable meaning of the code</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>code.Add("code", "I21.0");</para>
-        // /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
-        // /// <para>code.Add("display", "Acute transmural myocardial infarction of anterior wall");</para>
-        // /// <para>ExampleDeathRecord.CODE1A = code;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1A['display']}");</para>
-        // /// </example>
-        // [Property("CODE1A", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line a.", false, IGURL.CauseOfDeathPart1, false, 100)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // public Dictionary<string, string> CODE1A
-        // {
-        //     get
-        //     {
-        //         if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Code != null)
-        //         {
-        //             return CodeableConceptToDict(CauseOfDeathConditionA.Code);
-        //         }
-        //         return EmptyCodeDict();
-        //     }
-        //     set
-        //     {
-        //         if(CauseOfDeathConditionA == null)
-        //         {
-        //             CauseOfDeathConditionA = CauseOfDeathCondition(0);
-        //         }
-        //         if (CauseOfDeathConditionA.Code != null)
-        //         {
-        //             CodeableConcept code = DictToCodeableConcept(value);
-        //             code.Text = CauseOfDeathConditionA.Code.Text;
-        //             CauseOfDeathConditionA.Code = code;
-        //         }
-        //         else
-        //         {
-        //         CauseOfDeathConditionA.Code = DictToCodeableConcept(value);
-        //         }
-        //     }
-        // }
+        /// <summary>Cause of Death Part I Code, Line a.</summary>
+        /// <value>the immediate cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "I21.0");</para>
+        /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
+        /// <para>code.Add("display", "Acute transmural myocardial infarction of anterior wall");</para>
+        /// <para>ExampleDeathRecord.CODE1A = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1A['display']}");</para>
+        /// </example>
+        [Property("CODE1A", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line a.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        public Dictionary<string, string> CODE1A
+        {
+            get
+            {
+                if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionA.Code);
+                }
+                return EmptyCodeDict();
+            }
+            set
+            {
+                if(CauseOfDeathConditionA == null)
+                {
+                    CauseOfDeathConditionA = CauseOfDeathCondition(0);
+                }
+                if (CauseOfDeathConditionA.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionA.Code.Text;
+                    CauseOfDeathConditionA.Code = code;
+                }
+                else
+                {
+                CauseOfDeathConditionA.Code = DictToCodeableConcept(value);
+                }
+            }
+        }
 
         /// <summary>Cause of Death Part I, Line b.</summary>
         /// <value>the first underlying cause of death literal.</value>
@@ -1787,14 +1751,14 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1B}");</para>
         /// </example>
-        [Property("COD1B", Property.Types.String, "Death Certification", "Cause of Death Part I, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("COD1B", Property.Types.String, "Death Certification", "Cause of Death Part I, Line b.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string COD1B
         {
             get
             {
-                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Value != null)
+                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Code != null)
                 {
-                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionB.Value))["text"];
+                    return CauseOfDeathConditionB.Code.Text;
                 }
                 return null;
             }
@@ -1804,7 +1768,16 @@ namespace VRDR
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
-                CauseOfDeathConditionB.Value = new CodeableConcept(null, null, null, value);
+
+                if (CauseOfDeathConditionB.Code != null)
+                {
+                    CauseOfDeathConditionB.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionB.Code = new CodeableConcept();
+                    CauseOfDeathConditionB.Code.Text = value;
+                }
             }
         }
 
@@ -1816,21 +1789,16 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1B}");</para>
         /// </example>
-     [Property("INTERVAL1B", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
-       public string INTERVAL1B
+        [Property("INTERVAL1B", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line b.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1B
         {
             get
             {
-                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Component != null)
+                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Onset != null)
                 {
-                    var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
-                    {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
-                    }
+                    return CauseOfDeathConditionB.Onset.ToString();
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1838,72 +1806,58 @@ namespace VRDR
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
-                // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
-
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
-                    }
-                    else
-                    {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
-                    CauseOfDeathConditionB.Component.Add(component);
-                }
+                CauseOfDeathConditionB.Onset = new FhirString(value);
             }
-
         }
-        // /// <summary>Cause of Death Part I Code, Line b.</summary>
-        // /// <value>the first underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        // /// <para>"code" - the code</para>
-        // /// <para>"system" - the code system this code belongs to</para>
-        // /// <para>"display" - a human readable meaning of the code</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>code.Add("code", "I21.9");</para>
-        // /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
-        // /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
-        // /// <para>ExampleDeathRecord.CODE1B = code;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1B['display']}");</para>
-        // /// </example>
-        // [Property("CODE1B", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // public Dictionary<string, string> CODE1B
-        // {
-        //     get
-        //     {
-        //         if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Code != null)
-        //         {
-        //             return CodeableConceptToDict(CauseOfDeathConditionB.Code);
-        //         }
-        //         return EmptyCodeDict();
-        //     }
-        //     set
-        //     {
-        //         if(CauseOfDeathConditionB == null)
-        //         {
-        //             CauseOfDeathConditionB = CauseOfDeathCondition(1);
-        //         }
-        //         if (CauseOfDeathConditionB.Code != null)
-        //         {
-        //             CodeableConcept code = DictToCodeableConcept(value);
-        //             code.Text = CauseOfDeathConditionB.Code.Text;
-        //             CauseOfDeathConditionB.Code = code;
-        //         }
-        //         else
-        //         {
-        //             CauseOfDeathConditionB.Code = DictToCodeableConcept(value);
-        //         }
-        //                     }
-        // }
+
+        /// <summary>Cause of Death Part I Code, Line b.</summary>
+        /// <value>the first underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "I21.9");</para>
+        /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
+        /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
+        /// <para>ExampleDeathRecord.CODE1B = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1B['display']}");</para>
+        /// </example>
+        [Property("CODE1B", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line b.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        public Dictionary<string, string> CODE1B
+        {
+            get
+            {
+                if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionB.Code);
+                }
+                return EmptyCodeDict();
+            }
+            set
+            {
+                if(CauseOfDeathConditionB == null)
+                {
+                    CauseOfDeathConditionB = CauseOfDeathCondition(1);
+                }
+                if (CauseOfDeathConditionB.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionB.Code.Text;
+                    CauseOfDeathConditionB.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionB.Code = DictToCodeableConcept(value);
+                }
+                            }
+        }
 
         /// <summary>Cause of Death Part I, Line c.</summary>
         /// <value>the second underlying cause of death literal.</value>
@@ -1913,14 +1867,14 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1C}");</para>
         /// </example>
-        [Property("COD1C", Property.Types.String, "Death Certification", "Cause of Death Part I, Line c.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("COD1C", Property.Types.String, "Death Certification", "Cause of Death Part I, Line c.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string COD1C
         {
             get
             {
-                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Value != null)
+                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Code != null)
                 {
-                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionC.Value))["text"];
+                    return CauseOfDeathConditionC.Code.Text;
                 }
                 return null;
             }
@@ -1930,9 +1884,15 @@ namespace VRDR
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
-
-                CauseOfDeathConditionC.Value = new CodeableConcept(null, null, null, value);
-
+                if (CauseOfDeathConditionC.Code != null)
+                {
+                    CauseOfDeathConditionC.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionC.Code = new CodeableConcept();
+                    CauseOfDeathConditionC.Code.Text = value;
+                }
             }
         }
 
@@ -1944,21 +1904,16 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1C}");</para>
         /// </example>
-        [Property("INTERVAL1C", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line c.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("INTERVAL1C", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line c.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string INTERVAL1C
         {
             get
             {
-                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Component != null)
+                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Onset != null)
                 {
-                    var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
-                    {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
-                    }
+                    return CauseOfDeathConditionC.Onset.ToString();
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1966,72 +1921,59 @@ namespace VRDR
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
-                // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
 
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
-                    }
-                    else
-                    {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
-                    CauseOfDeathConditionC.Component.Add(component);
+                CauseOfDeathConditionC.Onset = new FhirString(value);
+              }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line c.</summary>
+        /// <value>the second underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "I21.9");</para>
+        /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
+        /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
+        /// <para>ExampleDeathRecord.CODE1C = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1C['display']}");</para>
+        /// </example>
+        [Property("CODE1C", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line c.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        public Dictionary<string, string> CODE1C
+        {
+            get
+            {
+                if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionC.Code);
+                }
+                return EmptyCodeDict();
+            }
+            set
+            {
+                if(CauseOfDeathConditionC == null)
+                {
+                    CauseOfDeathConditionC = CauseOfDeathCondition(2);
+                }
+               if (CauseOfDeathConditionC.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionC.Code.Text;
+                    CauseOfDeathConditionC.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionC.Code = DictToCodeableConcept(value);
                 }
             }
         }
-
-        // /// <summary>Cause of Death Part I Code, Line c.</summary>
-        // /// <value>the second underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
-        // /// <para>"code" - the code</para>
-        // /// <para>"system" - the code system this code belongs to</para>
-        // /// <para>"display" - a human readable meaning of the code</para>
-        // /// </value>
-        // /// <example>
-        // /// <para>// Setter:</para>
-        // /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        // /// <para>code.Add("code", "I21.9");</para>
-        // /// <para>code.Add("system", "http://hl7.org/fhir/sid/icd-10");</para>
-        // /// <para>code.Add("display", "Acute myocardial infarction, unspecified");</para>
-        // /// <para>ExampleDeathRecord.CODE1C = code;</para>
-        // /// <para>// Getter:</para>
-        // /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1C['display']}");</para>
-        // /// </example>
-        // [Property("CODE1C", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line c.", false, IGURL.CauseOfDeathPart1, false, 100)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // public Dictionary<string, string> CODE1C
-        // {
-        //     get
-        //     {
-        //         if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Code != null)
-        //         {
-        //             return CodeableConceptToDict(CauseOfDeathConditionC.Code);
-        //         }
-        //         return EmptyCodeDict();
-        //     }
-        //     set
-        //     {
-        //         if(CauseOfDeathConditionC == null)
-        //         {
-        //             CauseOfDeathConditionC = CauseOfDeathCondition(2);
-        //         }
-        //        if (CauseOfDeathConditionC.Code != null)
-        //         {
-        //             CodeableConcept code = DictToCodeableConcept(value);
-        //             code.Text = CauseOfDeathConditionC.Code.Text;
-        //             CauseOfDeathConditionC.Code = code;
-        //         }
-        //         else
-        //         {
-        //             CauseOfDeathConditionC.Code = DictToCodeableConcept(value);
-        //         }
-        //     }
-        // }
 
         /// <summary>Cause of Death Part I, Line d.</summary>
         /// <value>the third underlying cause of death literal.</value>
@@ -2041,14 +1983,14 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1D}");</para>
         /// </example>
-        [Property("COD1D", Property.Types.String, "Death Certification", "Cause of Death Part I, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("COD1D", Property.Types.String, "Death Certification", "Cause of Death Part I, Line d.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string COD1D
         {
             get
             {
-                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Value != null)
+                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Code != null)
                 {
-                    return (CodeableConceptToDict((CodeableConcept)CauseOfDeathConditionD.Value))["text"];
+                    return CauseOfDeathConditionD.Code.Text;
                 }
                 return null;
             }
@@ -2058,7 +2000,15 @@ namespace VRDR
                 {
                     CauseOfDeathConditionD = CauseOfDeathCondition(3);
                 }
-                CauseOfDeathConditionD.Value = new CodeableConcept(null, null, null, value);
+                if (CauseOfDeathConditionD.Code != null)
+                {
+                    CauseOfDeathConditionD.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionD.Code = new CodeableConcept();
+                    CauseOfDeathConditionD.Code.Text = value;
+                }
             }
         }
 
@@ -2070,43 +2020,24 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1D}");</para>
         /// </example>
-        [Property("INTERVAL1D", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        [Property("INTERVAL1D", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line d.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
         public string INTERVAL1D
         {
             get
             {
-                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Component != null)
+                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Onset != null)
                 {
-                    var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
-                    {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
-                    }
+                    return CauseOfDeathConditionD.Onset.ToString();
                 }
-                return "";
+                return null;
             }
             set
             {
-                if(CauseOfDeathConditionD == null)
-                {
+                 if (CauseOfDeathConditionD == null)
+                 {
                     CauseOfDeathConditionD = CauseOfDeathCondition(3);
-                }
-                // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
-
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
-                    }
-                    else
-                    {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
-                    CauseOfDeathConditionD.Component.Add(component);
-                }
+                 }
+                CauseOfDeathConditionD.Onset = new FhirString(value);
             }
         }
 
@@ -2126,39 +2057,735 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1D['display']}");</para>
         /// </example>
-        // [Property("CODE1D", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line d.", false, IGURL.CauseOfDeathPart1, false, 100)]
-        // [PropertyParam("code", "The code used to describe this concept.")]
-        // [PropertyParam("system", "The relevant code system.")]
-        // [PropertyParam("display", "The human readable version of this code.")]
-        // public Dictionary<string, string> CODE1D
-        // {
-        //     get
-        //     {
-        //         if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Code != null)
-        //         {
-        //             return CodeableConceptToDict(CauseOfDeathConditionD.Code);
-        //         }
-        //         return EmptyCodeDict();
-        //     }
-        //     set
-        //     {
-        //         if (CauseOfDeathConditionD == null)
-        //         {
-        //             CauseOfDeathConditionD = CauseOfDeathCondition(3);
-        //         }
-        //        if (CauseOfDeathConditionD.Code != null)
-        //         {
-        //             CodeableConcept code = DictToCodeableConcept(value);
-        //             code.Text = CauseOfDeathConditionD.Code.Text;
-        //             CauseOfDeathConditionD.Code = code;
-        //         }
-        //         else
-        //         {
-        //             CauseOfDeathConditionD.Code = DictToCodeableConcept(value);
-        //         }
-        //     }
-        // }
+        [Property("CODE1D", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line d.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        public Dictionary<string, string> CODE1D
+        {
+            get
+            {
+                if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionD.Code);
+                }
+                return EmptyCodeDict();
+            }
+            set
+            {
+                if (CauseOfDeathConditionD == null)
+                {
+                    CauseOfDeathConditionD = CauseOfDeathCondition(3);
+                }
+               if (CauseOfDeathConditionD.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionD.Code.Text;
+                    CauseOfDeathConditionD.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionD.Code = DictToCodeableConcept(value);
+                }
+            }
+        }
 
+        /// <summary>Cause of Death Part I, Line e.</summary>
+        /// <value>the fourth underlying cause of death literal.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.COD1E = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1E}");</para>
+        /// </example>
+        [Property("COD1E", Property.Types.String, "Death Certification", "Cause of Death Part I, Line e.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string COD1E
+        {
+            get
+            {
+                if (CauseOfDeathConditionE != null && CauseOfDeathConditionE.Code != null)
+                {
+                    return CauseOfDeathConditionE.Code.Text;
+                }
+                return null;
+            }
+            set
+            {
+                 if (CauseOfDeathConditionE == null)
+                 {
+                    CauseOfDeathConditionE = CauseOfDeathCondition(4);
+                 }
+                if (CauseOfDeathConditionE.Code != null)
+                {
+                    CauseOfDeathConditionE.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionE.Code = new CodeableConcept();
+                    CauseOfDeathConditionE.Code.Text = value;
+                }
+            }
+        }
+
+        /// <summary>Cause of Death Part I Interval, Line e.</summary>
+        /// <value>the fourth underlying cause of death approximate interval: onset to death.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.INTERVAL1E = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1E}");</para>
+        /// </example>
+        [Property("INTERVAL1E", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line e.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1E
+        {
+            get
+            {
+                if (CauseOfDeathConditionE != null && CauseOfDeathConditionE.Onset != null)
+                {
+                    return CauseOfDeathConditionE.Onset.ToString();
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionE == null)
+                 {
+                    CauseOfDeathConditionE = CauseOfDeathCondition(4);
+                 }
+                CauseOfDeathConditionE.Onset = new FhirString(value);
+             }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line e.</summary>
+        /// <value>the fourth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "example");</para>
+        /// <para>code.Add("system", "example");</para>
+        /// <para>code.Add("display", "example");</para>
+        /// <para>ExampleDeathRecord.CODE1E = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1E['display']}");</para>
+        /// </example>
+        [Property("CODE1E", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line e.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        public Dictionary<string, string> CODE1E
+        {
+            get
+            {
+                if (CauseOfDeathConditionE != null && CauseOfDeathConditionE.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionE.Code);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                 if (CauseOfDeathConditionE == null)
+                 {
+                    CauseOfDeathConditionE = CauseOfDeathCondition(4);
+                 }
+                if (CauseOfDeathConditionE.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionE.Code.Text;
+                    CauseOfDeathConditionE.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionE.Code = DictToCodeableConcept(value);
+                }
+            }
+        }
+
+        /// <summary>Cause of Death Part I, Line f.</summary>
+        /// <value>the fifth underlying cause of death literal.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.COD1F = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1F}");</para>
+        /// </example>
+        [Property("COD1F", Property.Types.String, "Death Certification", "Cause of Death Part I, Line f.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string COD1F
+        {
+            get
+            {
+                if (CauseOfDeathConditionF != null && CauseOfDeathConditionF.Code != null)
+                {
+                    return CauseOfDeathConditionF.Code.Text;
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionF == null)
+                 {
+                    CauseOfDeathConditionF = CauseOfDeathCondition(5);
+                 }
+                  if (CauseOfDeathConditionF.Code != null)
+                {
+                    CauseOfDeathConditionF.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionF.Code = new CodeableConcept();
+                    CauseOfDeathConditionF.Code.Text = value;
+                }
+            }
+        }
+
+        /// <summary>Cause of Death Part I Interval, Line f.</summary>
+        /// <value>the fifth underlying cause of death approximate interval: onset to death.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.INTERVAL1F = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1F}");</para>
+        /// </example>
+        [Property("INTERVAL1F", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line f.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1F
+        {
+            get
+            {
+                if (CauseOfDeathConditionF != null && CauseOfDeathConditionF.Onset != null)
+                {
+                    return CauseOfDeathConditionF.Onset.ToString();
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionF == null)
+                 {
+                    CauseOfDeathConditionF = CauseOfDeathCondition(5);
+                 }
+                CauseOfDeathConditionF.Onset = new FhirString(value);
+            }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line f.</summary>
+        /// <value>the fifth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "example");</para>
+        /// <para>code.Add("system", "example");</para>
+        /// <para>code.Add("display", "example");</para>
+        /// <para>ExampleDeathRecord.CODE1F = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1F['display']}");</para>
+        /// </example>
+        [Property("CODE1F", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line f.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        public Dictionary<string, string> CODE1F
+        {
+            get
+            {
+                if (CauseOfDeathConditionF != null && CauseOfDeathConditionF.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionF.Code);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                if (CauseOfDeathConditionF == null)
+                 {
+                    CauseOfDeathConditionF = CauseOfDeathCondition(5);
+                 }
+                if (CauseOfDeathConditionF.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionF.Code.Text;
+                    CauseOfDeathConditionF.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionF.Code = DictToCodeableConcept(value);
+                }
+             }
+        }
+
+        /// <summary>Cause of Death Part I, Line g.</summary>
+        /// <value>the sixth underlying cause of death literal.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.COD1G = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1G}");</para>
+        /// </example>
+        [Property("COD1G", Property.Types.String, "Death Certification", "Cause of Death Part I, Line g.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string COD1G
+        {
+            get
+            {
+                if (CauseOfDeathConditionG != null && CauseOfDeathConditionG.Code != null)
+                {
+                    return CauseOfDeathConditionG.Code.Text;
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionG == null)
+                 {
+                    CauseOfDeathConditionG = CauseOfDeathCondition(6);
+                 }
+                if (CauseOfDeathConditionG.Code != null)
+                {
+                    CauseOfDeathConditionG.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionG.Code = new CodeableConcept();
+                    CauseOfDeathConditionG.Code.Text = value;
+                }
+            }
+        }
+
+        /// <summary>Cause of Death Part I Interval, Line g.</summary>
+        /// <value>the sixth underlying cause of death approximate interval: onset to death.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.INTERVAL1G = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1G}");</para>
+        /// </example>
+        [Property("INTERVAL1G", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line g.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1G
+        {
+            get
+            {
+                if (CauseOfDeathConditionG != null && CauseOfDeathConditionG.Onset != null)
+                {
+                    return CauseOfDeathConditionG.Onset.ToString();
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionG == null)
+                 {
+                    CauseOfDeathConditionG = CauseOfDeathCondition(6);
+                 }
+                CauseOfDeathConditionG.Onset = new FhirString(value);
+             }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line g.</summary>
+        /// <value>the sixth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "example");</para>
+        /// <para>code.Add("system", "example");</para>
+        /// <para>code.Add("display", "example");</para>
+        /// <para>ExampleDeathRecord.CODE1G = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1G['display']}");</para>
+        /// </example>
+        [Property("CODE1G", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line g.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        public Dictionary<string, string> CODE1G
+        {
+            get
+            {
+                if (CauseOfDeathConditionG != null && CauseOfDeathConditionG.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionG.Code);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+               if (CauseOfDeathConditionG == null)
+                {
+                    CauseOfDeathConditionG = CauseOfDeathCondition(6);
+                }
+                if (CauseOfDeathConditionG.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionG.Code.Text;
+                    CauseOfDeathConditionG.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionG.Code = DictToCodeableConcept(value);
+                }
+            }
+        }
+
+        /// <summary>Cause of Death Part I, Line h.</summary>
+        /// <value>the seventh underlying cause of death literal.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.COD1H = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1H}");</para>
+        /// </example>
+        [Property("COD1H", Property.Types.String, "Death Certification", "Cause of Death Part I, Line h.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string COD1H
+        {
+            get
+            {
+                if (CauseOfDeathConditionH != null && CauseOfDeathConditionH.Code != null)
+                {
+                    return CauseOfDeathConditionH.Code.Text;
+                }
+                return null;
+            }
+            set
+            {
+               if (CauseOfDeathConditionH == null)
+                 {
+                    CauseOfDeathConditionH = CauseOfDeathCondition(7);
+                 }
+                if (CauseOfDeathConditionH.Code != null)
+                {
+                    CauseOfDeathConditionH.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionH.Code = new CodeableConcept();
+                    CauseOfDeathConditionH.Code.Text = value;
+                }
+            }
+        }
+
+        /// <summary>Cause of Death Part I Interval, Line h.</summary>
+        /// <value>the seventh underlying cause of death approximate interval: onset to death.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.INTERVAL1H = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1H}");</para>
+        /// </example>
+        [Property("INTERVAL1H", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line h.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1H
+        {
+            get
+            {
+                if (CauseOfDeathConditionH != null && CauseOfDeathConditionH.Onset != null)
+                {
+                    return CauseOfDeathConditionH.Onset.ToString();
+                }
+                return null;
+            }
+            set
+            {
+               if (CauseOfDeathConditionH == null)
+                {
+                    CauseOfDeathConditionH = CauseOfDeathCondition(7);
+                }
+                CauseOfDeathConditionH.Onset = new FhirString(value);
+            }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line h.</summary>
+        /// <value>the seventh underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "example");</para>
+        /// <para>code.Add("system", "example");</para>
+        /// <para>code.Add("display", "example");</para>
+        /// <para>ExampleDeathRecord.CODE1H = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1H['display']}");</para>
+        /// </example>
+        [Property("CODE1H", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line h.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        public Dictionary<string, string> CODE1H
+        {
+            get
+            {
+                if (CauseOfDeathConditionH != null && CauseOfDeathConditionH.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionH.Code);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+              if (CauseOfDeathConditionH == null)
+                {
+                    CauseOfDeathConditionH = CauseOfDeathCondition(7);
+                }
+                if (CauseOfDeathConditionH.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionH.Code.Text;
+                    CauseOfDeathConditionH.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionH.Code = DictToCodeableConcept(value);
+                }
+                            }
+        }
+
+        /// <summary>Cause of Death Part I, Line i.</summary>
+        /// <value>the eighth underlying cause of death literal.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.COD1I = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1I}");</para>
+        /// </example>
+        [Property("COD1I", Property.Types.String, "Death Certification", "Cause of Death Part I, Line i.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string COD1I
+        {
+            get
+            {
+                if (CauseOfDeathConditionI != null && CauseOfDeathConditionI.Code != null)
+                {
+                    return CauseOfDeathConditionI.Code.Text;
+                }
+                return null;
+            }
+            set
+            {
+              if (CauseOfDeathConditionI == null)
+                {
+                    CauseOfDeathConditionI = CauseOfDeathCondition(8);
+                }
+                if (CauseOfDeathConditionI.Code != null)
+                {
+                    CauseOfDeathConditionI.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionI.Code = new CodeableConcept();
+                    CauseOfDeathConditionI.Code.Text = value;
+                }
+                            }
+        }
+
+        /// <summary>Cause of Death Part I Interval, Line i.</summary>
+        /// <value>the eighth underlying cause of death approximate interval: onset to death.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.INTERVAL1I = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1I}");</para>
+        /// </example>
+        [Property("INTERVAL1I", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line i.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1I
+        {
+            get
+            {
+                if (CauseOfDeathConditionI != null && CauseOfDeathConditionI.Onset != null)
+                {
+                    return CauseOfDeathConditionI.Onset.ToString();
+                }
+                return null;
+            }
+            set
+            {
+               if (CauseOfDeathConditionI == null)
+                {
+                    CauseOfDeathConditionI = CauseOfDeathCondition(8);
+                }
+                CauseOfDeathConditionI.Onset = new FhirString(value);
+             }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line i.</summary>
+        /// <value>the eighth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "example");</para>
+        /// <para>code.Add("system", "example");</para>
+        /// <para>code.Add("display", "example");</para>
+        /// <para>ExampleDeathRecord.CODE1I = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1I['display']}");</para>
+        /// </example>
+        [Property("CODE1I", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line i.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        public Dictionary<string, string> CODE1I
+        {
+            get
+            {
+                if (CauseOfDeathConditionI != null && CauseOfDeathConditionI.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionI.Code);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                if (CauseOfDeathConditionI == null)
+                {
+                    CauseOfDeathConditionI = CauseOfDeathCondition(8);
+                }
+                if (CauseOfDeathConditionI.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionI.Code.Text;
+                    CauseOfDeathConditionI.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionI.Code = DictToCodeableConcept(value);
+                }
+                            }
+        }
+
+        /// <summary>Cause of Death Part I, Line j.</summary>
+        /// <value>the ninth underlying cause of death literal.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.COD1J = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Cause: {ExampleDeathRecord.COD1J}");</para>
+        /// </example>
+        [Property("COD1J", Property.Types.String, "Death Certification", "Cause of Death Part I, Line j.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string COD1J
+        {
+            get
+            {
+                if (CauseOfDeathConditionJ != null && CauseOfDeathConditionJ.Code != null)
+                {
+                    return CauseOfDeathConditionJ.Code.Text;
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionJ == null)
+                {
+                    CauseOfDeathConditionJ = CauseOfDeathCondition(9);
+                }
+                if (CauseOfDeathConditionJ.Code != null)
+                {
+                    CauseOfDeathConditionJ.Code.Text = value;
+                }
+                else
+                {
+                    CauseOfDeathConditionJ.Code = new CodeableConcept();
+                    CauseOfDeathConditionJ.Code.Text = value;
+                }
+             }
+        }
+
+        /// <summary>Cause of Death Part I Interval, Line j.</summary>
+        /// <value>the ninth underlying cause of death approximate interval: onset to death.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.INTERVAL1J = "example";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1J}");</para>
+        /// </example>
+        [Property("INTERVAL1J", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line j.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        public string INTERVAL1J
+        {
+            get
+            {
+                if (CauseOfDeathConditionJ != null && CauseOfDeathConditionJ.Onset != null)
+                {
+                    return CauseOfDeathConditionJ.Onset.ToString();
+                }
+                return null;
+            }
+            set
+            {
+                if (CauseOfDeathConditionJ == null)
+                {
+                    CauseOfDeathConditionJ = CauseOfDeathCondition(9);
+                }
+
+                CauseOfDeathConditionJ.Onset = new FhirString(value);
+             }
+        }
+
+        /// <summary>Cause of Death Part I Code, Line j.</summary>
+        /// <value>the ninth underlying cause of death coding. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "example");</para>
+        /// <para>code.Add("system", "example");</para>
+        /// <para>code.Add("display", "example");</para>
+        /// <para>ExampleDeathRecord.CODE1J = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"\tCause of Death: {ExampleDeathRecord.CODE1J['display']}");</para>
+        /// </example>
+        [Property("CODE1J", Property.Types.Dictionary, "Death Certification", "Cause of Death Part I Code, Line j.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Cause-Of-Death-Condition.html", false, 100)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        public Dictionary<string, string> CODE1J
+        {
+            get
+            {
+                if (CauseOfDeathConditionJ != null && CauseOfDeathConditionJ.Code != null)
+                {
+                    return CodeableConceptToDict(CauseOfDeathConditionJ.Code);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                if (CauseOfDeathConditionJ == null)
+                {
+                    CauseOfDeathConditionJ = CauseOfDeathCondition(9);
+                }
+               if (CauseOfDeathConditionJ.Code != null)
+                {
+                    CodeableConcept code = DictToCodeableConcept(value);
+                    code.Text = CauseOfDeathConditionJ.Code.Text;
+                    CauseOfDeathConditionJ.Code = code;
+                }
+                else
+                {
+                    CauseOfDeathConditionJ.Code = DictToCodeableConcept(value);
+                }
+            }
+        }
 
 
         /////////////////////////////////////////////////////////////////////////////////
@@ -2167,7 +2794,7 @@ namespace VRDR
         //
         /////////////////////////////////////////////////////////////////////////////////
 
-        /// <summary>Decedent's Legal Name - Given. Middle name should be the last entry.</summary>
+        /// <summary>Decedent's Given Name(s). Middle name should be the last entry.</summary>
         /// <value>the decedent's name (first, etc., middle)</value>
         /// <example>
         /// <para>// Setter:</para>
@@ -2176,7 +2803,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Given Name(s): {string.Join(", ", ExampleDeathRecord.GivenNames)}");</para>
         /// </example>
-        [Property("Given Names", Property.Types.StringArr, "Decedent Demographics", "Decedent's Given Name(s).", true, ProfileURL.Decedent, true, 0)]
+        [Property("Given Names", Property.Types.StringArr, "Decedent Demographics", "Decedent's Given Name(s).", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 0)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
         public string[] GivenNames
         {
@@ -2210,7 +2837,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent's Last Name: {ExampleDeathRecord.FamilyName}");</para>
         /// </example>
-        [Property("Family Name", Property.Types.String, "Decedent Demographics", "Decedent's Family Name.", true, ProfileURL.Decedent, true, 5)]
+        [Property("Family Name", Property.Types.String, "Decedent Demographics", "Decedent's Family Name.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 5)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
         public string FamilyName
         {
@@ -2243,7 +2870,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Suffix: {ExampleDeathRecord.Suffix}");</para>
         /// </example>
-        [Property("Suffix", Property.Types.String, "Decedent Demographics", "Decedent's Suffix.", true, ProfileURL.Decedent, true, 6)]
+        [Property("Suffix", Property.Types.String, "Decedent Demographics", "Decedent's Suffix.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 6)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
         public string Suffix
         {
@@ -2278,13 +2905,13 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent's Maiden Name: {ExampleDeathRecord.MaidenName}");</para>
         /// </example>
-        [Property("Maiden Name", Property.Types.String, "Decedent Demographics", "Decedent's Maiden Name.", true, ProfileURL.Decedent, true, 10)]
+        [Property("Maiden Name", Property.Types.String, "Decedent Demographics", "Decedent's Maiden Name.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 10)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient).name.where(use='maiden')", "family")]
         public string MaidenName
         {
             get
             {
-                return GetFirstString("Bundle.entry.resource.where($this is Patient).name.where(use='maiden').text");
+                return GetFirstString("Bundle.entry.resource.where($this is Patient).name.where(use='maiden').family");
             }
             set
             {
@@ -2297,7 +2924,7 @@ namespace VRDR
                 {
                     name = new HumanName();
                     name.Use = HumanName.NameUse.Maiden;
-                    name.Text = value;
+                    name.Family = value;
                     Decedent.Name.Add(name);
                 }
             }
@@ -2311,7 +2938,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Gender: {ExampleDeathRecord.Gender}");</para>
         /// </example>
-        [Property("Gender", Property.Types.String, "Decedent Demographics", "Decedent's Gender.", true, ProfileURL.Decedent, true, 11)]
+        [Property("Gender", Property.Types.String, "Decedent Demographics", "Decedent's Gender.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 11)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "gender")]
         public string Gender
         {
@@ -2351,65 +2978,6 @@ namespace VRDR
             }
         }
 
-        /// <summary>Decedent's Sex at Death.</summary>
-        /// <value>the decedent's sex at time of death</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.SexAtDeath = "F";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Sex at Time of Death: {ExampleDeathRecord.SexAtDeath}");</para>
-        /// </example>
-        [Property("Sex At Death", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Sex at Death.", true, ProfileURL.Decedent, true, 12)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath')", "")]
-        public Dictionary<string, string> SexAtDeath
-        {
-            get
-            {
-                Extension sex = Decedent.Extension.Find(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath");
-                if (sex != null && sex.Value != null && sex.Value as CodeableConcept != null)
-                {
-                    return CodeableConceptToDict((CodeableConcept)sex.Value);
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                Decedent.Extension.RemoveAll(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath");
-                Extension sex = new Extension();
-                sex.Url = "http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath";
-                sex.Value = DictToCodeableConcept(value);
-                Decedent.Extension.Add(sex);
-            }
-        }
-
-        /// <summary>Decedent's Sex At Death Helper</summary>
-        /// <value>Decedent's sex at death.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.SexAtDeathHelper = VRDR.ValueSets.AdministractiveGender.Male;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's SexAtDeathHelper: {ExampleDeathRecord.SexAtDeathHelper}");</para>
-        /// </example>
-        [Property("Sex At Death", Property.Types.String, "Decedent Demographics", "Decedent's Sex At Death.", true, ProfileURL.Decedent, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath')", "")]
-        public string SexAtDeathHelper
-        {
-            get
-            {
-                if (SexAtDeath.ContainsKey("code"))
-                {
-                    return SexAtDeath["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("SexAtDeath", value, VRDR.ValueSets.AdministrativeGender.Codes);
-            }
-        }
-
-        // Should this be removed for IG v1.3 updates?
         /// <summary>Decedent's Birth Sex.</summary>
         /// <value>the decedent's birth sex</value>
         /// <example>
@@ -2418,7 +2986,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Birth Sex: {ExampleDeathRecord.BirthSex}");</para>
         /// </example>
-        [Property("Birth Sex", Property.Types.String, "Decedent Demographics", "Decedent's Birth Sex.", true, ProfileURL.Decedent, true, 12)]
+        [Property("Birth Sex", Property.Types.String, "Decedent Demographics", "Decedent's Birth Sex.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 12)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "")]
         public string BirthSex
         {
@@ -2470,7 +3038,6 @@ namespace VRDR
             }
         }
 
-        
         /// <summary>Decedent's Date of Birth Date Part Absent Extension.</summary>
         /// <value>the decedent's date of birth date part absent reason</value>
         /// <example>
@@ -2479,7 +3046,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Date of Birth Date Part Reason: {ExampleDeathRecord.DateOfBirthDatePartAbsent}");</para>
         /// </example>
-        [Property("Date Of Birth Date Part Absent", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Date of Birth Date Part.", true, ProfileURL.Decedent, true, 14)]
+        [Property("Date Of Birth Date Part Absent", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Date of Birth Date Part.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 14)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "_birthDate")]
         public Tuple<string,string>[] DateOfBirthDatePartAbsent
         {
@@ -2540,20 +3107,18 @@ namespace VRDR
         /// <para>address.Add("addressLine1", "123 Test Street");</para>
         /// <para>address.Add("addressLine2", "Unit 3");</para>
         /// <para>address.Add("addressCity", "Boston");</para>
-        /// <para>address.Add("addressCityC", "1234");</para>
         /// <para>address.Add("addressCounty", "Suffolk");</para>
         /// <para>address.Add("addressState", "MA");</para>
         /// <para>address.Add("addressZip", "12345");</para>
         /// <para>address.Add("addressCountry", "US");</para>
-        /// <para>SetterDeathRecord.Residence = address;</para> (addressStnum, 6)
+        /// <para>SetterDeathRecord.Residence = address;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"State of residence: {ExampleDeathRecord.Residence["addressState"]}");</para>
         /// </example>
-        [Property("Residence", Property.Types.Dictionary, "Decedent Demographics", "Decedent's residence.", true, ProfileURL.Decedent, true, 19)]
+        [Property("Residence", Property.Types.Dictionary, "Decedent Demographics", "Decedent's residence.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 19)]
         [PropertyParam("addressLine1", "address, line one")]
         [PropertyParam("addressLine2", "address, line two")]
         [PropertyParam("addressCity", "address, city")]
-        [PropertyParam("addressCityC", "address, _city")]
         [PropertyParam("addressCounty", "address, county")]
         [PropertyParam("addressState", "address, state")]
         [PropertyParam("addressZip", "address, zip")]
@@ -2565,25 +3130,34 @@ namespace VRDR
             {
                 if (Decedent != null && Decedent.Address != null && Decedent.Address.Count() > 0)
                 {
-                    Dictionary<string, string> address = AddressToDict(Decedent.Address.First());
-                    return address;
+                    return AddressToDict(Decedent.Address.First());
                 }
                 return EmptyAddrDict();
             }
             set
             {
-                if (Decedent.Address == null){
-                    Decedent.Address = new List<Address>();
+                if (ResidenceWithinCityLimitsBoolean == false)
+                {
+                    Decedent.Address.Clear();
+                    Decedent.Address.Add(DictToAddress(value));
+                    ResidenceWithinCityLimitsBoolean = false;
                 }
-                Decedent.Address.Clear();
-                Decedent.Address.Add(DictToAddress(value));
-                
-            
+                if (ResidenceWithinCityLimitsBoolean == true)
+                {
+                    Decedent.Address.Clear();
+                    Decedent.Address.Add(DictToAddress(value));
+                    ResidenceWithinCityLimitsBoolean = true;
+                }
+                else
+                {
+                    Decedent.Address.Clear();
+                    Decedent.Address.Add(DictToAddress(value));
+                }
                 // Now encode -
                 //        Address.Country as PH_Country_GEC
                 //        Adress.County as PHVS_DivisionVitalStatistics__County
                 //        Address.City as 5 digit code as per FIPS 55-3, which are included as the preferred alternate code in https://phinvads.cdc.gov/vads/ViewValueSet.action?id=D06EE94C-4D4C-440A-AD2A-1C3CB35E6D08#
-                //Address a = Decedent.Address.FirstOrDefault();
+               Address a = Decedent.Address.FirstOrDefault();
             }
         }
 
@@ -2602,7 +3176,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Residence within city limits: {ExampleDeathRecord.ResidenceWithinCityLimits['display']}");</para>
         /// </example>
-        [Property("Residence Within City Limits", Property.Types.Dictionary, "Decedent Demographics", "Decedent's residence is/is not within city limits.", true, ProfileURL.Decedent, true, 20)]
+        [Property("Residence Within City Limits", Property.Types.Dictionary, "Decedent Demographics", "Decedent's residence is/is not within city limits.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 20)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -2613,8 +3187,8 @@ namespace VRDR
             {
                 if (Decedent != null && Decedent.Address.FirstOrDefault() != null)
                 {
-                    Extension cityLimits = Decedent.Address.FirstOrDefault().Extension.Where(ext => ext.Url == ExtensionURL.WithinCityLimitsIndicator).FirstOrDefault();
-                    if (cityLimits != null && cityLimits.Value != null && cityLimits.Value as Coding != null)
+                    Extension cityLimits = Decedent.Address.FirstOrDefault().Extension.Find(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator");
+                    if (cityLimits != null && cityLimits.Value != null && cityLimits.Value.GetType() == typeof(Coding))
                     {
                         return CodingToDict((Coding)cityLimits.Value);
                     }
@@ -2629,43 +3203,15 @@ namespace VRDR
                     {
                         Decedent.Address.Add(new Address());
                     }
-                    Decedent.Address.FirstOrDefault().Extension.RemoveAll(ext => ext.Url == ExtensionURL.WithinCityLimitsIndicator);
+                    Decedent.Address.FirstOrDefault().Extension.RemoveAll(ext => ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator");
                     Extension withinCityLimits = new Extension();
-                    withinCityLimits.Url = ExtensionURL.WithinCityLimitsIndicator;
+                    withinCityLimits.Url = "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator";
                     withinCityLimits.Value = DictToCoding(value);
                     Decedent.Address.FirstOrDefault().Extension.Add(withinCityLimits);
                 }
             }
         }
 
-        /// <summary>Residence Within City Limits Helper</summary>
-        /// <value>Residence Within City Limits.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.ResidenceWithinCityLimitsHelper = VRDR.ValueSets.YesNoUnknown.Y;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's Residence within city limits: {ExampleDeathRecord.ResidenceWithinCityLimitsHelper}");</para>
-        /// </example>
-        [Property("ResidenceWithinCityLimits Helper", Property.Types.String, "Decedent Demographics", "Decedent's ResidenceWithinCityLimits.", true, ProfileURL.Decedent, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "address")]
-        public string ResidenceWithinCityLimitsHelper
-        {
-            get
-            {
-                if (ResidenceWithinCityLimits.ContainsKey("code"))
-                {
-                    return ResidenceWithinCityLimits["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("ResidenceWithinCityLimits", value, VRDR.ValueSets.YesNoUnknown.Codes);
-            }
-        }
-
-        // Todo remove in V1.3 IG updates
         /// <summary>Decedent's residence is/is not within city limits. This is a convenience method, to access the coded value use ResidenceWithinCityLimits.</summary>
         /// <value>Decedent's residence is/is not within city limits. A null value means "not applicable".</value>
         /// <example>
@@ -2674,7 +3220,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Residence within city limits: {ExampleDeathRecord.ResidenceWithinCityLimitsBoolean}");</para>
         /// </example>
-        [Property("Residence Within City Limits Boolean", Property.Types.Bool, "Decedent Demographics", "Decedent's residence is/is not within city limits.", true, ProfileURL.Decedent, true, 21)]
+        [Property("Residence Within City Limits Boolean", Property.Types.Bool, "Decedent Demographics", "Decedent's residence is/is not within city limits.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 21)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "address")]
         public bool? ResidenceWithinCityLimitsBoolean
         {
@@ -2724,7 +3270,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Suffix: {ExampleDeathRecord.SSN}");</para>
         /// </example>
-        [Property("SSN", Property.Types.String, "Decedent Demographics", "Decedent's Social Security Number.", true, ProfileURL.Decedent, true, 13)]
+        [Property("SSN", Property.Types.String, "Decedent Demographics", "Decedent's Social Security Number.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 13)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient).identifier.where(system='http://hl7.org/fhir/sid/us-ssn')", "")]
         public string SSN
         {
@@ -2747,539 +3293,297 @@ namespace VRDR
             }
         }
 
-        /// <summary>Decedent's Ethnicity Hispanic Mexican.</summary>
-        /// <value>the decedent's ethnicity. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
+        /// <summary>Decedent's Ethnicity.</summary>
+        /// <value>the decedent's ethnicity as a text string. Use the Ethnicity property to set coded ethnicity.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; ethnicity = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>ethnicity.Add("code", "Y");</para>
-        /// <para>ethnicity.Add("system", CodeSystems.YesNo);</para>
-        /// <para>ethnicity.Add("display", "Yes");</para>
+        /// <para>ExampleDeathRecord.EthnicityText = "Hispanic or Latino";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Decedent Ethnicity Text: {ExampleDeathRecord.EthnicityText}");</para>
+        /// </example>
+        [Property("EthnicityText", Property.Types.String, "Decedent Demographics", "Decedent's Ethnicity.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 35)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "")]
+        public string EthnicityText
+        {
+            get
+            {
+                Extension ethnicity = Decedent.Extension.Where(ext => ext.Url == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity").FirstOrDefault();
+                if (ethnicity != null)
+                {
+                    Extension ethnicityText = ethnicity.Extension.Where(ext => ext.Url == "text").FirstOrDefault();
+                    if (ethnicityText != null && ethnicityText.Value.GetType() == typeof(FhirString))
+                    {
+                        return ethnicityText.Value.ToString();
+                    }
+                }
+                return null;
+            }
+            set
+            {
+                Extension ethnicity = Decedent.Extension.Where(ext => ext.Url == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity").FirstOrDefault();
+                if (ethnicity == null)
+                {
+                    ethnicity = new Extension();
+                    ethnicity.Url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity";
+                    Decedent.Extension.Add(ethnicity);
+                }
+                Extension ethnicityText = ethnicity.Extension.Where(ext => ext.Url == "text").FirstOrDefault();
+                if (ethnicityText == null)
+                {
+                    ethnicityText = new Extension();
+                    ethnicityText.Url = "text";
+                    ethnicity.Extension.Add(ethnicityText);
+                }
+                ethnicityText.Value = new FhirString(value);
+            }
+        }
+
+        /// <summary>Decedent's Ethnicity.</summary>
+        /// <value>the decedent's ethnicity. An array of tuples, where the first value of each tuple is the display value, and the second is
+        /// the code. Use the EthnicityText property to set this value as a simple string, setting the value of this property will create a default value for the
+        /// EthnicityText property by concatenating the supplied code display texts.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Tuple&lt;string, string&gt;[] ethnicity = { Tuple.Create("Non Hispanic or Latino", "2186-5"), Tuple.Create("Salvadoran", "2161-8") };</para>
         /// <para>ExampleDeathRecord.Ethnicity = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleDeathRecord.Ethnicity1['display']}");</para>
+        /// <para>foreach(var pair in deathRecord.Ethnicity)</para>
+        /// <para>{</para>
+        /// <para>  Console.WriteLine($"\tEthnicity text: {pair.Key}: code: {pair.Value}");</para>
+        /// <para>};</para>
         /// </example>
-        [Property("Ethnicity1", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Ethnicity Hispanic Mexican.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public Dictionary<string, string> Ethnicity1
+        [Property("Ethnicity", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Ethnicity.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 36)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "")]
+        public Tuple<string, string>[] Ethnicity
         {
             get
             {
-                if (InputRaceandEthnicity != null)
+                string[] ombCodes = new string[] { };
+                string[] detailedCodes = new string[] { };
+                string[] ombDisplays = new string[] { };
+                string[] detailedDisplays = new string[] { };
+                ombCodes = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.where(url = 'ombCategory').value.code");
+                detailedCodes = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.where(url = 'detailed').value.code");
+                ombDisplays = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.where(url = 'ombCategory').value.display");
+                detailedDisplays = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.where(url = 'detailed').value.display");
+                Tuple<string, string>[] ethnicityList = new Tuple<string, string>[ombCodes.Length + detailedCodes.Length];
+                for (int i = 0; i < ombCodes.Length; i++)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceandEthnicity.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
+                    if (!String.IsNullOrWhiteSpace(MortalityData.EthnicityCodeToEthnicityName(ombCodes[i])))
                     {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
+                        ethnicityList[i] = (Tuple.Create(MortalityData.EthnicityCodeToEthnicityName(ombCodes[i]), String.IsNullOrWhiteSpace(ombCodes[i]) ? null : ombCodes[i]));
+                    }
+                    else
+                    {
+                        ethnicityList[i] = (Tuple.Create(ombDisplays[i], String.IsNullOrWhiteSpace(ombCodes[i]) ? null : ombCodes[i]));
                     }
                 }
-                return EmptyCodeableDict();
+                for (int i = 0; i < detailedCodes.Length; i++)
+                {
+                    if (!String.IsNullOrWhiteSpace(MortalityData.EthnicityCodeToEthnicityName(detailedCodes[i])))
+                    {
+                        ethnicityList[ombCodes.Length + i] = (Tuple.Create(MortalityData.EthnicityCodeToEthnicityName(detailedCodes[i]), String.IsNullOrWhiteSpace(detailedCodes[i]) ? null : detailedCodes[i]));
+                    }
+                    else
+                    {
+                        ethnicityList[ombCodes.Length + i] = (Tuple.Create(detailedDisplays[i], String.IsNullOrWhiteSpace(detailedCodes[i]) ? null : detailedCodes[i]));
+                    }
+                }
+                return ethnicityList;
             }
             set
             {
-                if (InputRaceandEthnicity == null)
+                Decedent.Extension.RemoveAll(ext => ext.Url == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
+                Extension ethnicities = new Extension();
+                ethnicities.Url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity";
+                List<string> textEthStrs = new List<string>();
+                foreach (Tuple<string, string> element in value)
                 {
-                    CreateRaceEthnicityObs();
+                    string display = element.Item1;
+                    string code = element.Item2;
+                    textEthStrs.Add(display);
+                    Extension codeEthnicity = new Extension();
+                    if (code == "2135-2" || code == "2186-5")
+                    {
+                        codeEthnicity.Url = "ombCategory";
+                    }
+                    else if (display.Equals("Hispanic or Latino", StringComparison.InvariantCultureIgnoreCase) ||
+                             display.Equals("Not Hispanic or Latino", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        codeEthnicity.Url = "ombCategory";
+                    }
+                    else
+                    {
+                        codeEthnicity.Url = "detailed";
+                    }
+                    Coding coding = new Coding();
+                    coding.System = CodeSystems.PH_RaceAndEthnicity_CDC;
+                    if (!String.IsNullOrWhiteSpace(code))
+                    {
+                        coding.Code = code;
+                    }
+                    if (!String.IsNullOrWhiteSpace(display))
+                    {
+                        coding.Display = display;
+                    }
+                    codeEthnicity.Value = coding;
+                    ethnicities.Extension.Add(codeEthnicity);
                 }
-                InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
-                var coding = EmptyRaceEthnicityCodeDict();
-                coding["code"] = NvssEthnicity.Mexican;
-                coding["display"] = NvssEthnicity.Mexican;
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = DictToCodeableConcept(coding);
-                component.Value = DictToCodeableConcept(value);
-                InputRaceandEthnicity.Component.Add(component);
+                Extension textEth = new Extension();
+                textEth.Url = "text";
+                textEth.Value = new FhirString(String.Join(", ", textEthStrs));
+                ethnicities.Extension.Add(textEth);
+                Decedent.Extension.Add(ethnicities);
             }
         }
 
-        /// <summary>Decedent's Ethnicity 1 Helper</summary>
-        /// <value>Decedent's Ethnicity 1.</value>
+        /// <summary>Decedent's Race.</summary>
+        /// <value>the decedent's race as a text string. Use the Race property to set coded race.</value>
         /// <example>
-        /// <para>// Setter:</para> 
-        /// <para>ExampleDeathRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.RaceText = "White";</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity1Helper}");</para>
+        /// <para>Console.WriteLine($"Decedent Race Text: {ExampleDeathRecord.RaceText}");</para>
         /// </example>
-        [Property("Ethnicity 1 Helper", Property.Types.String, "Decedent Demographics", "Decedent's Ethnicity 1.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public string Ethnicity1Helper
+        [Property("RaceText", Property.Types.String, "Decedent Demographics", "Decedent's Race.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 37)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')", "")]
+        public string RaceText
         {
             get
             {
-                if (Ethnicity1.ContainsKey("code"))
+                Extension race = Decedent.Extension.Where(ext => ext.Url == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race").FirstOrDefault();
+                if (race != null)
                 {
-                    return Ethnicity1["code"];
+                    Extension raceText = race.Extension.Where(ext => ext.Url == "text").FirstOrDefault();
+                    if (raceText != null && raceText.Value.GetType() == typeof(FhirString))
+                    {
+                        return raceText.Value.ToString();
+                    }
                 }
                 return null;
             }
             set
             {
-                SetCodeValue("Ethnicity1", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                Extension race = Decedent.Extension.Where(ext => ext.Url == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race").FirstOrDefault();
+                if (race == null)
+                {
+                    race = new Extension();
+                    race.Url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+                    Decedent.Extension.Add(race);
+                }
+                Extension raceText = race.Extension.Where(ext => ext.Url == "text").FirstOrDefault();
+                if (raceText == null)
+                {
+                    raceText = new Extension();
+                    raceText.Url = "text";
+                    race.Extension.Add(raceText);
+                }
+                raceText.Value = new FhirString(value);
             }
         }
 
-        /// <summary>Decedent's Ethnicity Hispanic Puerto Rican.</summary>
-        /// <value>the decedent's ethnicity. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
+        /// <summary>Decedent's Race.</summary>
+        /// <value>the decedent's race. An array of tuples, where the first value of each tuple is the display value, and the second is
+        /// the code. Use the RaceText property to set this value as a simple string, setting the value of this property will create a default value for the
+        /// RaceText property by concatenating the supplied code display texts.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; ethnicity = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>ethnicity.Add("code", "Y");</para>
-        /// <para>ethnicity.Add("system", CodeSystems.YesNo);</para>
-        /// <para>ethnicity.Add("display", "Yes");</para>
-        /// <para>ExampleDeathRecord.Ethnicity2 = ethnicity;</para>
+        /// <para>Tuple&lt;string, string&gt;[] race = { Tuple.Create("Non Hispanic or Latino", "2186-5"), Tuple.Create("Salvadoran", "2161-8") };</para>
+        /// <para>ExampleDeathRecord.Race = race;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleDeathRecord.Ethnicity2['display']}");</para>
+        /// <para>foreach(var pair in ExampleDeathRecord.race)</para>
+        /// <para>{</para>
+        /// <para>   Console.WriteLine($"\Race text: {pair.Key}: code: {pair.Value}");</para>
+        /// <para>};</para>
         /// </example>
-        [Property("Ethnicity2", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Ethnicity Hispanic Puerto Rican.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public Dictionary<string, string> Ethnicity2
-        {
-            get
-            {
-                if (InputRaceandEthnicity != null)
-                {
-                    Observation.ComponentComponent ethnicity = InputRaceandEthnicity.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (InputRaceandEthnicity == null)
-                {
-                    CreateRaceEthnicityObs();
-                }
-                InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
-                var coding = EmptyRaceEthnicityCodeDict();
-                coding["code"] = NvssEthnicity.PuertoRican;
-                coding["display"] = NvssEthnicity.PuertoRican;
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = DictToCodeableConcept(coding);
-                component.Value = DictToCodeableConcept(value);
-                InputRaceandEthnicity.Component.Add(component);
-            }
-        }
-
-        /// <summary>Decedent's Ethnicity 2 Helper</summary>
-        /// <value>Decedent's Ethnicity 2.</value>
-        /// <example>
-        /// <para>// Setter:</para> 
-        /// <para>ExampleDeathRecord.Ethnicity2Helper = "Y";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity1Helper}");</para>
-        /// </example>
-        [Property("Ethnicity 2 Helper", Property.Types.String, "Decedent Demographics", "Decedent's Ethnicity 2.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public string Ethnicity2Helper
-        {
-            get
-            {
-                if (Ethnicity2.ContainsKey("code"))
-                {
-                    return Ethnicity2["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("Ethnicity2", value, VRDR.ValueSets.YesNoUnknown.Codes);
-            }
-        }
-
-        /// <summary>Decedent's Ethnicity Hispanic Cuban.</summary>
-        /// <value>the decedent's ethnicity. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; ethnicity = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>ethnicity.Add("code", "Y");</para>
-        /// <para>ethnicity.Add("system", CodeSystems.YesNo);</para>
-        /// <para>ethnicity.Add("display", "Yes");</para>
-        /// <para>ExampleDeathRecord.Ethnicity3 = ethnicity;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleDeathRecord.Ethnicity3['display']}");</para>
-        /// </example>
-        [Property("Ethnicity3", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Ethnicity Hispanic Cuban.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public Dictionary<string, string> Ethnicity3
-        {
-            get
-            {
-                if (InputRaceandEthnicity != null)
-                {
-                    Observation.ComponentComponent ethnicity = InputRaceandEthnicity.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (InputRaceandEthnicity == null)
-                {
-                    CreateRaceEthnicityObs();
-                }
-                InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
-                var coding = EmptyRaceEthnicityCodeDict();
-                coding["code"] = NvssEthnicity.Cuban;
-                coding["display"] = NvssEthnicity.Cuban;
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = DictToCodeableConcept(coding);
-                component.Value = DictToCodeableConcept(value);
-                InputRaceandEthnicity.Component.Add(component);
-            }
-        }
-
-        /// <summary>Decedent's Ethnicity 3 Helper</summary>
-        /// <value>Decedent's Ethnicity 3.</value>
-        /// <example>
-        /// <para>// Setter:</para> 
-        /// <para>ExampleDeathRecord.Ethnicity3Helper = "Y";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity3Helper}");</para>
-        /// </example>
-        [Property("Ethnicity 3 Helper", Property.Types.String, "Decedent Demographics", "Decedent's Ethnicity 3.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public string Ethnicity3Helper
-        {
-            get
-            {
-                if (Ethnicity3.ContainsKey("code"))
-                {
-                    return Ethnicity3["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("Ethnicity3", value, VRDR.ValueSets.YesNoUnknown.Codes);
-            }
-        }
-
-        /// <summary>Decedent's Ethnicity Hispanic Other.</summary>
-        /// <value>the decedent's ethnicity. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; ethnicity = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>ethnicity.Add("code", "Y");</para>
-        /// <para>ethnicity.Add("system", CodeSystems.YesNo);</para>
-        /// <para>ethnicity.Add("display", "Yes");</para>
-        /// <para>ExampleDeathRecord.Ethnicity4 = ethnicity;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleDeathRecord.Ethnicity4['display']}");</para>
-        /// </example>
-        [Property("Ethnicity4", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Ethnicity Hispanic Other.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public Dictionary<string, string> Ethnicity4
-        {
-            get
-            {
-                if (InputRaceandEthnicity != null)
-                {
-                    Observation.ComponentComponent ethnicity = InputRaceandEthnicity.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (InputRaceandEthnicity == null)
-                {
-                    CreateRaceEthnicityObs();
-                }
-                InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
-                var coding = EmptyRaceEthnicityCodeDict();
-                coding["code"] = NvssEthnicity.Other;
-                coding["display"] = NvssEthnicity.Other;
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = DictToCodeableConcept(coding);
-                component.Value = DictToCodeableConcept(value);
-                InputRaceandEthnicity.Component.Add(component);
-            }
-        }
-
-        /// <summary>Decedent's Ethnicity 4 Helper</summary>
-        /// <value>Decedent's Ethnicity 4.</value>
-        /// <example>
-        /// <para>// Setter:</para> 
-        /// <para>ExampleDeathRecord.Ethnicity4Helper = "Y";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's Ethnicity: {ExampleDeathRecord.Ethnicity4Helper}");</para>
-        /// </example>
-        [Property("Ethnicity 4 Helper", Property.Types.String, "Decedent Demographics", "Decedent's Ethnicity 4.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public string Ethnicity4Helper
-        {
-            get
-            {
-                if (Ethnicity4.ContainsKey("code"))
-                {
-                    return Ethnicity4["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("Ethnicity4", value, VRDR.ValueSets.YesNoUnknown.Codes);
-            }
-        }
-
-        /// <summary>Decedent's Ethnicity Hispanic Literal.</summary>
-        /// <value>the decedent's ethnicity. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.EthnicityLiteral = ethnicity;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleDeathRecord.Ethnicity4['display']}");</para>
-        /// </example>
-        [Property("EthnicityLiteral", Property.Types.String, "Decedent Demographics", "Decedent's Ethnicity Literal.", true, ProfileURL.InputRaceAndEthnicity, false, 34)]
-        [PropertyParam("ethnicity", "The literal string to describe ethnicity.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation)", "")]
-        public string EthnicityLiteral
-        {
-            get
-            {
-                if (InputRaceandEthnicity != null)
-                {
-                    Observation.ComponentComponent ethnicity = InputRaceandEthnicity.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
-                    if (ethnicity != null && ethnicity.Value != null)
-                    {
-                        return ethnicity.Value.ToString();
-                    }
-                }
-                return "";
-            }
-            set
-            {
-                if (InputRaceandEthnicity == null)
-                {
-                    CreateRaceEthnicityObs();
-                }
-                InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
-                var coding = EmptyRaceEthnicityCodeDict();
-                coding["code"] = NvssEthnicity.Literal;
-                coding["display"] = NvssEthnicity.Literal;
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = DictToCodeableConcept(coding);
-                component.Value = new FhirString(value);
-                InputRaceandEthnicity.Component.Add(component);
-            }
-        }
-
-        /// <summary>Decedent's Race values.</summary>
-        /// <value>the decedent's race. A tuple, where the first value of the tuple is the display value, and the second is
-        /// the IJE code Y or N.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.Race = {NvssRace.BlackOrAfricanAmerican, "Y"};</para>
-        /// <para>// Getter:</para>
-        /// <para>string boaa = ExampleDeathRecord.RaceBlackOfAfricanAmerican;</para>
-        /// </example>
-        [Property("Race", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Race", true, ProfileURL.InputRaceAndEthnicity, true, 38)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicity')", "")]
+        [Property("Race", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Race.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 38)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')", "")]
         public Tuple<string, string>[] Race
         {
             get
             {
-                // filter the boolean race values
-                var booleanRaceCodes = NvssRace.GetBooleanRaceCodes();
-                List<string> raceCodes = booleanRaceCodes.Concat(NvssRace.GetLiteralRaceCodes()).ToList();
-
-                var races = new List<Tuple<string, string>>(){};
-
-                if (InputRaceandEthnicity == null)
+                string[] ombCodes = new string[] { };
+                string[] detailedCodes = new string[] { };
+                string[] ombDisplays = new string[] { };
+                string[] detailedDisplays = new string[] { };
+                ombCodes = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.where(url = 'ombCategory').value.code");
+                detailedCodes = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.where(url = 'detailed').value.code");
+                ombDisplays = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.where(url = 'ombCategory').value.display");
+                detailedDisplays = GetAllString("Bundle.entry.resource.where($this is Patient).extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.where(url = 'detailed').value.display");
+                Tuple<string, string>[] raceList = new Tuple<string, string>[ombCodes.Length + detailedCodes.Length];
+                for (int i = 0; i < ombCodes.Length; i++)
                 {
-                    return races.ToArray();
-                }
-                foreach(string raceCode in raceCodes)
-                {
-                    Observation.ComponentComponent component = InputRaceandEthnicity.Component.Where(c => c.Code.Coding[0].Code == raceCode).FirstOrDefault();
-                    if (component != null)
+                    if (!String.IsNullOrWhiteSpace(MortalityData.RaceCodeToRaceName(ombCodes[i])))
                     {
-                        // convert boolean race codes to strings
-                        if (booleanRaceCodes.Contains(raceCode))
-                        {
-
-                            // Todo Find conversion from FhirBoolean to bool
-                            string raceBool = ((FhirBoolean)component.Value).ToString();
-
-                            if (Convert.ToBoolean(raceBool))
-                            {   
-                                var race = Tuple.Create(raceCode, "Y");
-                                races.Add(race);
-                            }
-                            else
-                            {
-                                var race = Tuple.Create(raceCode, "N");
-                                races.Add(race);
-                            } 
-                        }
-                        else
-                        {
-                            var race = Tuple.Create(raceCode, component.Value.ToString());
-                            races.Add(race);
-                        }
-
-                    }
-                }
-
-                return races.ToArray();
-            }
-            set
-            {
-                if (InputRaceandEthnicity == null)
-                {
-                    CreateRaceEthnicityObs();
-                }
-                var booleanRaceCodes = NvssRace.GetBooleanRaceCodes();
-                foreach (Tuple<string, string> element in value)
-                {
-                    InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == element.Item1);
-                    var coding = EmptyRaceEthnicityCodeDict();
-                    coding["code"] = element.Item1;
-                    coding["display"] = element.Item1;
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = DictToCodeableConcept(coding);
-                    if (booleanRaceCodes.Contains(element.Item1))
-                    {
-                        if (element.Item2 == "Y")
-                        {
-                            component.Value = new FhirBoolean(true);
-                        }
-                        else
-                        {
-                            component.Value = new FhirBoolean(false);
-                        }
+                        raceList[i] = (Tuple.Create(MortalityData.RaceCodeToRaceName(ombCodes[i]), String.IsNullOrWhiteSpace(ombCodes[i]) ? null : ombCodes[i]));
                     }
                     else
                     {
-                        component.Value = new FhirString(element.Item2);
+                        raceList[i] = (Tuple.Create(ombDisplays[i], String.IsNullOrWhiteSpace(ombCodes[i]) ? null : ombCodes[i]));
                     }
-                    InputRaceandEthnicity.Component.Add(component);
                 }
-
-            }
-        }
-
-        /// <summary>Decedent's Race MissingValueReason.</summary>
-        /// <value>why the decedent's race is missing. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; mvr = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>mvr.Add("code", "R");</para>
-        /// <para>mvr.Add("system", CodeSystems.MissingValueReason);</para>
-        /// <para>mvr.Add("display", "Refused");</para>
-        /// <para>ExampleDeathRecord.RaceMissingValueReason = mvr;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Missing Race: {ExampleDeathRecord.RaceMissingValueReason['display']}");</para>
-        /// </example>
-        [Property("RaceMissingValueReason", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Race MissingValueReason.", true, ProfileURL.InputRaceAndEthnicity, true, 38)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='MissingValueReason')", "")]
-        public Dictionary<string, string> RaceMissingValueReason
-        {
-            get
-            {
-                if (InputRaceandEthnicity != null)
+                for (int i = 0; i < detailedCodes.Length; i++)
                 {
-                    Observation.ComponentComponent raceMVR = InputRaceandEthnicity.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssRace.MissingValueReason);
-                    if (raceMVR != null && raceMVR.Value != null && raceMVR.Value as CodeableConcept != null)
+                    if (!String.IsNullOrWhiteSpace(MortalityData.RaceCodeToRaceName(detailedCodes[i])))
                     {
-                        return CodeableConceptToDict((CodeableConcept)raceMVR.Value);
+                        raceList[ombCodes.Length + i] = (Tuple.Create(MortalityData.RaceCodeToRaceName(detailedCodes[i]), String.IsNullOrWhiteSpace(detailedCodes[i]) ? null : detailedCodes[i]));
+                    }
+                    else
+                    {
+                        raceList[ombCodes.Length + i] = (Tuple.Create(detailedDisplays[i], String.IsNullOrWhiteSpace(detailedCodes[i]) ? null : detailedCodes[i]));
                     }
                 }
-                return EmptyCodeableDict();
+                return raceList;
             }
             set
             {
-                if (InputRaceandEthnicity == null)
+                Decedent.Extension.RemoveAll(ext => ext.Url == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
+                Extension races = new Extension();
+                races.Url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+                List<string> textRaceStrs = new List<string>();
+                foreach(Tuple<string,string> element in value)
                 {
-                    CreateRaceEthnicityObs();
+                    string display = element.Item1;
+                    string code = element.Item2;
+                    textRaceStrs.Add(display);
+                    Extension codeRace = new Extension();
+                    if (code == "1002-5" || code == "2028-9" || code == "2054-5" || code == "2076-8" || code == "2106-3")
+                    {
+                        codeRace.Url = "ombCategory";
+                    }
+                    else if (display.Equals("American Indian or Alaska Native", StringComparison.InvariantCultureIgnoreCase) ||
+                             display.Equals("Asian", StringComparison.InvariantCultureIgnoreCase) ||
+                             display.Equals("Black or African American", StringComparison.InvariantCultureIgnoreCase) ||
+                             display.Equals("Native Hawaiian or Other Pacific Islander", StringComparison.InvariantCultureIgnoreCase) ||
+                             display.Equals("White", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        codeRace.Url = "ombCategory";
+                    }
+                    else
+                    {
+                        codeRace.Url = "detailed";
+                    }
+                    Coding coding = new Coding();
+                    coding.System = CodeSystems.PH_RaceAndEthnicity_CDC;
+                    if (!String.IsNullOrWhiteSpace(code))
+                    {
+                        coding.Code = code;
+                    }
+                    if (!String.IsNullOrWhiteSpace(display))
+                    {
+                        coding.Display = display;
+                    }
+                    codeRace.Value = coding;
+                    races.Extension.Add(codeRace);
                 }
-                InputRaceandEthnicity.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssRace.MissingValueReason);
-                var coding = EmptyRaceEthnicityCodeDict();
-                coding["code"] = NvssRace.MissingValueReason;
-                coding["display"] = NvssRace.MissingValueReason;
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = DictToCodeableConcept(coding);
-                component.Value = DictToCodeableConcept(value);
-                InputRaceandEthnicity.Component.Add(component);
+                Extension textRace = new Extension();
+                textRace.Url = "text";
+                textRace.Value = new FhirString(String.Join(", ", textRaceStrs));
+                races.Extension.Add(textRace);
+                Decedent.Extension.Add(races);
             }
         }
 
-
-        /// <summary>Decedent's RaceMissingValueReason</summary>
-        /// <value>Decedent's RaceMissingValueReason.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.RaceMissingValueReasonHelper = VRDR.ValueSets.RaceMissingValueReason.R;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's RaceMissingValueReason: {ExampleDeathRecord.RaceMissingValueReasonHelper}");</para>
-        /// </example>
-        [Property("RaceMissingValueReason", Property.Types.TupleArr, "Decedent Demographics", "Decedent's Race MissingValueReason.", true, ProfileURL.InputRaceAndEthnicity, true, 38)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='MissingValueReason')", "")]
-        public string RaceMissingValueReasonHelper
-        {
-            get
-            {
-                if (RaceMissingValueReason.ContainsKey("code"))
-                {
-                    return RaceMissingValueReason["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("RaceMissingValueReason", value, VRDR.ValueSets.RaceMissingValueReason.Codes);
-            }
-        }
-       
         /// <summary>Decedent's Place Of Birth.</summary>
         /// <value>decedent's Place Of Birth. A Dictionary representing residence address, containing the following key/value pairs:
         /// <para>"addressLine1" - address, line one</para>
@@ -3304,7 +3608,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"State where decedent was born: {ExampleDeathRecord.PlaceOfBirth["placeOfBirthState"]}");</para>
         /// </example>
-        [Property("Place Of Birth", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Place Of Birth.", true, ProfileURL.Decedent, true, 15)]
+        [Property("Place Of Birth", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Place Of Birth.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 15)]
         [PropertyParam("addressLine1", "address, line one")]
         [PropertyParam("addressLine2", "address, line two")]
         [PropertyParam("addressCity", "address, city")]
@@ -3339,41 +3643,6 @@ namespace VRDR
             }
         }
 
-        /// <summary>The informant of the decedent's death.</summary>
-        /// <value>String representation of the informant's relationship to the decedent
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.Contact = "Friend of family";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Contact's Relationship: {ExampleDeathRecord.Contact}");</para>
-        /// </example>
-        [Property("Contact Relationship", Property.Types.Dictionary, "Decedent Demographics", "The informant's relationship to the decedent", true, ProfileURL.Decedent, true, 24)]
-        [PropertyParam("relationship", "The relationship to the decedent.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "contact")]
-        public Dictionary<string, string> ContactRelationship
-        {
-            get
-            {
-                if (Decedent != null && Decedent.Contact != null)
-                {
-                    var contact = Decedent.Contact.FirstOrDefault();
-                    if (contact != null && contact.Relationship != null)
-                    {
-                        return CodeableConceptToDict(contact.Relationship.FirstOrDefault());
-                    }
-                }
-                return null;
-            }
-            set
-            {
-                Patient.ContactComponent component = new Patient.ContactComponent();
-                component.Relationship.Add(DictToCodeableConcept(value));
-                Decedent.Contact.Add(component);
-            }
-        }
-
-
         /// <summary>The marital status of the decedent at the time of death.</summary>
         /// <value>the marital status of the decedent at the time of death. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code describing this finding</para>
@@ -3390,7 +3659,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Marital status: {ExampleDeathRecord.MaritalStatus["display"]}");</para>
         /// </example>
-        [Property("Marital Status", Property.Types.Dictionary, "Decedent Demographics", "The marital status of the decedent at the time of death.", true, ProfileURL.Decedent, true, 24)]
+        [Property("Marital Status", Property.Types.Dictionary, "Decedent Demographics", "The marital status of the decedent at the time of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 24)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -3399,76 +3668,16 @@ namespace VRDR
         {
             get
             {
-                if (Decedent != null && Decedent.MaritalStatus != null && Decedent.MaritalStatus as CodeableConcept != null)
+                if (Decedent != null && Decedent.MaritalStatus != null)
                 {
-                    return CodeableConceptToDict((CodeableConcept)Decedent.MaritalStatus);
+                    return CodeableConceptToDict(Decedent.MaritalStatus);
                 }
                 return EmptyCodeDict();
             }
             set
             {
-                if (Decedent.MaritalStatus == null)
-                {
-                    Decedent.MaritalStatus = DictToCodeableConcept(value);
-                }
-                else 
-                {
-                    string text = Decedent.MaritalStatus.Text;
-                    Extension bypass = Decedent.MaritalStatus.Extension.FirstOrDefault();
-                    Decedent.MaritalStatus = DictToCodeableConcept(value);
-                    Decedent.MaritalStatus.Extension.Add(bypass);
-                    Decedent.MaritalStatus.Text = text;
-                }
-                
+                Decedent.MaritalStatus = DictToCodeableConcept(value);
             }
-        }
-
-        /// <summary>The marital status edit flag.</summary>
-        /// <value>the marital status edit flag
-        /// <para>"code" - the code describing this finding</para>
-        /// <para>"system" - the system the given code belongs to</para>
-        /// <para>"display" - the human readable display text that corresponds to the given code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "S");</para>
-        /// <para>code.Add("system", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus");</para>
-        /// <para>code.Add("display", "Never Married");</para>
-        /// <para>ExampleDeathRecord.MaritalStatus = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Marital status: {ExampleDeathRecord.MaritalStatus["display"]}");</para>
-        /// </example>
-        [Property("Marital Status Bypass", Property.Types.Dictionary, "Decedent Demographics", "The marital status edit flag.", true, ProfileURL.Decedent, true, 24)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "maritalStatus")]
-        public Dictionary<string, string> MaritalBypass
-        {
-            get
-            {
-                if (Decedent.MaritalStatus != null && Decedent.MaritalStatus.Extension.FirstOrDefault() != null)
-                {
-                    Extension addressExt = Decedent.MaritalStatus.Extension.FirstOrDefault(extension => extension.Url == ExtensionURL.BypassEditFlag);
-                    if (addressExt != null && addressExt.Value != null && addressExt.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)addressExt.Value);
-                    }
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                Extension ext = new Extension();
-                ext.Url = ExtensionURL.BypassEditFlag;
-                ext.Value = DictToCodeableConcept(value);
-                if (Decedent.MaritalStatus == null){
-                    Decedent.MaritalStatus = new CodeableConcept();
-                }
-                Decedent.MaritalStatus.Extension.Add(ext);
-            }
-
         }
 
         /// <summary>The marital status of the decedent at the time of death helper method.</summary>
@@ -3481,7 +3690,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Marital status: {ExampleDeathRecord.MaritalStatusHelper}");</para>
         /// </example>
-        [Property("Marital Status", Property.Types.String, "Decedent Demographics", "The marital status of the decedent at the time of death.", true, ProfileURL.Decedent, true, 24)]
+        [Property("Marital Status", Property.Types.String, "Decedent Demographics", "The marital status of the decedent at the time of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent.html", true, 24)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "maritalStatus")]
         public string MaritalStatusHelper
@@ -3497,68 +3706,6 @@ namespace VRDR
             set
             {
                 SetCodeValue("MaritalStatus", value, VRDR.ValueSets.MaritalStatus.Codes);
-            }
-        }
-
-        /// <summary>The marital bypass helper method.</summary>
-        /// <value>the marital pass.:
-        /// <para>"code" - the code describing this finding</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.MaritalBypassHelper = ValueSets.EditBypass0124.0;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Marital status: {ExampleDeathRecord.MaritalBypassHelper}");</para>
-        /// </example>
-        [Property("Marital Bypass", Property.Types.String, "Decedent Demographics", "The marital bypass.", true, ProfileURL.Decedent, true, 24)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "maritalStatus")]
-        public string MaritalBypassHelper
-        {
-            get
-            {
-                if (MaritalBypass.ContainsKey("code"))
-                {
-                    return MaritalBypass["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("MaritalBypass", value, VRDR.ValueSets.EditBypass0124.Codes);
-            }
-        }
-
-        /// <summary>The literal text string of the marital status of the decedent at the time of death.</summary>
-        /// <value>the marital status of the decedent at the time of death. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"text" - the code describing this finding</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.MaritalStatusLiteral = "Single";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Marital status: {ExampleDeathRecord.MaritalStatusLiteral}");</para>
-        /// </example>
-        [Property("Marital Status Literal", Property.Types.String, "Decedent Demographics", "The marital status of the decedent at the time of death.", true, ProfileURL.Decedent, true, 24)]
-        [PropertyParam("text", "The literal string")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "maritalStatus")]
-        public string MaritalStatusLiteral
-        {
-            get
-            {
-                if (Decedent != null && Decedent.MaritalStatus != null && Decedent.MaritalStatus.Text != null)
-                {
-                    return Decedent.MaritalStatus.Text;
-                }
-                return "";
-            }
-            set
-            {
-                if (Decedent.MaritalStatus == null)
-                {
-                    Decedent.MaritalStatus = new CodeableConcept();
-                }
-                Decedent.MaritalStatus.Text = value;  
             }
         }
 
@@ -3960,7 +4107,7 @@ namespace VRDR
         /// </example>
         [Property("Spouse Maiden Name", Property.Types.String, "Decedent Demographics", "Spouse's Maiden Name.", true, IGURL.DecedentSpouse, false, 27)]
         [FHIRPath("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='SPS').name.where(use='maiden')", "family")]
-        public string SpouseMaidenName
+public string SpouseMaidenName
         {
             get
             {
@@ -3990,74 +4137,6 @@ namespace VRDR
                 }
             }
         }
-        /// <summary>Spouse Alive.</summary>
-        /// <value>whether the decedent's spouse is alive
-        /// <para>"code" - the code describing this finding</para>
-        /// <para>"system" - the system the given code belongs to</para>
-        /// <para>"display" - the human readable display text that corresponds to the given code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "Y");</para>
-        /// <para>code.Add("system", "http://terminology.hl7.org/CodeSystem/v2-0136");</para>
-        /// <para>code.Add("display", "Yes");</para>
-        /// <para>ExampleDeathRecord.SpouseAlive = code;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Marital status: {ExampleDeathRecord.SpouseAlive["display"]}");</para>
-        /// </example>
-        [Property("Spouse Alive", Property.Types.Dictionary, "Decedent Demographics", "Spouse Alive", true, ProfileURL.Decedent, false, 27)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "")]
-        public Dictionary<string, string> SpouseAlive
-        {
-            get
-            {
-                Extension spouseExt = Decedent.Extension.FirstOrDefault( extension => extension.Url == ExtensionURL.SpouseAlive);
-                if (spouseExt != null && spouseExt.Value != null && spouseExt.Value as CodeableConcept != null) {
-
-                    return CodeableConceptToDict((CodeableConcept)spouseExt.Value);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-
-                Extension ext = new Extension();
-                ext.Url = ExtensionURL.SpouseAlive;
-                ext.Value = DictToCodeableConcept(value);
-                Decedent.Extension.Add(ext);
-            }
-        }
-
-        /// <summary>Decedent's SpouseAlive</summary>
-        /// <value>Decedent's SpouseAlive.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.SpouseAliveHelper = VRDR.ValueSets.YesNoUnknownNotApplicable.Y;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's RaceMissingValueReason: {ExampleDeathRecord.RaceMissingValueReasonHelper}");</para>
-        /// </example>
-        [Property("Spouse Alive", Property.Types.String, "Decedent Demographics", "Spouse Alive", true, ProfileURL.Decedent, false, 27)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "")]
-        public string SpouseAliveHelper
-        {
-            get
-            {
-                if (SpouseAlive.ContainsKey("code"))
-                {
-                    return SpouseAlive["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("SpouseAlive", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
-            }
-        }
-
         /// <summary>Create an empty EducationLevel Observation, to be populated in either EducationLevel or EducationLevelEditFlag.</summary>
         private void CreateEmptyEducationLevelObservation()
         {
@@ -4113,7 +4192,6 @@ namespace VRDR
                 DecedentEducationLevel.Value = DictToCodeableConcept(value);
             }
         }
-
         /// <summary>Decedent's Education Level Helper</summary>
         /// <value>Decedent's Education Level.</value>
         /// <example>
@@ -4169,13 +4247,13 @@ namespace VRDR
             {
                 if (DecedentEducationLevel != null && DecedentEducationLevel.Extension != null)
                 {
-                    Extension editFlag = DecedentEducationLevel.Value.Extension.FirstOrDefault(extension => extension.Url == ExtensionURL.BypassEditFlag);
+                    Extension editFlag = DecedentEducationLevel.Extension.FirstOrDefault(extension => extension.Url == ExtensionURL.BypassEditFlag);
                     if (editFlag != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)editFlag.Value);
                     }
                 }
-                return EmptyCodeableDict();
+                return EmptyCodeDict();
             }
             set
             {
@@ -4183,16 +4261,11 @@ namespace VRDR
                 {
                     CreateEmptyEducationLevelObservation();
                 }
-                if (DecedentEducationLevel.Value != null && DecedentEducationLevel.Value.Extension != null){
-                    DecedentEducationLevel.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
-                }
+                DecedentEducationLevel.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
                 Extension editFlag = new Extension();
                 editFlag.Url = ExtensionURL.BypassEditFlag;
-                if(DecedentEducationLevel.Value == null){
-                    DecedentEducationLevel.Value = new CodeableConcept();
-                }
                 editFlag.Value = DictToCodeableConcept(value);
-                DecedentEducationLevel.Value.Extension.Add(editFlag);
+                DecedentEducationLevel.Extension.Add(editFlag);
             }
         }
 
@@ -4471,6 +4544,7 @@ namespace VRDR
                 }
             }
         }
+
         /// <summary>Decedent's Usual Occupation (Code).</summary>
         /// <value>the decedent's usual occupation. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
@@ -4487,7 +4561,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Usual Occupation: {ExampleDeathRecord.UsualOccupationCode['display']}");</para>
         /// </example>
-        [Property("Usual Occupation (Code)", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Usual Occupation.", false, IGURL.DecedentUsualWork, false, 39)]
+        [Property("Usual Occupation (Code)", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Usual Occupation.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Usual-Work.html", false, 39)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -4507,10 +4581,23 @@ namespace VRDR
             {
                 if (UsualWork == null)
                 {
-                    CreateUsualWork();
+                    UsualWork = new Observation();
+                    UsualWork.Id = Guid.NewGuid().ToString();
+                    UsualWork.Meta = new Meta();
+                    string[] usualwork_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Usual-Work" };
+                    UsualWork.Meta.Profile = usualwork_profile;
+                    UsualWork.Status = ObservationStatus.Final;
+                    UsualWork.Code = new CodeableConcept(CodeSystems.LOINC, "21843-8", "History of Usual occupation", null);
+                    UsualWork.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    UsualWork.Effective = new Period();
+                    UsualWork.Value = DictToCodeableConcept(value);
+                    AddReferenceToComposition(UsualWork.Id);
+                    Bundle.AddResourceEntry(UsualWork, "urn:uuid:" + UsualWork.Id);
                 }
-                UsualWork.Value = DictToCodeableConcept(value);
-
+                else
+                {
+                    UsualWork.Value = DictToCodeableConcept(value);
+                }
             }
         }
 
@@ -4522,7 +4609,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Usual Occupation: {ExampleDeathRecord.UsualOccupation}");</para>
         /// </example>
-        [Property("Usual Occupation (Text)", Property.Types.String, "Decedent Demographics", "Decedent's Usual Occupation.", true, IGURL.DecedentUsualWork, true, 40)]
+        [Property("Usual Occupation (Text)", Property.Types.String, "Decedent Demographics", "Decedent's Usual Occupation.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Usual-Work.html", true, 40)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
         public string UsualOccupation
         {
@@ -4554,7 +4641,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Start of Usual Occupation: {ExampleDeathRecord.UsualOccupationStart}");</para>
         /// </example>
-        [Property("Usual Occupation Start Date", Property.Types.StringDateTime, "Decedent Demographics", "Decedent's Usual Occupation.", true, IGURL.DecedentUsualWork, true, 41)]
+        [Property("Usual Occupation Start Date", Property.Types.StringDateTime, "Decedent Demographics", "Decedent's Usual Occupation.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Usual-Work.html", true, 41)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
         public string UsualOccupationStart
         {
@@ -4570,12 +4657,25 @@ namespace VRDR
             {
                 if (UsualWork == null)
                 {
-                    CreateUsualWork();
+                    UsualWork = new Observation();
+                    UsualWork.Id = Guid.NewGuid().ToString();
+                    UsualWork.Meta = new Meta();
+                    string[] usualwork_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Usual-Work" };
+                    UsualWork.Meta.Profile = usualwork_profile;
+                    UsualWork.Status = ObservationStatus.Final;
+                    UsualWork.Code = new CodeableConcept(CodeSystems.LOINC, "21843-8", "History of Usual occupation", null);
+                    UsualWork.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
                     UsualWork.Effective = new Period(new FhirDateTime(value), null);
+                    AddReferenceToComposition(UsualWork.Id);
+                    Bundle.AddResourceEntry(UsualWork, "urn:uuid:" + UsualWork.Id);
                 }
-                if (UsualWork.Effective as Period != null)
+                else if (UsualWork.Effective as Period != null)
                 {
                     ((Period)UsualWork.Effective).Start = value;
+                }
+                else
+                {
+                    UsualWork.Effective = new Period(new FhirDateTime(value), null);
                 }
             }
         }
@@ -4588,7 +4688,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"End of Usual Occupation: {ExampleDeathRecord.UsualOccupationEnd}");</para>
         /// </example>
-        [Property("Usual Occupation End Date", Property.Types.StringDateTime, "Decedent Demographics", "Decedent's Usual Occupation.", true, IGURL.DecedentUsualWork, true, 42)]
+        [Property("Usual Occupation End Date", Property.Types.StringDateTime, "Decedent Demographics", "Decedent's Usual Occupation.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Usual-Work.html", true, 42)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
         public string UsualOccupationEnd
         {
@@ -4604,15 +4704,29 @@ namespace VRDR
             {
                 if (UsualWork == null)
                 {
-                    CreateUsualWork();
+                    UsualWork = new Observation();
+                    UsualWork.Id = Guid.NewGuid().ToString();
+                    UsualWork.Meta = new Meta();
+                    string[] usualwork_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Usual-Work" };
+                    UsualWork.Meta.Profile = usualwork_profile;
+                    UsualWork.Status = ObservationStatus.Final;
+                    UsualWork.Code = new CodeableConcept(CodeSystems.LOINC, "21843-8", "History of Usual occupation", null);
+                    UsualWork.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
                     UsualWork.Effective = new Period(null, new FhirDateTime(value));
+                    AddReferenceToComposition(UsualWork.Id);
+                    Bundle.AddResourceEntry(UsualWork, "urn:uuid:" + UsualWork.Id);
                 }
-                if (UsualWork.Effective as Period != null)
+                else if (UsualWork.Effective as Period != null)
                 {
                     ((Period)UsualWork.Effective).End = value;
                 }
+                else
+                {
+                    UsualWork.Effective = new Period(null, new FhirDateTime(value));
+                }
             }
         }
+
         /// <summary>Decedent's Usual Industry (Code).</summary>
         /// <value>the decedent's usual industry. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
@@ -4629,7 +4743,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Usual Industry: {ExampleDeathRecord.UsualIndustryCode['display']}");</para>
         /// </example>
-        [Property("Usual Industry (Code)", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Usual Industry.", false, IGURL.DecedentUsualWork, false, 43)]
+        [Property("Usual Industry (Code)", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Usual Industry.", false, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Usual-Work.html", false, 43)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -4653,16 +4767,30 @@ namespace VRDR
             {
                 if (UsualWork == null)
                 {
-                    CreateUsualWork();
+                    UsualWork = new Observation();
+                    UsualWork.Id = Guid.NewGuid().ToString();
+                    UsualWork.Meta = new Meta();
+                    string[] employmenthistory_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Employment-History" };
+                    UsualWork.Meta.Profile = employmenthistory_profile;
+                    UsualWork.Status = ObservationStatus.Final;
+                    UsualWork.Code = new CodeableConcept(CodeSystems.LOINC, "21843-8", "History of Usual occupation", null);
+                    UsualWork.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    UsualWork.Effective = new Period();
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
+                    component.Value = DictToCodeableConcept(value);
+                    UsualWork.Component.Add(component);
+                    AddReferenceToComposition(UsualWork.Id);
+                    Bundle.AddResourceEntry(UsualWork, "urn:uuid:" + UsualWork.Id);
                 }
-
-                UsualWork.Component.RemoveAll( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6" );
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
-
-                component.Value = DictToCodeableConcept(value);
-                UsualWork.Component.Add(component);
-
+                else
+                {
+                    UsualWork.Component.RemoveAll( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6" );
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
+                    component.Value = DictToCodeableConcept(value);
+                    UsualWork.Component.Add(component);
+                }
             }
         }
 
@@ -4674,7 +4802,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Usual Industry: {ExampleDeathRecord.UsualIndustry}");</para>
         /// </example>
-        [Property("Usual Industry (Text)", Property.Types.String, "Decedent Demographics", "Decedent's Usual Industry.", true, IGURL.DecedentUsualWork, true, 44)]
+        [Property("Usual Industry (Text)", Property.Types.String, "Decedent Demographics", "Decedent's Usual Industry.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Usual-Work.html", true, 44)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
         public string UsualIndustry
         {
@@ -4736,7 +4864,7 @@ namespace VRDR
                     MilitaryServiceObs = new Observation();
                     MilitaryServiceObs.Id = Guid.NewGuid().ToString();
                     MilitaryServiceObs.Meta = new Meta();
-                    string[] militaryhistory_profile = { ProfileURL.DecedentMilitaryService };
+                    string[] militaryhistory_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Military-Service" };
                     MilitaryServiceObs.Meta.Profile = militaryhistory_profile;
                     MilitaryServiceObs.Status = ObservationStatus.Final;
                     MilitaryServiceObs.Code = new CodeableConcept(CodeSystems.LOINC, "55280-2", "Military service Narrative", null);
@@ -4756,25 +4884,49 @@ namespace VRDR
         /// <value>the decedent's military service. Whether the decedent served in the military, a null value means "unknown".</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.MilitaryServiceHelper = Y;</para>
+        /// <para>ExampleDeathRecord.MilitaryServiceBoolean = true;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Military Service: {ExampleDeathRecord.MilitaryServiceHelper}");</para>
+        /// <para>Console.WriteLine($"Military Service: {ExampleDeathRecord.MilitaryServiceBoolean}");</para>
         /// </example>
-        [Property("Military Service Helper", Property.Types.String, "Decedent Demographics", "Decedent's Military Service.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Military-Service.html", false, 23)]
+        [Property("Military Service Boolean", Property.Types.Bool, "Decedent Demographics", "Decedent's Military Service.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Military-Service.html", false, 23)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='55280-2')", "")]
-         public string MilitaryServiceHelper
+        public bool? MilitaryServiceBoolean
         {
             get
             {
-                if (MilitaryService.ContainsKey("code"))
+                var code = this.MilitaryService;
+                switch (code["code"])
                 {
-                    return(MilitaryService["code"]);
+                    case "Y": // Yes
+                        return true;
+                    case "N": // No
+                        return false;
+                    default: // Unknown
+                        return null;
                 }
-                return null;
             }
             set
             {
-                SetCodeValue("MilitaryService", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                var code = EmptyCodeDict();
+                switch(value)
+                {
+                    case true:
+                        code["code"] = "Y";
+                        code["display"] = "Yes";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    case false:
+                        code["code"] = "N";
+                        code["display"] = "No";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    default:
+                        code["code"] = "UNK";
+                        code["display"] = "unknown";
+                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
+                        break;
+                }
+                this.MilitaryService = code;
             }
         }
 
@@ -5382,14 +5534,26 @@ namespace VRDR
             {
                 if (AutopsyPerformed == null)
                 {
-                    CreateAutopsyPerformed();
+                    AutopsyPerformed = new Observation();
+                    AutopsyPerformed.Id = Guid.NewGuid().ToString();
+                    AutopsyPerformed.Meta = new Meta();
+                    string[] autopsyperformed_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator" };
+                    AutopsyPerformed.Meta.Profile = autopsyperformed_profile;
+                    AutopsyPerformed.Status = ObservationStatus.Final;
+                    AutopsyPerformed.Code = new CodeableConcept(CodeSystems.LOINC, "85699-7", "Autopsy was performed", null);
+                    AutopsyPerformed.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    AutopsyPerformed.Value = DictToCodeableConcept(value);
+                    AddReferenceToComposition(AutopsyPerformed.Id);
+                    Bundle.AddResourceEntry(AutopsyPerformed, "urn:uuid:" + AutopsyPerformed.Id);
                 }
-
-                AutopsyPerformed.Value = DictToCodeableConcept(value);
+                else
+                {
+                    AutopsyPerformed.Value = DictToCodeableConcept(value);
+                }
             }
         }
 
-        /// <summary>Autopsy Performed Indicator Helper. This is a helper method, to access the code use the AutopsyPerformedIndicator property.</summary>
+        /// <summary>Autopsy Performed Indicator Boolean. This is a helper method, to access the code use the AutopsyPerformedIndicator property.</summary>
         /// <value>autopsy performed indicator. A null value indicates "not applicable".</value>
         /// <example>
         /// <para>// Setter:</para>
@@ -5397,21 +5561,45 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Autopsy Performed Indicator: {ExampleDeathRecord.AutopsyPerformedIndicatorBoolean}");</para>
         /// </example>
-        [Property("Autopsy Performed Indicator Helper", Property.Types.String, "Death Investigation", "Autopsy Performed Indicator.", true, IGURL.AutopsyPerformedIndicator, true, 29)]
+        [Property("Autopsy Performed Indicator Boolean", Property.Types.Bool, "Death Investigation", "Autopsy Performed Indicator.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Autopsy-Performed-Indicator.html", true, 29)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='85699-7')", "")]
-        public string AutopsyPerformedIndicatorHelper
+        public bool? AutopsyPerformedIndicatorBoolean
         {
             get
             {
-                if (AutopsyPerformedIndicator.ContainsKey("code"))
+                var code = this.AutopsyPerformedIndicator;
+                switch (code["code"])
                 {
-                    return AutopsyPerformedIndicator["code"];
+                    case "Y": // Yes
+                        return true;
+                    case "N": // No
+                        return false;
+                    default: // Not applicable
+                        return null;
                 }
-                return null;
             }
             set
             {
-                SetCodeValue("AutopsyPerformedIndicator", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                var code = EmptyCodeDict();
+                switch(value)
+                {
+                    case true:
+                        code["code"] = "Y";
+                        code["display"] = "Yes";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    case false:
+                        code["code"] = "N";
+                        code["display"] = "No";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    default:
+                        code["code"] = "NA";
+                        code["display"] = "not applicable";
+                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
+                        break;
+                }
+                this.AutopsyPerformedIndicator = code;
             }
         }
 
@@ -5756,39 +5944,80 @@ namespace VRDR
             {
                 if (AutopsyPerformed == null)
                 {
-                    CreateAutopsyPerformed();
+                    AutopsyPerformed = new Observation();
+                    AutopsyPerformed.Id = Guid.NewGuid().ToString();
+                    AutopsyPerformed.Meta = new Meta();
+                    string[] autopsyperformed_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator" };
+                    AutopsyPerformed.Meta.Profile = autopsyperformed_profile;
+                    AutopsyPerformed.Status = ObservationStatus.Final;
+                    AutopsyPerformed.Code = new CodeableConcept(CodeSystems.LOINC, "85699-7", "Autopsy was performed", null);
+                    AutopsyPerformed.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69436-4", "Autopsy results available", null);
+                    component.Value = DictToCodeableConcept(value);
+                    AutopsyPerformed.Component.Clear();
+                    AutopsyPerformed.Component.Add(component);
+                    AddReferenceToComposition(AutopsyPerformed.Id);
+                    Bundle.AddResourceEntry(AutopsyPerformed, "urn:uuid:" + AutopsyPerformed.Id);
                 }
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = new CodeableConcept(CodeSystems.LOINC, "69436-4", "Autopsy results available", null);
-                component.Value = DictToCodeableConcept(value);
-                AutopsyPerformed.Component.Clear();
-                AutopsyPerformed.Component.Add(component);
+                else
+                {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69436-4", "Autopsy results available", null);
+                    component.Value = DictToCodeableConcept(value);
+                    AutopsyPerformed.Component.Clear();
+                    AutopsyPerformed.Component.Add(component);
+                }
             }
         }
 
-        /// <summary>Autopsy Results Available Helper. This is a convenience method, to access the coded value use AutopsyResultsAvailable.</summary>
+        /// <summary>Autopsy Results Available Boolean. This is a convenience method, to access the coded value use AutopsyResultsAvailable.</summary>
         /// <value>autopsy results available. A null value indicates "not applicable".</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.AutopsyResultsAvailableHelper = "N";</para>
+        /// <para>ExampleDeathRecord.AutopsyResultsAvailableBoolean = false;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Autopsy Results Available: {ExampleDeathRecord.AutopsyResultsAvailableHelper}");</para>
+        /// <para>Console.WriteLine($"Autopsy Results Available: {ExampleDeathRecord.AutopsyResultsAvailableBoolean}");</para>
         /// </example>
-        [Property("Autopsy Results Available Helper", Property.Types.String, "Death Investigation", "Autopsy results available, used to complete cause of death.", true, IGURL.AutopsyPerformedIndicator, true, 31)]
+        [Property("Autopsy Results Available Boolean", Property.Types.Bool, "Death Investigation", "Autopsy results available, used to complete cause of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Autopsy-Performed-Indicator.html", true, 31)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='85699-7')", "")]
-        public string AutopsyResultsAvailableHelper
+        public bool? AutopsyResultsAvailableBoolean
         {
             get
             {
-                if (AutopsyResultsAvailable.ContainsKey("code"))
+                var code = this.AutopsyResultsAvailable;
+                switch (code["code"])
                 {
-                    return AutopsyResultsAvailable["code"];
+                    case "Y": // Yes
+                        return true;
+                    case "N": // No
+                        return false;
+                    default: // Not applicable
+                        return null;
                 }
-                return null;
             }
             set
             {
-                SetCodeValue("AutopsyResultsAvailable", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                var code = EmptyCodeDict();
+                switch(value)
+                {
+                    case true:
+                        code["code"] = "Y";
+                        code["display"] = "Yes";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    case false:
+                        code["code"] = "N";
+                        code["display"] = "No";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    default:
+                        code["code"] = "NA";
+                        code["display"] = "not applicable";
+                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
+                        break;
+                }
+                this.AutopsyResultsAvailable = code;
             }
         }
 
@@ -6225,12 +6454,12 @@ namespace VRDR
         /// <example>
         /// <para>// Setter:</para>
         /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>code.Add("code", "1");</para>
-        /// <para>code.Add("system", VRDR.CodeSystems.PregnancyStatus);</para>
+        /// <para>code.Add("code", "PHC1260");</para>
+        /// <para>code.Add("system", "urn:oid:2.16.840.1.114222.4.5.274");</para>
         /// <para>code.Add("display", "Not pregnant within past year");</para>
-        /// <para>ExampleDeathRecord.PregnancyObs = code;</para>
+        /// <para>ExampleDeathRecord.PregnancyStatus = code;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Pregnancy Status: {ExampleDeathRecord.PregnancyObs['display']}");</para>
+        /// <para>Console.WriteLine($"Pregnancy Status: {ExampleDeathRecord.PregnancyStatus['display']}");</para>
         /// </example>
         [Property("Pregnancy Status", Property.Types.Dictionary, "Death Investigation", "Pregnancy Status At Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Pregnancy.html", true, 33)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -6251,9 +6480,22 @@ namespace VRDR
             {
                 if (PregnancyObs == null)
                 {
-                    CreatePregnancyObs();
+                    PregnancyObs = new Observation();
+                    PregnancyObs.Id = Guid.NewGuid().ToString();
+                    PregnancyObs.Meta = new Meta();
+                    string[] p_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy" };
+                    PregnancyObs.Meta.Profile = p_profile;
+                    PregnancyObs.Status = ObservationStatus.Final;
+                    PregnancyObs.Code = new CodeableConcept(CodeSystems.LOINC, "69442-2", "Timing of recent pregnancy in relation to death", null);
+                    PregnancyObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    PregnancyObs.Value = DictToCodeableConcept(value);
+                    AddReferenceToComposition(PregnancyObs.Id);
+                    Bundle.AddResourceEntry(PregnancyObs, "urn:uuid:" + PregnancyObs.Id);
                 }
-                PregnancyObs.Value = DictToCodeableConcept(value);
+                else
+                {
+                    PregnancyObs.Value = DictToCodeableConcept(value);
+                }
             }
         }
 
@@ -6285,89 +6527,6 @@ namespace VRDR
                 SetCodeValue("PregnancyStatus", value, VRDR.ValueSets.PregnancyStatus.Codes);
             }
         }
-        /// <summary>Decedent's Pregnancy Status at Death Edit Flag.</summary>
-        /// <value>the decedent's pregnancy status at death edit flag. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>elevel.Add("code", "0");</para>
-        /// <para>elevel.Add("system", CodeSystems.BypassEditFlag);</para>
-        /// <para>elevel.Add("display", "Edit Passed");</para>
-        /// <para>ExampleDeathRecord.EducationLevelEditFlag = elevel;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Education Level Edit Flag: {ExampleDeathRecord.EducationLevelEditFlag['display']}");</para>
-        /// </example>
-        // TODO: This URL should be the html one, and those should be generated as well
-        [Property("Decedent's Pregnancy Status at Death Edit Flag", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Decedent's Pregnancy Status at Death Edit Flag.", true, IGURL.DecedentPregnancyStatus, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69442-2')", "")]
-        public Dictionary<string, string> PregnancyStatusEditFlag
-        {
-            get
-            {
-                if (PregnancyObs != null && PregnancyObs.Value != null && PregnancyObs.Value.Extension != null)
-                {
-                    Extension editFlag = PregnancyObs.Value.Extension.FirstOrDefault(extension => extension.Url == ExtensionURL.BypassEditFlag);
-                    if (editFlag != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)editFlag.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (PregnancyObs == null)
-                {
-                    CreatePregnancyObs();
-                }
-                if (PregnancyObs.Value != null && PregnancyObs.Value.Extension != null){
-                    PregnancyObs.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
-                }
-                Extension editFlag = new Extension();
-                editFlag.Url = ExtensionURL.BypassEditFlag;
-                editFlag.Value = DictToCodeableConcept(value);
-                if(PregnancyObs.Value == null){
-                    PregnancyObs.Value = new CodeableConcept();
-                }
-                PregnancyObs.Value.Extension.Add(editFlag);
-            }
-        }
-
-        /// <summary>Decedent's Pregnancy Status Edit Flag Helper</summary>
-        /// <value>Decedent's Pregnancy Status Edit Flag.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.DecedentPregnancyStatusEditFlag = VRDR.ValueSets.EditBypass012.EditPassed;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Decedent's Pregnancy Status Edit Flag: {ExampleDeathRecord.PregnancyStatusHelperEditFlag}");</para>
-        /// </example>
-        [Property("Pregnancy Status Edit Flag", Property.Types.String, "Decedent Demographics", "Decedent's Pregnancy Status Edit Flag.", true, IGURL.DecedentPregnancyStatus, false, 34)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69442-2')", "")]
-        public string PregnancyStatusEditFlagHelper
-        {
-            get
-            {
-                if (PregnancyStatusEditFlag.ContainsKey("code"))
-                {
-                    return PregnancyStatusEditFlag["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("PregnancyStatusEditFlag", value, VRDR.ValueSets.EditBypass012.Codes);
-            }
-        }
-
-
         /// <summary>Examiner Contacted.</summary>
         /// <value>if a medical examiner was contacted.</value>
         /// <example>
@@ -6380,7 +6539,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted['display']}");</para>
         /// </example>
-        [Property("Examiner Contacted", Property.Types.Dictionary, "Death Investigation", "Examiner Contacted.", true, IGURL.ExaminerContacted, true, 26)]
+        [Property("Examiner Contacted", Property.Types.Dictionary, "Death Investigation", "Examiner Contacted.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Examiner-Contacted.html", true, 26)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6404,7 +6563,7 @@ namespace VRDR
                     ExaminerContactedObs = new Observation();
                     ExaminerContactedObs.Id = Guid.NewGuid().ToString();
                     ExaminerContactedObs.Meta = new Meta();
-                    string[] ec_profile = { ProfileURL.ExaminerContacted };
+                    string[] ec_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted" };
                     ExaminerContactedObs.Meta.Profile = ec_profile;
                     ExaminerContactedObs.Status = ObservationStatus.Final;
                     ExaminerContactedObs.Code = new CodeableConcept(CodeSystems.LOINC, "74497-9", "Medical examiner or coroner was contacted [US Standard Certificate of Death]", null);
@@ -6428,21 +6587,45 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Examiner Contacted: {ExampleDeathRecord.ExaminerContacted}");</para>
         /// </example>
-        [Property("Examiner Contacted Helper", Property.Types.String, "Death Investigation", "Examiner Contacted.", true, IGURL.ExaminerContacted, true, 27)]
+        [Property("Examiner Contacted Boolean", Property.Types.Bool, "Death Investigation", "Examiner Contacted.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Examiner-Contacted.html", true, 27)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='74497-9')", "")]
-        public string ExaminerContactedHelper
+        public bool? ExaminerContactedBoolean
         {
             get
             {
-                if (ExaminerContacted.ContainsKey("code"))
+                var code = this.ExaminerContacted;
+                switch (code["code"])
                 {
-                    return ExaminerContacted["code"];
+                    case "Y": // Yes
+                        return true;
+                    case "N": // No
+                        return false;
+                    default: // Unknown
+                        return null;
                 }
-                return null;
             }
             set
             {
-                SetCodeValue("ExaminerContacted", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                var code = EmptyCodeDict();
+                switch(value)
+                {
+                    case true:
+                        code["code"] = "Y";
+                        code["display"] = "Yes";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    case false:
+                        code["code"] = "N";
+                        code["display"] = "No";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    default:
+                        code["code"] = "UNK";
+                        code["display"] = "unknown";
+                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
+                        break;
+                }
+                this.ExaminerContacted = code;
             }
         }
 
@@ -6547,8 +6730,8 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Injury Location Description: {ExampleDeathRecord.InjuryLocationDescription}");</para>
         /// </example>
-        [Property("Injury Location Description", Property.Types.String, "Death Investigation", "Description of Injury Location.", true, IGURL.InjuryLocation, true, 36)]
-        [ FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile=ProfileURL.InjuryLocation)", "description")]
+        [Property("Injury Location Description", Property.Types.String, "Death Investigation", "Description of Injury Location.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Injury-Location.html", true, 36)]
+        [FHIRPath("Bundle.entry.resource.where($this is Location).where(meta.profile='http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location')", "description")]
         public string InjuryLocationDescription
         {
             get
@@ -6581,7 +6764,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Date of Injury: {ExampleDeathRecord.InjuryDate}");</para>
         /// </example>
-        [Property("Injury Date/Time", Property.Types.StringDateTime, "Death Investigation", "Date/Time of Injury.", true, IGURL.InjuryIncident, true, 37)]
+        [Property("Injury Date/Time", Property.Types.StringDateTime, "Death Investigation", "Date/Time of Injury.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 37)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
         public string InjuryDate
         {
@@ -6611,7 +6794,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Injury Description: {ExampleDeathRecord.InjuryDescription}");</para>
         /// </example>
-        [Property("Injury Description", Property.Types.String, "Death Investigation", "Description of Injury.", true, IGURL.InjuryIncident, true, 38)]
+        [Property("Injury Description", Property.Types.String, "Death Investigation", "Description of Injury.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 38)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
         public string InjuryDescription
         {
@@ -6633,6 +6816,94 @@ namespace VRDR
             }
         }
 
+        /// <summary>Place of Injury.</summary>
+        /// <value>the place of injury. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>code.Add("code", "0");</para>
+        /// <para>code.Add("system", "urn:oid:2.16.840.1.114222.4.5.320");</para>
+        /// <para>code.Add("display", "Home");</para>
+        /// <para>ExampleDeathRecord.InjuryPlace = code;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Place of Injury: {ExampleDeathRecord.InjuryPlace['display']}");</para>
+        /// </example>
+        [Property("Injury Place", Property.Types.Dictionary, "Death Investigation", "Place of Injury.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 39)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [PropertyParam("text", "Additional descriptive text.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
+        public Dictionary<string, string> InjuryPlace
+        {
+            get
+            {
+                if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
+                {
+                    // Find correct component
+                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
+                    if (placeComp?.Value != null && placeComp.Value as CodeableConcept != null)
+                    {
+                        return CodeableConceptToDict((CodeableConcept)placeComp.Value);
+                    }
+                }
+                return EmptyCodeDict();
+            }
+            set
+            {
+                if (InjuryIncidentObs == null)
+                {
+                    CreateInjuryIncidentObs();
+                }
+
+                // Find correct component; if doesn't exist add another
+                var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
+                if (placeComp != null)
+                {
+                    ((Observation.ComponentComponent)placeComp).Value = DictToCodeableConcept(value);
+                }
+                else
+                {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69450-5", "Place of injury Facility", null);
+                    component.Value = DictToCodeableConcept(value);
+                    InjuryIncidentObs.Component.Add(component);
+                }
+            }
+        }
+       /// <summary>Place of Injury Helper.</summary>
+        /// <value>the place of injury. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.InjuryPlaceHelper = "code";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Place of Injury: {ExampleDeathRecord.InjuryPlaceHelper}");</para>
+        /// </example>
+        [Property("Injury Place", Property.Types.String, "Death Investigation", "Place of Injury.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 39)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
+        public string InjuryPlaceHelper
+        {
+            get
+            {
+                if (InjuryPlace.ContainsKey("code"))
+                {
+                    return InjuryPlace["code"];
+                }
+                return null;
+            }
+            set
+            {
+                SetCodeValue("InjuryPlace", value, VRDR.ValueSets.PlaceOfInjury.Codes);
+            }
+        }
+
         /// <summary>Place of Injury Description.</summary>
         /// <value>the place of injury.</value>
         /// <example>
@@ -6641,47 +6912,27 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Place of Injury Description: {ExampleDeathRecord.InjuryPlaceDescription}");</para>
         /// </example>
-        [Property("Injury Place Description", Property.Types.String, "Death Investigation", "Place of Injury.", true, IGURL.InjuryIncident, true, 40)]
+        [Property("Injury Place Description", Property.Types.String, "Death Investigation", "Place of Injury.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 40)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
         public string InjuryPlaceDescription
         {
             get
             {
-                // Find the component
-                if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
+                var injuryPlace = this.InjuryPlace;
+                if (injuryPlace.ContainsKey("text") && injuryPlace["text"] != null)
                 {
-                    // Find correct component
-                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
-                    if (placeComp != null && placeComp.Value != null && placeComp.Value as CodeableConcept != null)
-                    {
-                        Dictionary<string, string> dict = CodeableConceptToDict((CodeableConcept)placeComp.Value);
-                        if ( dict.ContainsKey("text")){
-                                    return (dict["text"]);
-                        }
-                    }
-                }
-                return "";
-            }
-            set
-            {
-                if (InjuryIncidentObs == null){
-                    CreateInjuryIncidentObs();
-                }
-                // Find correct component; if doesn't exist add another
-                var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
-                if (placeComp != null)
-                {
-                    ((Observation.ComponentComponent)placeComp).Value = new CodeableConcept(null, null, null, value);
+                    return injuryPlace["text"];
                 }
                 else
                 {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69450-5", "Place of injury Facility", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
-                    InjuryIncidentObs.Component.Add(component);
+                    return "";
                 }
+            }
+            set
+            {
+                var injuryPlace = this.InjuryPlace;
+                injuryPlace["text"] = value;
+                this.InjuryPlace = injuryPlace;
             }
         }
 
@@ -6695,13 +6946,13 @@ namespace VRDR
         /// <para>// Setter:</para>
         /// <para>Dictionary&lt;string, string&gt; code = new Dictionary&lt;string, string&gt;();</para>
         /// <para>code.Add("code", "N");</para>
-        /// <para>code.Add("system", CodeSystems.YesNo);</para>
+        /// <para>code.Add("system", CodeSystems.PH_YesNo_HL7_2x);</para>
         /// <para>code.Add("display", "No");</para>
         /// <para>ExampleDeathRecord.InjuryAtWork = code;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Injury At Work?: {ExampleDeathRecord.InjuryAtWork['display']}");</para>
         /// </example>
-        [Property("Injury At Work?", Property.Types.Dictionary, "Death Investigation", "Did the injury occur at work?", true, IGURL.InjuryIncident, true, 41)]
+        [Property("Injury At Work?", Property.Types.Dictionary, "Death Investigation", "Did the injury occur at work?", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 41)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6713,8 +6964,7 @@ namespace VRDR
                 if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
                 {
                     // Find correct component
-                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                    && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69444-8" );
+                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69444-8" );
                     if (placeComp != null && placeComp.Value != null && placeComp.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)placeComp.Value);
@@ -6746,29 +6996,53 @@ namespace VRDR
             }
         }
 
-        /// <summary>Injury At Work Helper This is a convenience method, to access the code use the InjuryAtWork property instead.</summary>
+        /// <summary>Injury At Work? This is a convenience method, to access the code use the InjuryAtWork property instead.</summary>
         /// <value>did the injury occur at work? A null value indicates "not applicable".</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.InjuryAtWorkHelper = true;</para>
+        /// <para>ExampleDeathRecord.InjuryAtWorkBoolean = true;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Injury At Work? : {ExampleDeathRecord.InjuryAtWorkHelper}");</para>
+        /// <para>Console.WriteLine($"Injury At Work?: {ExampleDeathRecord.InjuryAtWorkBoolean}");</para>
         /// </example>
-        [Property("Injury At Work Helper", Property.Types.String, "Death Investigation", "Did the injury occur at work?", true, IGURL.InjuryIncident, true, 42)]
+        [Property("Injury At Work?", Property.Types.Bool, "Death Investigation", "Did the injury occur at work?", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 42)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        public string InjuryAtWorkHelper
+        public bool? InjuryAtWorkBoolean
         {
             get
             {
-                if (InjuryAtWork.ContainsKey("code"))
+                var code = this.InjuryAtWork;
+                switch (code["code"])
                 {
-                    return InjuryAtWork["code"];
+                    case "Y": // Yes
+                        return true;
+                    case "N": // No
+                        return false;
+                    default: // Not applicable
+                        return null;
                 }
-                return null;
             }
             set
             {
-                SetCodeValue("InjuryAtWork", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                var code = EmptyCodeDict();
+                switch(value)
+                {
+                    case true:
+                        code["code"] = "Y";
+                        code["display"] = "Yes";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    case false:
+                        code["code"] = "N";
+                        code["display"] = "No";
+                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
+                        break;
+                    default:
+                        code["code"] = "NA";
+                        code["display"] = "not applicable";
+                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
+                        break;
+                }
+                this.InjuryAtWork = code;
             }
         }
 
@@ -6788,7 +7062,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEvent['display']}");</para>
         /// </example>
-        [Property("Transportation Event?", Property.Types.Dictionary, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 43)]
+        [Property("Transportation Event?", Property.Types.Dictionary, "Death Investigation", "Was the injury associated with a transportation event?", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 43)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6839,7 +7113,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Transportation Event?: {ExampleDeathRecord.TransportationEventBoolean}");</para>
         /// </example>
-        [Property("Transportation Event Boolean?", Property.Types.Bool, "Death Investigation", "Was the injury associated with a transportation event?", true, IGURL.InjuryIncident, true, 44)]
+        [Property("Transportation Event Boolean?", Property.Types.Bool, "Death Investigation", "Was the injury associated with a transportation event?", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-InjuryIncident.html", true, 44)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
         public bool? TransportationEventBoolean
         {
@@ -6916,10 +7190,22 @@ namespace VRDR
             {
                 if (TransportationRoleObs == null)
                 {
-                    CreateTransportationRoleObs();
+                    TransportationRoleObs = new Observation();
+                    TransportationRoleObs.Id = Guid.NewGuid().ToString();
+                    TransportationRoleObs.Meta = new Meta();
+                    string[] t_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role" };
+                    TransportationRoleObs.Meta.Profile = t_profile;
+                    TransportationRoleObs.Status = ObservationStatus.Final;
+                    TransportationRoleObs.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent ", null);
+                    TransportationRoleObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    TransportationRoleObs.Value = DictToCodeableConcept(value);
+                    AddReferenceToComposition(TransportationRoleObs.Id);
+                    Bundle.AddResourceEntry(TransportationRoleObs, "urn:uuid:" + TransportationRoleObs.Id);
                 }
-                TransportationRoleObs.Value = DictToCodeableConcept(value);
-
+                else
+                {
+                    TransportationRoleObs.Value = DictToCodeableConcept(value);
+                }
             }
         }
         /// <summary>Transportation Role in death helper.</summary>
@@ -6941,29 +7227,13 @@ namespace VRDR
             {
                 if (TransportationRole.ContainsKey("code"))
                 {
-                    string code = TransportationRole["code"] ;
-                    if (code == "OTH"){
-                        if (TransportationRole.ContainsKey("text")){
-                            return (TransportationRole["text"]);
-                        }
-                        return("Other");
-                    }
+                    return TransportationRole["code"] ;
                 }
                 return null;
             }
             set
             {
-                if ((value != null) && !VRDR.Mappings.TransportationIncidentRole.FHIRToIJE.ContainsKey(value)){ //other
-                    if (TransportationRoleObs == null)
-                    {
-                        CreateTransportationRoleObs();
-                    }
-                    TransportationRoleObs.Value = new CodeableConcept(CodeSystems.NullFlavor_HL7_V3, "OTH", "Other", value);
-                }
-                else
-                { // normal path
-                    SetCodeValue("TransportationRole", value, VRDR.ValueSets.TransportationRoles.Codes);
-                }
+                SetCodeValue("TransportationRole", value, VRDR.ValueSets.TransportationRoles.Codes);
             }
         }
 
@@ -6983,7 +7253,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Tobacco Use: {ExampleDeathRecord.TobaccoUse['display']}");</para>
         /// </example>
-        [Property("Tobacco Use", Property.Types.Dictionary, "Death Investigation", "If Tobacco Use Contributed To Death.", true, IGURL.TobaccoUseContributedToDeath , true, 32)]
+        [Property("Tobacco Use", Property.Types.Dictionary, "Death Investigation", "If Tobacco Use Contributed To Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Tobacco-Use-Contributed-To-Death.html", true, 32)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -7005,7 +7275,7 @@ namespace VRDR
                     TobaccoUseObs = new Observation();
                     TobaccoUseObs.Id = Guid.NewGuid().ToString();
                     TobaccoUseObs.Meta = new Meta();
-                    string[] tb_profile = { ProfileURL.TobaccoUseContributedToDeath };
+                    string[] tb_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death" };
                     TobaccoUseObs.Meta.Profile = tb_profile;
                     TobaccoUseObs.Status = ObservationStatus.Final;
                     TobaccoUseObs.Code = new CodeableConcept(CodeSystems.LOINC, "69443-0", "Did tobacco use contribute to death", null);
@@ -7018,32 +7288,6 @@ namespace VRDR
                 {
                     TobaccoUseObs.Value = DictToCodeableConcept(value);
                 }
-            }
-        }
-
-        /// <summary>Tobacco Use Helper. This is a convenience method, to access the code use TobaccoUse instead.</summary>
-        /// <value>From a value set..</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.TobaccoUseHelper = "N";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Tobacco Use: {ExampleDeathRecord.TobaccoUseHelper}");</para>
-        /// </example>
-        [Property("Tobacco Use Helper", Property.Types.String, "Death Investigation", "Tobacco Use.", true, IGURL.TobaccoUseContributedToDeath, true, 27)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69443-0')", "")]
-        public string TobaccoUseHelper
-        {
-            get
-            {
-                if (TobaccoUse.ContainsKey("code"))
-                {
-                    return TobaccoUse["code"];
-                }
-                return null;
-            }
-            set
-            {
-                SetCodeValue("TobaccoUse", value, VRDR.ValueSets.ContributoryTobaccoUse.Codes);
             }
         }
 
@@ -7337,13 +7581,6 @@ namespace VRDR
                 throw new System.ArgumentException("Failed to find a Decedent (Patient). The second entry in the FHIR Bundle is usually the Decedent (Patient).");
             }
 
-            // Grab Input Race and Ethinicity
-            var inputRaceAndEthnicity = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && ((Observation)entry.Resource).Code.Coding.First().Code == "inputraceandethnicity" );
-            if (inputRaceAndEthnicity != null)
-            {
-                InputRaceandEthnicity = (Observation)inputRaceAndEthnicity.Resource;
-            }
-
             // Grab Certifier
             if (Composition.Attester == null || Composition.Attester.FirstOrDefault() == null || Composition.Attester.First().Party == null || String.IsNullOrWhiteSpace(Composition.Attester.First().Party.Reference))
             {
@@ -7453,18 +7690,17 @@ namespace VRDR
             }
 
             // Grab Causes of Death using CauseOfDeathConditionPathway
-            List<Observation> causeConditions = new List<Observation>();
+            List<Condition> causeConditions = new List<Condition>();
             if (CauseOfDeathConditionPathway != null)
             {
                 foreach (List.EntryComponent condition in CauseOfDeathConditionPathway.Entry)
                 {
                     if (condition != null && condition.Item != null && condition.Item.Reference != null)
                     {
-                        var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69453-9") &&
-                        (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
+                        var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Condition && (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
                         if (codCond != null)
                         {
-                            causeConditions.Add((Observation)codCond.Resource);
+                            causeConditions.Add((Condition)codCond.Resource);
                         }
                     }
                 }
@@ -7484,18 +7720,41 @@ namespace VRDR
                 {
                     CauseOfDeathConditionD = causeConditions[3];
                 }
-
+                if (causeConditions.Count() > 4)
+                {
+                    CauseOfDeathConditionE = causeConditions[4];
+                }
+                if (causeConditions.Count() > 5)
+                {
+                    CauseOfDeathConditionF = causeConditions[5];
+                }
+                if (causeConditions.Count() > 6)
+                {
+                    CauseOfDeathConditionG = causeConditions[6];
+                }
+                if (causeConditions.Count() > 7)
+                {
+                    CauseOfDeathConditionH = causeConditions[7];
+                }
+                if (causeConditions.Count() > 8)
+                {
+                    CauseOfDeathConditionI = causeConditions[8];
+                }
+                if (causeConditions.Count() > 9)
+                {
+                    CauseOfDeathConditionJ = causeConditions[9];
+                }
             }
 
             // Grab Condition Contributing To Death
-            List<Observation> remainingConditions = new List<Observation>();
-            foreach (var condition in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69441-4")))
+            List<Condition> remainingConditions = new List<Condition>();
+            foreach (var condition in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Condition ))
             {
                 if (condition != null)
                 {
-                    if (!causeConditions.Contains((Observation)condition.Resource)) // should never trigger, since now Part1 and Part2 are observations with different codes
+                    if (!causeConditions.Contains((Condition)condition.Resource))
                     {
-                        remainingConditions.Add((Observation)condition.Resource);
+                        remainingConditions.Add((Condition)condition.Resource);
 
                     }
                 }
@@ -7780,7 +8039,6 @@ namespace VRDR
         private Address DictToAddress(Dictionary<string, string> dict)
         {
             Address address = new Address();
-
             if (dict != null)
             {
                 List<string> lines = new List<string>();
@@ -7796,44 +8054,13 @@ namespace VRDR
                 {
                     address.Line = lines.ToArray();
                 }
-                if (dict.ContainsKey("addressCityC") && !String.IsNullOrEmpty(dict["addressCityC"]))
-                {
-                    Extension cityCode = new Extension();
-                    cityCode.Url = ExtensionURL.CityCode;
-                    cityCode.Value = new FhirString(dict["addressCityC"]);
-                    address.CityElement = new FhirString();
-                    address.CityElement.Extension.Add(cityCode);
-                }
                 if (dict.ContainsKey("addressCity") && !String.IsNullOrEmpty(dict["addressCity"]))
                 {
-                    if (address.CityElement != null)
-                    {
-                        address.CityElement.Value = dict["addressCity"];
-                    }
-                    else
-                    {
-                        address.City = dict["addressCity"];
-                    }
-                    
-                }
-                if (dict.ContainsKey("addressCountyC") && !String.IsNullOrEmpty(dict["addressCountyC"]))
-                {
-                    Extension countyCode = new Extension();
-                    countyCode.Url = ExtensionURL.DistrictCode;
-                    countyCode.Value = new FhirString(dict["addressCountyC"]);
-                    address.DistrictElement = new FhirString();
-                    address.DistrictElement.Extension.Add(countyCode);
+                    address.City = dict["addressCity"];
                 }
                 if (dict.ContainsKey("addressCounty") && !String.IsNullOrEmpty(dict["addressCounty"]))
                 {
-                    if (address.DistrictElement != null)
-                    {
-                        address.DistrictElement.Value = dict["addressCounty"];
-                    }
-                    else
-                    {
-                        address.District = dict["addressCounty"];
-                    }
+                    address.District = dict["addressCounty"];
                 }
                 if (dict.ContainsKey("addressState") && !String.IsNullOrEmpty(dict["addressState"]))
                 {
@@ -7847,53 +8074,9 @@ namespace VRDR
                 {
                     address.Country = dict["addressCountry"];
                 }
-                if (dict.ContainsKey("addressStnum") && !String.IsNullOrEmpty(dict["addressStnum"]))
-                {
-                    Extension stnum = new Extension();
-                    stnum.Url = ExtensionURL.StreetNumber;
-                    stnum.Value = new FhirString(dict["addressStnum"]);
-                    address.Extension.Add(stnum);
-                }
-                if (dict.ContainsKey("addressPredir") && !String.IsNullOrEmpty(dict["addressPredir"]))
-                {
-                    Extension predir = new Extension();
-                    predir.Url = ExtensionURL.PreDirectional;
-                    predir.Value = new FhirString(dict["addressPredir"]);
-                    address.Extension.Add(predir);
-                }
-                if (dict.ContainsKey("addressStname") && !String.IsNullOrEmpty(dict["addressStname"]))
-                {
-                    Extension stname = new Extension();
-                    stname.Url = ExtensionURL.StreetName;
-                    stname.Value = new FhirString(dict["addressStname"]);
-                    address.Extension.Add(stname);
-                }
-                if (dict.ContainsKey("addressStdesig") && !String.IsNullOrEmpty(dict["addressStdesig"]))
-                {
-                    Extension stdesig = new Extension();
-                    stdesig.Url = ExtensionURL.StreetDesignator;
-                    stdesig.Value = new FhirString(dict["addressStdesig"]);
-                    address.Extension.Add(stdesig);
-                }
-                if (dict.ContainsKey("addressPostdir") && !String.IsNullOrEmpty(dict["addressPostdir"]))
-                {
-                    Extension postdir = new Extension();
-                    postdir.Url = ExtensionURL.PostDirectional;
-                    postdir.Value = new FhirString(dict["addressPostdir"]);
-                    address.Extension.Add(postdir);
-                }
-                if (dict.ContainsKey("addressUnitnum") && !String.IsNullOrEmpty(dict["addressUnitnum"]))
-                {
-                    Extension unitnum = new Extension();
-                    unitnum.Url = ExtensionURL.UnitOrAptNumber;
-                    unitnum.Value = new FhirString(dict["addressUnitnum"]);
-                    address.Extension.Add(unitnum);
-                }
-
             }
             return address;
         }
-
 
         /// <summary>Convert a Date Part Extension to an Array.</summary>
         /// <param name="datePartAbsent">a Date Part Extension.</param>
@@ -7960,112 +8143,39 @@ namespace VRDR
         private Dictionary<string, string> AddressToDict(Address addr)
         {
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
-            dictionary.Add("addressLine1", "");
-            dictionary.Add("addressLine2", "");
-            dictionary.Add("addressCity", "");
-            dictionary.Add("addressCityC", "");
-            dictionary.Add("addressCounty", "");
-            dictionary.Add("addressCountyC", "");
-            dictionary.Add("addressState", "");
-            dictionary.Add("addressZip", "");
-            dictionary.Add("addressCountry", "");
-            dictionary.Add("addressStnum", "");
-            dictionary.Add("addressPredir", "");
-            dictionary.Add("addressStname", "");
-            dictionary.Add("addressStdesig", "");
-            dictionary.Add("addressPostdir", "");
-            dictionary.Add("addressUnitnum", "");
             if (addr != null)
             {
                 if (addr.Line != null && addr.Line.Count() > 0)
                 {
-                    dictionary["addressLine1"] = addr.Line.First();
+                    dictionary.Add("addressLine1", addr.Line.First());
                 }
-
+                else
+                {
+                    dictionary.Add("addressLine1", "");
+                }
                 if (addr.Line != null && addr.Line.Count() > 1)
                 {
-                    dictionary["addressLine2"] = addr.Line.Last();
+                    dictionary.Add("addressLine2", addr.Line.Last());
                 }
-
-                if(addr.CityElement != null)
+                else
                 {
-                    Extension cityCode = addr.CityElement.Extension.Where(ext => ext.Url == ExtensionURL.CityCode).FirstOrDefault();
-                    if (cityCode != null)
-                    {
-                        dictionary["addressCityC"] = cityCode.Value.ToString();
-                    }
+                    dictionary.Add("addressLine2", "");
                 }
-
-                if(addr.DistrictElement != null)
-                {
-                    Extension districtCode = addr.DistrictElement.Extension.Where(ext => ext.Url == ExtensionURL.DistrictCode).FirstOrDefault();
-                    if (districtCode != null){
-                        dictionary["addressCountyC"] = districtCode.Value.ToString();
-                    } 
-                }
-                
-                Extension stnum = addr.Extension.Where(ext => ext.Url == ExtensionURL.StreetNumber).FirstOrDefault();
-                if (stnum != null)
-                {
-                    dictionary["addressStnum"] = stnum.Value.ToString();
-                }
-
-                Extension predir = addr.Extension.Where(ext => ext.Url == ExtensionURL.PreDirectional).FirstOrDefault();
-                if (predir != null)
-                {
-                    dictionary["addressPredir"] = predir.Value.ToString();
-                }
-
-                Extension stname = addr.Extension.Where(ext => ext.Url == ExtensionURL.StreetName).FirstOrDefault();
-                if (stname != null)
-                {
-                    dictionary["addressStname"] = stname.Value.ToString();
-                }
-                
-                Extension stdesig = addr.Extension.Where(ext => ext.Url == ExtensionURL.StreetDesignator).FirstOrDefault();
-                if (stdesig != null)
-                {
-                    dictionary["addressStdesig"] = stdesig.Value.ToString();
-                }
-                
-                Extension postdir = addr.Extension.Where(ext => ext.Url == ExtensionURL.PostDirectional).FirstOrDefault();
-                if (postdir != null)
-                {
-                    dictionary["addressPostdir"] = postdir.Value.ToString();
-                }
-                
-                Extension unitnum = addr.Extension.Where(ext => ext.Url == ExtensionURL.UnitOrAptNumber).FirstOrDefault();
-                if (unitnum != null)
-                {
-                    dictionary["addressUnitnum"] = unitnum.Value.ToString();
-                }
-                
-                //Check for possible state extension
-                dictionary["addressState"] = addr.State;
-                if (addr.StateElement != null) 
-                {
-                    Extension stateExt = addr.StateElement.Extension.Where(ext => ext.Url == ExtensionURL.LocationJurisdictionId).FirstOrDefault();
-                    if (stateExt != null)
-                    {
-                        dictionary["addressState"] = stateExt.Value.ToString();
-                    } 
-                }
-                if (addr.City != null)
-                {
-                    dictionary["addressCity"] = addr.City;
-                }
-                if (addr.District != null)
-                {
-                    dictionary["addressCounty"] = addr.District;
-                }
-                if (addr.PostalCode != null)
-                {
-                    dictionary["addressZip"] = addr.PostalCode;
-                }
-                if (addr.Country != null)
-                {
-                    dictionary["addressCountry"] = addr.Country;
-                }
+                dictionary.Add("addressCity", addr.City);
+                dictionary.Add("addressCounty", addr.District);
+                dictionary.Add("addressState", addr.State);
+                dictionary.Add("addressZip", addr.PostalCode);
+                dictionary.Add("addressCountry", addr.Country);
+            }
+            else
+            {
+                dictionary.Add("addressLine1", "");
+                dictionary.Add("addressLine2", "");
+                dictionary.Add("addressCity", "");
+                dictionary.Add("addressCounty", "");
+                dictionary.Add("addressState", "");
+                dictionary.Add("addressZip", "");
+                dictionary.Add("addressCountry", "");
             }
             return dictionary;
         }
@@ -8078,7 +8188,6 @@ namespace VRDR
             dictionary.Add("addressLine1", "");
             dictionary.Add("addressLine2", "");
             dictionary.Add("addressCity", "");
-            dictionary.Add("addressCityC", "");
             dictionary.Add("addressCounty", "");
             dictionary.Add("addressState", "");
             dictionary.Add("addressZip", "");
@@ -8093,16 +8202,6 @@ namespace VRDR
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
             dictionary.Add("code", "");
             dictionary.Add("system", "");
-            dictionary.Add("display", "");
-            return dictionary;
-        }
-        
-        /// <summary>Returns an empty "code" Dictionary for race and ethnicity.</summary>
-        /// <returns>an empty "code" Dictionary.</returns>
-        private Dictionary<string, string> EmptyRaceEthnicityCodeDict()
-        {
-            Dictionary<string, string> dictionary = new Dictionary<string, string>();
-            dictionary.Add("code", "");
             dictionary.Add("display", "");
             return dictionary;
         }
@@ -8418,7 +8517,7 @@ namespace VRDR
                     }
                     else if (property.Value["Type"] == Property.Types.TupleCOD)
                     {
-                        value = property.Value["Value"].ToObject<Tuple<string, string /*, Dictionary<string, string>*/>[]>();
+                        value = property.Value["Value"].ToObject<Tuple<string, string, Dictionary<string, string>>[]>();
                     }
                     else if (property.Value["Type"] == Property.Types.Dictionary)
                     {

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4881,6 +4881,10 @@ namespace VRDR
             }
             set
             {
+<<<<<<< HEAD
+=======
+                // NOOP
+>>>>>>> 8544b11 (added support for Certifier Address.  Need to merge SUpport for address fields from Decedent PR for this to work)
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4990,7 +4990,9 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_Geo_Get("STINJURY", "InjuryLocationAddress", "address", "state", false);
+                var stateCode = Dictionary_Geo_Get("STATECODE_I", "InjuryLocationAddress", "address", "stateC", false);
+                var mortalityData = MortalityData.Instance;
+                return mortalityData.StateCodeToStateName(stateCode);
             }
             set
             {

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4881,10 +4881,6 @@ namespace VRDR
             }
             set
             {
-<<<<<<< HEAD
-=======
-                // NOOP
->>>>>>> 8544b11 (added support for Certifier Address.  Need to merge SUpport for address fields from Decedent PR for this to work)
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4875,12 +4875,15 @@ namespace VRDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: Certifier
-                return "";
+                return Dictionary_Geo_Get("CERTSTNUM", "CertifierAddress", "address", "stnum", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: Certifier
+                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);
+                }
             }
         }
 
@@ -4890,12 +4893,15 @@ namespace VRDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: Certifier
-                return "";
+                return Dictionary_Geo_Get("CERTPREDIR", "CertifierAddress", "address", "predir", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: Certifier
+                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CERTPREDIR", "CertifierAddress", "address", "predir", false, value);
+                }
             }
         }
 
@@ -4905,12 +4911,15 @@ namespace VRDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: Certifier
-                return "";
+                return Dictionary_Geo_Get("CERTSTRNAME", "CertifierAddress", "address", "stname", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: Certifier
+                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CERTSTRNAME", "CertifierAddress", "address", "stname", false, value);
+                }
             }
         }
 
@@ -4920,12 +4929,15 @@ namespace VRDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: Certifier
-                return "";
+                return Dictionary_Geo_Get("CERTSTRDESIG", "CertifierAddress", "address", "stdesig", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: Certifier
+                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CERTSTRDESIG", "CertifierAddress", "address", "stdesig", false, value);
+                }
             }
         }
 
@@ -4933,29 +4945,35 @@ namespace VRDR
         [IJEField(228, 4120, 10, "Certifier - Post Directional", "CERTPOSTDIR", 1)]
         public string CERTPOSTDIR
         {
-            get
+           get
             {
-                // TODO: Implement mapping from FHIR record location: Certifier
-                return "";
+                return Dictionary_Geo_Get("CERTPOSTDIR", "CertifierAddress", "address", "postdir", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: Certifier
+                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CERTPOSTDIR", "CertifierAddress", "address", "postdir", false, value);
+                }
             }
+
         }
 
         /// <summary>Certifier - Unit or apt number</summary>
         [IJEField(229, 4130, 7, "Certifier - Unit or apt number", "CERTUNITNUM", 1)]
         public string CERTUNITNUM
         {
-            get
+           get
             {
-                // TODO: Implement mapping from FHIR record location: Certifier
-                return "";
+                return Dictionary_Geo_Get("CERTUNITNUM", "CertifierAddress", "address", "unitnum", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: Certifier
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CERTUNITNUM", "CertifierAddress", "address", "unitnum", false, value);
+                }
             }
         }
 
@@ -4989,14 +5007,14 @@ namespace VRDR
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Set("CERTCITYTEXT", "CertifierAddress", "addressCity", value);
-                    // We've got city, and we probably also have state now - so attempt to find county while we're at it (IJE does NOT include this).
-                    string county = dataLookup.StateCodeAndCityNameToCountyName(CERTSTATECD, value);
-                    if (!String.IsNullOrWhiteSpace(county))
-                    {
-                        Dictionary_Geo_Set("CERTCITYTEXT", "CertifierAddress", "address", "county", false, county);
-                        // If we found a county, we know the country.
-                        Dictionary_Geo_Set("CERTCITYTEXT", "CertifierAddress", "address", "country", false, "US");
-                    }
+                    // // We've got city, and we probably also have state now - so attempt to find county while we're at it (IJE does NOT include this).
+                    // string county = dataLookup.StateCodeAndCityNameToCountyName(CERTSTATECD, value);
+                    // if (!String.IsNullOrWhiteSpace(county))
+                    // {
+                    //     Dictionary_Geo_Set("CERTCITYTEXT", "CertifierAddress", "address", "county", false, county);
+                    //     // If we found a county, we know the country.
+                    //     Dictionary_Geo_Set("CERTCITYTEXT", "CertifierAddress", "address", "country", false, "US");
+                    // }
                 }
             }
         }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4396,7 +4396,9 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_Geo_Get("DISPSTATE", "DispositionLocationAddress", "address", "state", false);
+                var stateCode = Dictionary_Geo_Get("DISPSTATECD", "InjuryLocationAddress", "address", "stateC", false);
+                var mortalityData = MortalityData.Instance;
+                return mortalityData.StateCodeToStateName(stateCode);
             }
             set
             {
@@ -4602,13 +4604,14 @@ namespace VRDR
         {
             get
             {
-                return dataLookup.StateNameToStateCode(Dictionary_Get_Full("FUNSTATECD", "FuneralHomeAddress", "addressState"));
+
+                return Dictionary_Geo_Get("FUNSTATECD", "InjuryLocationAddress", "address", "stateC", true);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Dictionary_Set("FUNSTATECD", "FuneralHomeAddress", "addressState", value);
+                    Dictionary_Set("FUNSTATECD", "FuneralHomeAddress", "stateC", value);
                 }
             }
         }
@@ -4619,7 +4622,9 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_Get("FUNSTATE", "FuneralHomeAddress", "addressState");
+                var stateCode = Dictionary_Geo_Get("FUNSTATECD", "InjuryLocationAddress", "address", "stateC", false);
+                var mortalityData = MortalityData.Instance;
+                return mortalityData.StateCodeToStateName(stateCode);
             }
             set
             {

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4583,12 +4583,14 @@ namespace VRDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: FuneralHome
-                return "";
+                return Dictionary_Geo_Get("FUNFACSTNUM", "CertifierAddress", "address", "stnum", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: FuneralHome
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("FUNFACSTNUM", "CertifierAddress", "address", "stnum", false, value);
+                }
             }
         }
 
@@ -4879,7 +4881,6 @@ namespace VRDR
             }
             set
             {
-                // NOOP
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -2743,62 +2743,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("MANNER", "MannerOfDeathType", "code");
-                switch (code)
-                {
-                    case "38605008": // Natural
-                        return "N";
-                    case "7878000": // Accident
-                        return "A";
-                    case "44301001": // Suicide
-                        return "S";
-                    case "27935005": // Homicide
-                        return "H";
-                    case "185973002": // Pending Investigation
-                        return "P";
-                    case "65037004": // Could not be determined
-                        return "C";
-                }
-                return "";
+                return Get_MappingFHIRToIJE(Mappings.MannerOfDeath.FHIRToIJE, "MannerOfDeathType", "MANNER");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "N":
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "code", "38605008");
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "system", CodeSystems.SCT);
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "display", "Natural death");
-                            break;
-                        case "A":
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "code", "7878000");
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "system", CodeSystems.SCT);
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "display", "Accidental death");
-                            break;
-                        case "S":
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "code", "44301001");
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "system", CodeSystems.SCT);
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "display", "Suicide");
-                            break;
-                        case "H":
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "code", "27935005");
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "system", CodeSystems.SCT);
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "display", "Homicide");
-                            break;
-                        case "P":
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "code", "185973002");
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "system", CodeSystems.SCT);
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "display", "Patient awaiting investigation");
-                            break;
-                        case "C":
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "code", "65037004");
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "system", CodeSystems.SCT);
-                            Dictionary_Set("MANNER", "MannerOfDeathType", "display", "Death, manner undetermined");
-                            break;
-                    }
-                }
+                Set_MappingIJEToFHIR(Mappings.MannerOfDeath.IJEToFHIR, "MANNER", "MannerOfDeathType", value);
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -3911,7 +3911,10 @@ namespace VRDR
             }
             set
             {
-                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("COUNTYTEXT_I", "InjuryLocationAddress", "address", "county", false, value);
+                }
             }
         }
 
@@ -3921,13 +3924,13 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_Geo_Get("COUNTYCODE_I", "InjuryLocationAddress", "address", "county", true);
+                return Dictionary_Geo_Get("COUNTYCODE_I", "InjuryLocationAddress", "address", "countyC", true);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Dictionary_Geo_Set("COUNTYCODE_I", "InjuryLocationAddress", "address", "county", true, value);
+                    Dictionary_Geo_Set("COUNTYCODE_I", "InjuryLocationAddress", "address", "countyC", true, value);
                 }
             }
         }
@@ -3955,11 +3958,14 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_Geo_Get("CITYCODE_I", "InjuryLocationAddress", "address", "city", true);
+                return Dictionary_Geo_Get("CITYCODE_I", "InjuryLocationAddress", "address", "cityC", true);
             }
             set
             {
-                // NOOP
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("CITYCODE_I", "InjuryLocationAddress", "address", "CityC", true, value);
+                }
             }
         }
 
@@ -3969,13 +3975,13 @@ namespace VRDR
         {
             get
             {
-                return Dictionary_Geo_Get("STATECODE_I", "InjuryLocationAddress", "address", "state", true);
+                return Dictionary_Geo_Get("STATECODE_I", "InjuryLocationAddress", "address", "stateC", true);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Dictionary_Geo_Set("STATECODE_I", "InjuryLocationAddress", "address", "state", true, value);
+                    Dictionary_Geo_Set("STATECODE_I", "InjuryLocationAddress", "address", "stateC", true, value);
                 }
             }
         }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4017,41 +4017,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("TRANSPRT", "TransportationRole", "code");
-                switch (code)
-                {
-                    case "236320001": // Vehicle driver
-                        return "DR";
-                    case "257500003": // Passenger
-                        return "PA";
-                    case "257518000": // Pedestrian
-                        return "PE";
-                }
-                return "";
+                return Get_MappingFHIRToIJE(Mappings.MannerOfDeath.FHIRToIJE, "TransportationRole", "TRANSPRT");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value.Trim())
-                    {
-                        case "DR":
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "code", "236320001");
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "system", CodeSystems.SCT);
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "display", "Vehicle driver");
-                            break;
-                        case "PA":
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "code", "257500003");
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "system", CodeSystems.SCT);
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "display", "Passenger");
-                            break;
-                        case "PE":
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "code", "257518000");
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "system", CodeSystems.SCT);
-                            Dictionary_Set("TRANSPRT", "TransportationRole", "display", "Pedestrian");
-                            break;
-                    }
-                }
+                Set_MappingIJEToFHIR(Mappings.MannerOfDeath.IJEToFHIR, "TRANSPRT", "TransportationRole", value);
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -735,7 +735,7 @@ namespace VRDR
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     LeftJustified_Set("DSTATE", "DeathLocationJurisdiction",value);
-                    Dictionary_Set("STATEC", "DeathLocationAddress", "addressState", value);
+                    // Dictionary_Set("STATEC", "DeathLocationAddress", "addressState", value); // WHY????... used to be STATEC
                 }
             }
         }
@@ -1354,76 +1354,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("DPLACE", "DeathLocationType", "code");
-                switch (code)
-                {
-                    case "16983000":
-                        return "1";
-                    case "450391000124102":
-                        return "2";
-                    case "63238001":
-                        return "3";
-                    case "440081000124100":
-                        return "4";
-                    case "440071000124103":
-                        return "5";
-                    case "450381000124100":
-                        return "6";
-                    case "OTH":
-                        return "7";
-                    case "UNK":
-                        return "9";
-                }
-                return "";
+                return Get_MappingFHIRToIJE(Mappings.PlaceOfDeath.FHIRToIJE, "DeathLocationType", "DPLACE");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "1":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "16983000");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Hospital Inpatient");
-                            break;
-                        case "2":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "450391000124102");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Death in emergency Room/Outpatient");
-                            break;
-                        case "3":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "63238001");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Hospital Dead on Arrival");
-                            break;
-                        case "4":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "440081000124100");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Decendent's Home");
-                            break;
-                        case "5":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "440071000124103");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Hospice");
-                            break;
-                        case "6":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "450381000124100");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Death in nursing home/Long term care facility");
-                            break;
-                        case "7":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "OTH");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Other(Specify)");
-                            break;
-                        case "9":
-                            Dictionary_Set("DPLACE", "DeathLocationType", "code", "Unknown");
-                            Dictionary_Set("DPLACE", "DeathLocationType", "system", CodeSystems.PH_SNOMED_CT);
-                            Dictionary_Set("DPLACE", "DeathLocationType", "display", "Unknown");
-                            break;
-                    }
-                }
+                Set_MappingIJEToFHIR(Mappings.PlaceOfDeath.IJEToFHIR, "DPLACE", "DeathLocationType", value);
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -1450,70 +1450,11 @@ namespace VRDR
         {
             get
             {
-                string code = Dictionary_Get_Full("DISP", "DecedentDispositionMethod", "code");
-                switch (code)
-                {
-                    case "449951000124101": // Donation
-                        return "D";
-                    case "449971000124106": // Burial
-                        return "B";
-                    case "449961000124104": // Cremation
-                        return "C";
-                    case "449931000124108": // Entombment
-                        return "E";
-                    case "449941000124103": // Removal from state
-                        return "R";
-                    case "UNK": // Unknown
-                        return "U";
-                    case "455401000124109": // Hospital Disposition
-                    case "OTH": // Other
-                        return "O";
-                }
-                return "";
+                return Get_MappingFHIRToIJE(Mappings.MethodOfDisposition.FHIRToIJE, "DecedentDispositionMethod", "DISP");
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    switch (value)
-                    {
-                        case "D":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "449951000124101");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.SCT);
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Patient status determination, deceased and body donated");
-                            break;
-                        case "B":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "449971000124106");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.SCT);
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Patient status determination, deceased and buried");
-                            break;
-                        case "C":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "449961000124104");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.SCT);
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Patient status determination, deceased and cremated");
-                            break;
-                        case "E":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "449931000124108");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.SCT);
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Patient status determination, deceased and entombed");
-                            break;
-                        case "R":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "449941000124103");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.SCT);
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Patient status determination, deceased and removed from state");
-                            break;
-                        case "U":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "UNK");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.PH_NullFlavor_HL7_V3 );
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Unknown");
-                            break;
-                        case "O":
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "code", "OTH");
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "system", CodeSystems.PH_NullFlavor_HL7_V3);
-                            Dictionary_Set("DISP", "DecedentDispositionMethod", "display", "Other");
-                            break;
-                    }
-                }
+                Set_MappingIJEToFHIR(Mappings.MethodOfDisposition.IJEToFHIR, "DISP", "DecedentDispositionMethod", value);
             }
         }
 
@@ -4528,12 +4469,14 @@ namespace VRDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: DispositionLocation
-                return "";
+                return Dictionary_Geo_Get("DISPCITYCODE", "DispositionLocationAddress", "address", "cityC", false);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: DispositionLocation
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Geo_Set("DISPCITYCODE", "DispositionLocationAddress", "address", "cityC", false, value);
+                }
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4881,6 +4881,10 @@ namespace VRDR
             }
             set
             {
+<<<<<<< HEAD
+=======
+                // NOOP
+>>>>>>> f469923 (added support for Certifier Address.  Need to merge SUpport for address fields from Decedent PR for this to work)
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -583,7 +583,7 @@ namespace VRDR
 
             Tuple<string, string> raceTuple = Array.Find(raceStatus, element => element.Item1 == name);
             if (raceTuple != null)
-            {   
+            {
                 return raceTuple.Item2;
             }
             return "";
@@ -1195,7 +1195,7 @@ namespace VRDR
                     record.DateOfBirthDatePartAbsent = dateParts.ToList().ToArray();
                     // TODO should we set DateOfBirth to null because it will have default values for the unknown date parts?
                     // record.DateOfBirth = "";
-                } 
+                }
                 else
                 {
                     DateTime_Set("DOB_DY", "dd", "DateOfBirth", value, true);
@@ -1793,7 +1793,7 @@ namespace VRDR
         public string RACE1
         {
             get
-            {   
+            {
                 return Get_Race(NvssRace.White);
             }
             set
@@ -1955,7 +1955,7 @@ namespace VRDR
                 {
                     Set_Race(NvssRace.OtherAsian, value);
                 }
-                
+
             }
         }
 
@@ -3570,7 +3570,7 @@ namespace VRDR
             get
             {
                 // This is Now just the two letter code.  Need to map it to country name
-                var countryCode = Dictionary_Geo_Get("COUNTRYC", "Residence", "address", "country", false); 
+                var countryCode = Dictionary_Geo_Get("COUNTRYC", "Residence", "address", "country", false);
                 var mortalityData = MortalityData.Instance;
                 return mortalityData.CountryCodeToCountryName(countryCode);
             }
@@ -3785,7 +3785,7 @@ namespace VRDR
         /// <summary>Race - old NCHS single race codes</summary>
         [IJEField(163, 1742, 1, "Race - old NCHS single race codes", "RACEOLDC", 1)]
         public string RACEOLDC
-        
+
         {
             get
             {
@@ -4881,10 +4881,6 @@ namespace VRDR
             }
             set
             {
-<<<<<<< HEAD
-=======
-                // NOOP
->>>>>>> f469923 (added support for Certifier Address.  Need to merge SUpport for address fields from Decedent PR for this to work)
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);
@@ -5422,7 +5418,7 @@ namespace VRDR
             }
             set
             {
-                
+
             }
         }
         // NOTE: This is a placeholder, the IJE field BLANK3 is not currently implemented in FHIR

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -4881,10 +4881,6 @@ namespace VRDR
             }
             set
             {
-<<<<<<< HEAD
-=======
-                // NOOP
->>>>>>> f469923 (added support for Certifier Address.  Need to merge SUpport for address fields from Decedent PR for this to work)
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     Dictionary_Geo_Set("CERTSTNUM", "CertifierAddress", "address", "stnum", false, value);

--- a/VRDR/Mappings.cs
+++ b/VRDR/Mappings.cs
@@ -3121,8 +3121,8 @@ namespace VRDR
                 { "D", "449951000124101" },
                 { "E", "449931000124108" },
                 { "R", "449941000124103" },
-                { "O", "Other" },
-                { "U", "Unkown" },
+                { "O", "OTH" },
+                { "U", "UNK" },
             };
             /// <summary>FHIR -> IJE Mapping for MethodOfDisposition</summary>
             public readonly static Dictionary<string, string> FHIRToIJE = new Dictionary<string, string>

--- a/VRDR/OtherURLs.cs
+++ b/VRDR/OtherURLs.cs
@@ -1,0 +1,18 @@
+namespace VRDR
+{
+    /// <summary>Profile URLs for non-VRDR Profiles</summary>
+    public static class OtherURL
+    {
+        /// <summary>URL for USCorePractitioner</summary>
+        public const string USCorePractitioner = "	http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner";
+
+    }
+        /// <summary>IG URLs for non-VRDR Profiles</summary>
+        public static class OtherIGURL
+    {
+        /// <summary>URL for USCorePractitioner</summary>
+        public const string ParametersForEmergingIssues = "http://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-practitioner.html";
+
+
+    }
+}


### PR DESCRIPTION
1) FOlded Transportation role into INjury Incident, as per revised IG.   Got rid of a lot of garbage in test cases for Transportation Event.
2) Death Certification Procedure
3) Manner of Death
4) Certifier 
5) Commented out InterestedParty code -- not used
6) Update EmergingIssues from Parameters to Observation (following VRDR IG changes).
7) Identify FuneralHome, DeathLocation, INjuryLocation, DispositionLocation by their 'type', not by their meta.profile.  The references to DeathLocation, INjury Location and Disposition Location are no longer needed/supported, since their purpose was to differentiate between different Location entries in the bundle.
8) DeathLocationType is now mapped to a component of DeathDate.
9) Commented out a lot of code and data relating to Mortician and Funeral Home Director which are now outside of scope.  I don't think they are coming back, so I didn't delete them.
10) Dealt with the change of the way DSTATE is mapped.  Basically, the DeathLocation.state is the jurisdiction, unless an extension is present (needed only for YC, but can be used by anybody).

Our fixtures are a huge effing mess of old/new formatted stuff with lots of vestigial stuff.