### PR TITLE
Messaging IG types

### DIFF
--- a/VRDR.Tests/CauseOfDeathCodedContentBundle_Should.cs
+++ b/VRDR.Tests/CauseOfDeathCodedContentBundle_Should.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.IO;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Xunit;
+
+using System.Linq;
+
+namespace VRDR.Tests
+{
+    public class CauseOfDeathCodedContentBundle_Should
+    {
+        private List<CauseOfDeathCodedContentBundle> XMLRecords;
+
+        private List<CauseOfDeathCodedContentBundle> JSONRecords;
+
+        private DemographicCodedContentBundle SetterContentBundle;
+
+        public CauseOfDeathCodedContentBundle_Should()
+        {
+            XMLRecords = new List<CauseOfDeathCodedContentBundle>();
+            // XMLRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/xml/DeathRecord1.xml"))));
+            JSONRecords = new List<CauseOfDeathCodedContentBundle>();
+            //JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecord1.json"))));
+            SetterContentBundle = new DemographicCodedContentBundle();
+        }
+
+        [Fact]
+        public void BundleGetsInitialized()
+        {
+            CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle = new CauseOfDeathCodedContentBundle();
+            Assert.NotNull(causeOfDeathCodedContentBundle.GetBundle());
+        }
+
+        [Fact]
+        public void ProvidedBundleGetsInitialized()
+        {
+            Bundle bundle = new Bundle();
+            CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle = new CauseOfDeathCodedContentBundle(bundle);
+            Assert.Equal(bundle, causeOfDeathCodedContentBundle.GetBundle());
+        }
+
+        [Fact]
+        public void ProfileUrlIsCorrect()
+        {
+            CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle = new CauseOfDeathCodedContentBundle();
+            Assert.Equal(ProfileURL.CauseOfDeathCodedContentBundle, causeOfDeathCodedContentBundle.GetContentType());
+        }
+
+        // TODO: Test cases
+
+        private string FixturePath(string filePath)
+        {
+            if (Path.IsPathRooted(filePath))
+            {
+                return filePath;
+            }
+            else
+            {
+                return Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
+            }
+        }
+    }
+}

--- a/VRDR.Tests/DemographicCodedContetBundle_Should.cs
+++ b/VRDR.Tests/DemographicCodedContetBundle_Should.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.IO;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Xunit;
+
+using System.Linq;
+
+namespace VRDR.Tests
+{
+    public class DemographicCodedContentBundle_Should
+    {
+        private List<DemographicCodedContentBundle> XMLRecords;
+
+        private List<DemographicCodedContentBundle> JSONRecords;
+
+        private DemographicCodedContentBundle SetterContentBundle;
+
+        public DemographicCodedContentBundle_Should()
+        {
+            XMLRecords = new List<DemographicCodedContentBundle>();
+            // XMLRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/xml/DeathRecord1.xml"))));
+            JSONRecords = new List<DemographicCodedContentBundle>();
+            //JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecord1.json"))));
+            SetterContentBundle = new DemographicCodedContentBundle();
+        }
+
+        [Fact]
+        public void BundleGetsInitialized()
+        {
+            DemographicCodedContentBundle demographicContentBundle = new DemographicCodedContentBundle();
+            Assert.NotNull(demographicContentBundle.GetBundle());
+        }
+
+        [Fact]
+        public void ProvidedBundleGetsInitialized()
+        {
+            Bundle bundle = new Bundle();
+            DemographicCodedContentBundle demographicContentBundle = new DemographicCodedContentBundle(bundle);
+            Assert.Equal(bundle, demographicContentBundle.GetBundle());
+        }
+
+        [Fact]
+        public void ProfileUrlIsCorrect()
+        {
+            DemographicCodedContentBundle demographicContentBundle = new DemographicCodedContentBundle();
+            Assert.Equal(ProfileURL.DemographicCodedContentBundle, demographicContentBundle.GetContentType());
+        }
+
+        // TODO: Test cases
+
+        private string FixturePath(string filePath)
+        {
+            if (Path.IsPathRooted(filePath))
+            {
+                return filePath;
+            }
+            else
+            {
+                return Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
+            }
+        }
+    }
+}

--- a/VRDR/CauseOfDeathCodedContentBundle.cs
+++ b/VRDR/CauseOfDeathCodedContentBundle.cs
@@ -14,7 +14,7 @@ namespace VRDR
     /// 
     /// Placeholder class; to be implemented to support VRDR Messaging IG.
     /// </summary>
-    public class CauseOfDeathCodedContentBundle
+    public class CauseOfDeathCodedContentBundle : VRDRBundle
     {
         private readonly Bundle Bundle;
 

--- a/VRDR/CauseOfDeathCodedContentBundle.cs
+++ b/VRDR/CauseOfDeathCodedContentBundle.cs
@@ -50,6 +50,15 @@ namespace VRDR
         // TODO: Implement relevant properties
 
         /// <summary>
+        /// Gets the FHIR IG type of the content.
+        /// </summary>
+        /// <returns>A string representation of the profile URL.</returns>
+        public string GetContentType()
+        {
+            return ProfileURL.CauseOfDeathCodedContentBundle;
+        }
+
+        /// <summary>
         /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.
         /// </summary>
         /// <returns>The FHIR Bundle.</returns>

--- a/VRDR/CauseOfDeathCodedContentBundle.cs
+++ b/VRDR/CauseOfDeathCodedContentBundle.cs
@@ -11,6 +11,8 @@ namespace VRDR
     /// This class was designed to help consume and produce coding responses that follow the
     /// HL7 FHIR Vital Records Death Reporting Implementation Guide, as described at:
     /// http://hl7.org/fhir/us/vrdr and https://github.com/hl7/vrdr. 
+    /// 
+    /// Placeholder class; to be implemented to support VRDR Messaging IG.
     /// </summary>
     public class CauseOfDeathCodedContentBundle
     {
@@ -44,6 +46,8 @@ namespace VRDR
             // TODO: Parser implementation
             throw new NotImplementedException("Parsing this from text is not yet implemented.");
         }
+
+        // TODO: Implement relevant properties
 
         /// <summary>
         /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.

--- a/VRDR/CauseOfDeathCodedContentBundle.cs
+++ b/VRDR/CauseOfDeathCodedContentBundle.cs
@@ -1,0 +1,75 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VRDR
+{
+    /// <summary>
+    /// Models a FHIR Vital Records Death Reporting (VRDR) CauseOfDeathCodedContentBundle.
+    /// This class was designed to help consume and produce coding responses that follow the
+    /// HL7 FHIR Vital Records Death Reporting Implementation Guide, as described at:
+    /// http://hl7.org/fhir/us/vrdr and https://github.com/hl7/vrdr. 
+    /// </summary>
+    public class CauseOfDeathCodedContentBundle
+    {
+        private readonly Bundle Bundle;
+
+        /// <summary>
+        /// Initializes an empty CauseOfDeathCodedContentBundle.
+        /// </summary>
+        public CauseOfDeathCodedContentBundle()
+        {
+            Bundle = new Bundle();
+        }
+
+        /// <summary>
+        /// Initializes a CauseOfDeathCodedContentBundle from a <see cref="Hl7.Fhir.Model.Bundle">FHIR Bundle</see>.
+        /// </summary>
+        public CauseOfDeathCodedContentBundle(Bundle bundle)
+        {
+            this.Bundle = bundle;
+            // TODO: Verify correct type/valid contents?
+        }
+
+        /// <summary>
+        /// Initializes a CauseOfDeathCodedContentBundle by parsing a JSON or XML representation of the bundle.
+        /// </summary>
+        /// <param name="record">Represents a FHIR CauseOfDeathCodedContentBundle in either XML or JSON format.</param>
+        /// <param name="permissive">Indicates whether the parser should be permissive when parsing the given string.</param>
+        /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
+        public CauseOfDeathCodedContentBundle(string record, bool permissive = false)
+        {
+            // TODO: Parser implementation
+            throw new NotImplementedException("Parsing this from text is not yet implemented.");
+        }
+
+        /// <summary>
+        /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.
+        /// </summary>
+        /// <returns>The FHIR Bundle.</returns>
+        public Bundle GetBundle()
+        {
+            return Bundle;
+        }
+
+        /// <summary>
+        /// Serializes the Bundle to XML.
+        /// </summary>
+        /// <returns>A string containing the XML representation of the Bundle.</returns>
+        public string ToXml()
+        {
+            return Bundle.ToXml();
+        }
+
+        /// <summary>
+        /// Serializes the Bundle to JSON.
+        /// </summary>
+        /// <returns>A string containing the JSON representation of the Bundle.</returns>
+        public string ToJson()
+        {
+            return Bundle.ToJson();
+        }
+    }
+}

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -17,7 +17,7 @@ namespace VRDR
     /// HL7 FHIR Vital Records Death Reporting Implementation Guide, as described at:
     /// http://hl7.org/fhir/us/vrdr and https://github.com/hl7/vrdr.
     /// </summary>
-    public class DeathRecord
+    public class DeathRecord : VRDRBundle
     {
         /// <summary>Mortality data for code translations.</summary>
         private MortalityData MortalityData = MortalityData.Instance;
@@ -8556,6 +8556,11 @@ namespace VRDR
                 }
             }
             return record;
+        }
+
+        public string GetContentType()
+        {
+            return ProfileURL.DeathCertificateDocument;
         }
     }
 

--- a/VRDR/DemographicCodedContentBundle.cs
+++ b/VRDR/DemographicCodedContentBundle.cs
@@ -50,6 +50,15 @@ namespace VRDR
         // TODO: Implement relevant properties
 
         /// <summary>
+        /// Gets the FHIR IG type of the content.
+        /// </summary>
+        /// <returns>A string representation of the profile URL.</returns>
+        public string GetContentType()
+        {
+            return ProfileURL.DemographicCodedContentBundle;
+        }
+
+        /// <summary>
         /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.
         /// </summary>
         /// <returns>The FHIR Bundle.</returns>

--- a/VRDR/DemographicCodedContentBundle.cs
+++ b/VRDR/DemographicCodedContentBundle.cs
@@ -1,0 +1,75 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VRDR
+{
+    /// <summary>
+    /// Models a FHIR Vital Records Death Reporting (VRDR) DemographicCodedContentBundle.
+    /// This class was designed to help consume and produce coding responses that follow the
+    /// HL7 FHIR Vital Records Death Reporting Implementation Guide, as described at:
+    /// http://hl7.org/fhir/us/vrdr and https://github.com/hl7/vrdr. 
+    /// </summary>
+    public class DemographicCodedContentBundle
+    {
+        private readonly Bundle Bundle;
+
+        /// <summary>
+        /// Initializes an empty DemographicCodedContentBundle.
+        /// </summary>
+        public DemographicCodedContentBundle()
+        {
+            Bundle = new Bundle();
+        }
+
+        /// <summary>
+        /// Initializes a DemographicCodedContentBundle from a <see cref="Hl7.Fhir.Model.Bundle">FHIR Bundle</see>.
+        /// </summary>
+        public DemographicCodedContentBundle(Bundle bundle)
+        {
+            this.Bundle = bundle;
+            // TODO: Verify correct type/valid contents?
+        }
+
+        /// <summary>
+        /// Initializes a DemographicCodedContentBundle by parsing a JSON or XML representation of the bundle.
+        /// </summary>
+        /// <param name="record">Represents a FHIR DemographicCodedContentBundle in either XML or JSON format.</param>
+        /// <param name="permissive">Indicates whether the parser should be permissive when parsing the given string.</param>
+        /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
+        public DemographicCodedContentBundle(string record, bool permissive = false)
+        {
+            // TODO: Parser implementation
+            throw new NotImplementedException("Parsing this from text is not yet implemented.");
+        }
+
+        /// <summary>
+        /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.
+        /// </summary>
+        /// <returns>The FHIR Bundle.</returns>
+        public Bundle GetBundle()
+        {
+            return Bundle;
+        }
+
+        /// <summary>
+        /// Serializes the Bundle to XML.
+        /// </summary>
+        /// <returns>A string containing the XML representation of the Bundle.</returns>
+        public string ToXml()
+        {
+            return Bundle.ToXml();
+        }
+
+        /// <summary>
+        /// Serializes the Bundle to JSON.
+        /// </summary>
+        /// <returns>A string containing the JSON representation of the Bundle.</returns>
+        public string ToJson()
+        {
+            return Bundle.ToJson();
+        }
+    }
+}

--- a/VRDR/DemographicCodedContentBundle.cs
+++ b/VRDR/DemographicCodedContentBundle.cs
@@ -14,7 +14,7 @@ namespace VRDR
     /// 
     /// Placeholder class; to be implemented to support VRDR Messaging IG.
     /// </summary>
-    public class DemographicCodedContentBundle
+    public class DemographicCodedContentBundle : VRDRBundle
     {
         private readonly Bundle Bundle;
 

--- a/VRDR/DemographicCodedContentBundle.cs
+++ b/VRDR/DemographicCodedContentBundle.cs
@@ -11,6 +11,8 @@ namespace VRDR
     /// This class was designed to help consume and produce coding responses that follow the
     /// HL7 FHIR Vital Records Death Reporting Implementation Guide, as described at:
     /// http://hl7.org/fhir/us/vrdr and https://github.com/hl7/vrdr. 
+    /// 
+    /// Placeholder class; to be implemented to support VRDR Messaging IG.
     /// </summary>
     public class DemographicCodedContentBundle
     {
@@ -44,6 +46,8 @@ namespace VRDR
             // TODO: Parser implementation
             throw new NotImplementedException("Parsing this from text is not yet implemented.");
         }
+
+        // TODO: Implement relevant properties
 
         /// <summary>
         /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.

--- a/VRDR/URLs.cs
+++ b/VRDR/URLs.cs
@@ -127,7 +127,6 @@ namespace VRDR
 
         /// <summary>URL for RecordAxisCauseOfDeath</summary>
         public const string RecordAxisCauseOfDeath = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-record-axis-cause-of-death";
-
     }
 
     /// <summary>Extension URLs</summary>

--- a/VRDR/VRDRBundle.cs
+++ b/VRDR/VRDRBundle.cs
@@ -1,0 +1,39 @@
+﻿using Hl7.Fhir.Model;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VRDR
+{
+    /// <summary>
+    /// A VRDR-augmented wrapper for a FHIR <see cref="Hl7.Fhir.Model.Bundle">Bundle</see>.
+    /// </summary>
+    public interface VRDRBundle
+    {
+        /// <summary>
+        /// Gets the FHIR IG type of the content.
+        /// </summary>
+        /// <returns>A string representation of the profile URL.</returns>
+        string GetContentType();
+
+
+        /// <summary>
+        /// Gets the underlying <see cref="Hl7.Fhir.Model.Bundle">Bundle</see> containing the data.
+        /// </summary>
+        /// <returns>The FHIR Bundle.</returns>
+        Bundle GetBundle();
+
+
+        /// <summary>
+        /// Serializes the Bundle to XML.
+        /// </summary>
+        /// <returns>A string containing the XML representation of the Bundle.</returns>
+        string ToXml();
+
+        /// <summary>
+        /// Serializes the Bundle to JSON.
+        /// </summary>
+        /// <returns>A string containing the JSON representation of the Bundle.</returns>
+        string ToJson();
+    }
+}


### PR DESCRIPTION
Added initial types to support messaging IG.

Commit f197ee87ea59db1d056e2711c5bb6c172df5ba6e adds a common interface for them and DeathRecord; we can simply revert this commit to remove the interface if it is not expected to be useful.