### PR TITLE
Move identifiers (FILENO, AUXNO, and AUXNO2) to DeathCertificate.

### DIFF
--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -337,8 +337,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_BundleIdentifier()
         {
-            Assert.Equal("000182", ((DeathRecord)JSONRecords[0]).BundleIdentifier);
-            Assert.Equal("000182", ((DeathRecord)XMLRecords[0]).BundleIdentifier);
+            Assert.Equal("2019YC000182", ((DeathRecord)JSONRecords[0]).BundleIdentifier);
+            Assert.Equal("2019YC000182", ((DeathRecord)XMLRecords[0]).BundleIdentifier);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -317,8 +317,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_Identifier()
         {
-            Assert.Equal("1", ((DeathRecord)JSONRecords[0]).Identifier);
-            Assert.Equal("1", ((DeathRecord)XMLRecords[0]).Identifier);
+            Assert.Equal("000182", ((DeathRecord)JSONRecords[0]).Identifier);
+            Assert.Equal("000182", ((DeathRecord)XMLRecords[0]).Identifier);
         }
 
         [Fact]

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -46,20 +46,20 @@ namespace VRDR.Tests
             Assert.Equal("2019-02-20T16:48:06-05:00", submission.DeathRecord.DateOfDeathPronouncement);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", submission.MessageType);
             Assert.Equal(10,10);
-            Assert.Equal((uint)1, submission.CertificateNumber);
+            Assert.Equal((uint)182, submission.CertificateNumber);
             Assert.Equal((uint)2019, submission.DeathYear);
             Assert.Equal("000000000042", submission.StateAuxiliaryIdentifier);
-            Assert.Equal("2019YC000001", submission.NCHSIdentifier);
+            Assert.Equal("2019YC000182", submission.NCHSIdentifier);
 
             record = (DeathRecord)JSONRecords[0];
             submission = new DeathRecordSubmission(record);
             Assert.NotNull(submission.DeathRecord);
             Assert.Equal("2018-02-20T16:48:06-05:00", submission.DeathRecord.DateOfDeathPronouncement);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", submission.MessageType);
-            Assert.Equal((uint)1, submission.CertificateNumber);
+            Assert.Equal((uint)182, submission.CertificateNumber);
             Assert.Equal((uint)2019, submission.DeathYear);
             Assert.Equal("000000000042", submission.StateAuxiliaryIdentifier);
-            Assert.Equal("2019YC000001", submission.NCHSIdentifier);
+            Assert.Equal("2019YC000182", submission.NCHSIdentifier);
 
             record = null;
             submission = new DeathRecordSubmission(record);
@@ -152,10 +152,10 @@ namespace VRDR.Tests
             Assert.NotNull(update.DeathRecord);
             Assert.Equal("2019-02-20T16:48:06-05:00", update.DeathRecord.DateOfDeathPronouncement);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission_update", update.MessageType);
-            Assert.Equal((uint)1, update.CertificateNumber);
+            Assert.Equal((uint)182, update.CertificateNumber);
             Assert.Equal((uint)2019, update.DeathYear);
             Assert.Equal("000000000042", update.StateAuxiliaryIdentifier);
-            Assert.Equal("2019YC000001", update.NCHSIdentifier);
+            Assert.Equal("2019YC000182", update.NCHSIdentifier);
 
             update = new DeathRecordUpdate((DeathRecord)JSONRecords[1]); // no ids in this death record (except jurisdiction id which is required)
             Assert.NotNull(update.DeathRecord);
@@ -894,9 +894,9 @@ namespace VRDR.Tests
         {
             VoidMessage message = new VoidMessage((DeathRecord)XMLRecords[0]);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission_void", message.MessageType);
-            Assert.Equal((uint)1, message.CertificateNumber);
+            Assert.Equal((uint)182, message.CertificateNumber);
             Assert.Equal("000000000042", message.StateAuxiliaryIdentifier);
-            Assert.Equal("2019YC000001", message.NCHSIdentifier);
+            Assert.Equal("2019YC000182", message.NCHSIdentifier);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", message.MessageDestination);
             Assert.Null(message.MessageSource);
 

--- a/VRDR.Tests/fixtures/json/Bundle-DeathCertificateDocument-Example2.json
+++ b/VRDR.Tests/fixtures/json/Bundle-DeathCertificateDocument-Example2.json
@@ -8,18 +8,8 @@
   },
   "type": "document",
   "identifier": {
-    "extension": [
-      {
-        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
-        "valueString": "000000000001"
-      },
-      {
-        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
-        "valueString": "100000000001"
-      }
-    ],
     "system": "http://nchs.cdc.gov/vrdr_id",
-    "value": "000182"
+    "value": "2020YC000182"
   },
   "timestamp": "2020-10-20T14:48:35.401641-04:00",
   "entry": [
@@ -70,6 +60,19 @@
             ]
           }
         ],
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "000000000001"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
+              "valueString": "100000000001"
+            }
+          ],
+          "value": "000182"
+        },
         "section": [
           {
             "code": {
@@ -411,15 +414,15 @@
               "extension": [
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
-                  "valueInteger": 10
+                  "valueUnsignedInt": 10
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
-                  "valueInteger": 2004
+                  "valueUnsignedInt": 2004
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
-                  "valueInteger": 11
+                  "valueUnsignedInt": 11
                 }
               ],
               "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDate"
@@ -599,8 +602,7 @@
           "coding": [
             {
               "code": "inputraceandethnicity",
-              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs",
-              "display": "Input Race and Ethnicity"
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs"
             }
           ]
         },
@@ -610,8 +612,7 @@
               "coding": [
                 {
                   "code": "White",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "White"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -622,8 +623,7 @@
               "coding": [
                 {
                   "code": "BlackOrAfricanAmerican",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "BlackOrAfricanAmerican"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -634,20 +634,18 @@
               "coding": [
                 {
                   "code": "AmericanIndianOrAlaskaNative",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "AmericanIndianOrAlaskaNative"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
-            "valueBoolean": false
+            "valueBoolean": true
           },
           {
             "code": {
               "coding": [
                 {
                   "code": "AsianIndian",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "AsianIndian"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -658,8 +656,7 @@
               "coding": [
                 {
                   "code": "Chinese",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Chinese"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -670,8 +667,7 @@
               "coding": [
                 {
                   "code": "Filipino",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Filipino"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -682,8 +678,7 @@
               "coding": [
                 {
                   "code": "Japanese",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Japanese"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -694,8 +689,7 @@
               "coding": [
                 {
                   "code": "Korean",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Korean"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -706,8 +700,7 @@
               "coding": [
                 {
                   "code": "Vietnamese",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Vietnamese"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -718,20 +711,18 @@
               "coding": [
                 {
                   "code": "OtherAsian",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "OtherAsian"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
-            "valueBoolean": false
+            "valueBoolean": true
           },
           {
             "code": {
               "coding": [
                 {
                   "code": "NativeHawaiian",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "NativeHawaiian"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -742,8 +733,7 @@
               "coding": [
                 {
                   "code": "GuamanianOrChamorro",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "GuamanianOrChamorro"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -754,8 +744,7 @@
               "coding": [
                 {
                   "code": "Samoan",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Samoan"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -766,8 +755,7 @@
               "coding": [
                 {
                   "code": "OtherPacificIslander",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "OtherPacificIslander"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -778,8 +766,7 @@
               "coding": [
                 {
                   "code": "OtherRace",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "OtherRace"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -789,9 +776,30 @@
             "code": {
               "coding": [
                 {
+                  "code": "FirstOtherAsianLiteral",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+                }
+              ]
+            },
+            "valueString": "Malaysian"
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "FirstAmericanIndianOrAlaskaNativeLiteral",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+                }
+              ]
+            },
+            "valueString": "Arikara"
+          },
+          {
+            "code": {
+              "coding": [
+                {
                   "code": "HispanicMexican",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "HispanicMexican"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -1181,15 +1189,15 @@
               "extension": [
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
-                  "valueInteger": 12
+                  "valueUnsignedInt": 12
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
-                  "valueInteger": 2020
+                  "valueUnsignedInt": 2020
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
-                  "valueInteger": 11
+                  "valueUnsignedInt": 11
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",
@@ -1316,8 +1324,7 @@
             "coding": [
               {
                 "code": "death",
-                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
-                "display": "Death Location"
+                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs"
               }
             ]
           }
@@ -1350,8 +1357,7 @@
             "coding": [
               {
                 "code": "injury",
-                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
-                "display": "InjuryLocation"
+                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs"
               }
             ]
           }
@@ -1363,6 +1369,92 @@
         }
       },
       "fullUrl": "http://www.example.org/fhir/Location/InjuryLocation-Example1"
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "InjuryIncident-Example1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-incident"
+          ]
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "code": "11374-6",
+              "system": "http://loinc.org",
+              "display": "Injury incident description Narrative"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "69444-8",
+                  "system": "http://loinc.org",
+                  "display": "Did death result from injury at work"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "N",
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                  "display": "No"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "69450-5",
+                  "system": "http://loinc.org",
+                  "display": "Place of injury Facility"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "text": "Home"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "69451-3",
+                  "system": "http://loinc.org",
+                  "display": "Transportation role of decedent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "OTH",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                  "display": "Other"
+                }
+              ],
+              "text": "Hoverboard Rider"
+            }
+          }
+        ],
+        "subject": {
+          "reference": "Patient/Decedent-Example1"
+        },
+        "effectiveDateTime": "2019-11-02T13:00:00-05:00",
+        "valueCodeableConcept": {
+          "text": "drug toxicity"
+        }
+      },
+      "fullUrl": "http://www.example.org/fhir/Observation/InjuryIncident-Example1"
     },
     {
       "resource": {
@@ -1649,8 +1741,7 @@
             "coding": [
               {
                 "code": "disposition",
-                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
-                "display": "Disposition location"
+                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs"
               }
             ]
           }
@@ -1849,8 +1940,7 @@
           "coding": [
             {
               "code": "80626-5",
-              "system": "http://loinc.org",
-              "display": "Activity at time of death [CDC]"
+              "system": "http://loinc.org"
             }
           ]
         },
@@ -1883,8 +1973,7 @@
           "coding": [
             {
               "code": "codedraceandethnicity",
-              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs",
-              "display": "Coded Race and Ethnicity"
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs"
             }
           ]
         },
@@ -1894,8 +1983,7 @@
               "coding": [
                 {
                   "code": "FirstEditedCode",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "FirstEditedCode"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -1914,8 +2002,7 @@
               "coding": [
                 {
                   "code": "SecondEditedCode",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "SecondEditedCode"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -1933,18 +2020,17 @@
             "code": {
               "coding": [
                 {
-                  "code": "HispanicCode",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "HispanicCode"
+                  "code": "FirstAmericanIndianCode",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
             "valueCodeableConcept": {
               "coding": [
                 {
-                  "code": "233",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-hispanic-origin-cs",
-                  "display": "Chilean"
+                  "code": "A31",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-race-code-cs",
+                  "display": "Arikara"
                 }
               ]
             }
@@ -1954,8 +2040,7 @@
               "coding": [
                 {
                   "code": "RaceRecode40",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "RaceRecode40"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -1965,6 +2050,25 @@
                   "code": "20",
                   "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-race-recode-40-cs",
                   "display": "AIAN and Asian"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "HispanicCode",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "code": "233",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-hispanic-origin-cs",
+                  "display": "Chilean"
                 }
               ]
             }
@@ -1990,8 +2094,7 @@
           "coding": [
             {
               "code": "80359-3",
-              "system": "http://loinc.org",
-              "display": "Cause of death.underlying [Manual]"
+              "system": "http://loinc.org"
             }
           ]
         },
@@ -2023,8 +2126,7 @@
           "coding": [
             {
               "code": "80358-5",
-              "system": "http://loinc.org",
-              "display": "Cause of death.underlying [Automated]"
+              "system": "http://loinc.org"
             }
           ]
         },
@@ -2056,8 +2158,7 @@
           "coding": [
             {
               "code": "80357-7",
-              "system": "http://loinc.org",
-              "display": "Cause of death record axis code [Automated]"
+              "system": "http://loinc.org"
             }
           ]
         },
@@ -2067,8 +2168,7 @@
               "coding": [
                 {
                   "code": "position",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Position"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -2103,8 +2203,7 @@
           "coding": [
             {
               "code": "80356-9",
-              "system": "http://loinc.org",
-              "display": "Cause of death entity axis code [Automated]"
+              "system": "http://loinc.org"
             }
           ]
         },
@@ -2114,8 +2213,7 @@
               "coding": [
                 {
                   "code": "lineNumber",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "lineNumber"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -2126,8 +2224,7 @@
               "coding": [
                 {
                   "code": "position",
-                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
-                  "display": "Position"
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
                 }
               ]
             },
@@ -2162,8 +2259,7 @@
           "coding": [
             {
               "code": "11376-1",
-              "system": "http://loinc.org",
-              "display": "Injury location"
+              "system": "http://loinc.org"
             }
           ]
         },

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -6,20 +6,6 @@
       "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document"
     ]
   },
-  "identifier" : {
-    "extension" : [
-      {
-        "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
-        "valueString" : "000000000042"
-      },
-      {
-        "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
-        "valueString" : "100000000001"
-      }
-    ],
-    "system" : "http://nchs.cdc.gov/vrdr_id",
-    "value" : "000182"
-  },
   "type" : "document",
   "timestamp" : "2020-10-20T14:48:35.401641-04:00",
   "entry": [
@@ -33,8 +19,18 @@
             "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate"
           ]
         },
-        "identifier": {
-          "value": "99999"
+        "identifier" : {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString" : "000000000042"
+            },
+            {
+              "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
+              "valueString" : "100000000001"
+            }
+          ],
+          "value" : "000182"
         },
         "extension" : [
           {

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -4,18 +4,6 @@
     <profile
              value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document"/>
   </meta>
-  <identifier>
-    <extension
-               url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1">
-      <valueString value="000000000042"/>
-    </extension>
-    <extension
-               url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2">
-      <valueString value="100000000001"/>
-    </extension>
-    <system value="http://nchs.cdc.gov/vrdr_id"/>
-    <value value="000182"/>
-  </identifier>
   <type value="document"/>
   <timestamp value="2020-10-20T14:48:35.401641-04:00"/>
   <entry>
@@ -47,9 +35,18 @@
         <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/StateSpecificField">
           <valueString value="State Specific Content"/>
         </extension>
-        <identifier>
-          <value value="99999" />
-        </identifier>
+  <identifier>
+    <extension
+               url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1">
+      <valueString value="000000000042"/>
+    </extension>
+    <extension
+               url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2">
+      <valueString value="100000000001"/>
+    </extension>
+    <system value="http://nchs.cdc.gov/vrdr_id"/>
+    <value value="000182"/>
+  </identifier>
         <status value="final" />
         <type>
           <coding>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -35,18 +35,18 @@
         <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/StateSpecificField">
           <valueString value="State Specific Content"/>
         </extension>
-  <identifier>
-    <extension
-               url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1">
-      <valueString value="000000000042"/>
-    </extension>
-    <extension
-               url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2">
-      <valueString value="100000000001"/>
-    </extension>
-    <system value="http://nchs.cdc.gov/vrdr_id"/>
-    <value value="000182"/>
-  </identifier>
+        <identifier>
+          <extension
+                    url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1">
+            <valueString value="000000000042"/>
+          </extension>
+          <extension
+                    url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2">
+            <valueString value="100000000001"/>
+          </extension>
+          <system value="http://nchs.cdc.gov/vrdr_id"/>
+          <value value="000182"/>
+        </identifier>
         <status value="final" />
         <type>
           <coding>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -6145,7 +6145,6 @@ namespace VRDR
                     CreateSurgeryDateObs();
                 }
                 SetPartialDate(SurgeryDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateYear, value);
-                UpdateBundleIdentifier();
             }
         }
 
@@ -7341,7 +7340,6 @@ namespace VRDR
                     CreateInjuryIncidentObs();
                 }
                 SetPartialDate(InjuryIncidentObs.Effective.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateYear, value);
-                UpdateBundleIdentifier();
             }
         }
 
@@ -7372,7 +7370,6 @@ namespace VRDR
                     CreateInjuryIncidentObs();
                 }
                 SetPartialDate(InjuryIncidentObs.Effective.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateMonth, value);
-                UpdateBundleIdentifier();
             }
         }
 
@@ -7403,7 +7400,6 @@ namespace VRDR
                     CreateInjuryIncidentObs();
                 }
                 SetPartialDate(InjuryIncidentObs.Effective.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateDay, value);
-                UpdateBundleIdentifier();
             }
         }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -961,7 +961,7 @@ namespace VRDR
             {
                 if (Composition?.Identifier?.Extension != null)
                 {
-                    Extension ext = Bundle.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
+                    Extension ext = Composition.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
                     if (ext?.Value != null)
                     {
                         return Convert.ToString(ext.Value);
@@ -5784,7 +5784,7 @@ namespace VRDR
                         // There's either a specific claim that there's no data or actually no data, so return null
                         return null;
                     }
-                    return (uint?)((Integer)part.Value).Value; // Untangle a FHIR UnsignedInt in an extension into a uint
+                    return (uint?)((UnsignedInt)part.Value).Value; // Untangle a FHIR UnsignedInt in an extension into a uint
                 }
             }
             return null;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -861,21 +861,28 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Certificate Number: {ExampleDeathRecord.Identifier}");</para>
         /// </example>
-        [Property("Identifier", Property.Types.String, "Death Certification", "Death Certificate Number.", true, IGURL.DeathCertification, true, 3)]
-        [FHIRPath("Bundle.entry.resource.where($this is Procedure).where(code.coding.code='308646001')", "identifier")]
+        [Property("Identifier", Property.Types.String, "Death Certification", "Death Certificate Number.", true, IGURL.DeathCertificate, true, 3)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Procedure).where(code.coding.code='308646001')", "identifier")]
+         [FHIRPath("Bundle.entry.resource.where($this is Composition)", "identifier")]
         public string Identifier
         {
             get
             {
-                Identifier id = DeathCertification?.Identifier?.FirstOrDefault(i => i.Value != null && i.Value.Length > 0);
-                return id == null ? null : id.Value;
+                if(Composition != null && Composition.Identifier != null && Composition.Identifier.Value != null && Composition.Identifier.Value.Length > 0)
+                {
+                    return Composition.Identifier.Value;
+                }
+                return null;
+
             }
             set
             {
-                DeathCertification.Identifier.Clear();
                 Identifier identifier = new Identifier();
                 identifier.Value = value;
-                DeathCertification.Identifier.Add(identifier);
+                if(Composition == null){
+                    Composition = new Composition();
+                }
+                Composition.Identifier = identifier;
                 UpdateBundleIdentifier();
             }
         }
@@ -884,7 +891,10 @@ namespace VRDR
         private void UpdateBundleIdentifier()
         {
             uint certificateNumber = 0;
-            UInt32.TryParse(this.Identifier, out certificateNumber);
+            if (Composition != null && Composition.Identifier != null && Composition.Identifier.Value != null)
+            {
+                UInt32.TryParse(Composition.Identifier.Value, out certificateNumber);
+            }
             uint deathYear = 0;
             if (this.DeathYear != null)
             {
@@ -912,7 +922,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"NCHS identifier: {ExampleDeathRecord.BundleIdentifier}");</para>
         /// </example>
-        [Property("Bundle Identifier", Property.Types.String, "Death Certification", "NCHS identifier.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Certificate-Document.html", true, 4)]
+        [Property("Bundle Identifier", Property.Types.String, "Death Certification", "NCHS identifier.", true, IGURL.DeathCertificateDocument, true, 4)]
         [FHIRPath("Bundle", "identifier")]
         public string BundleIdentifier
         {
@@ -943,13 +953,13 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"State local identifier: {ExampleDeathRecord.StateLocalIdentifier1}");</para>
         /// </example>
-        [Property("State Local Identifier1", Property.Types.String, "Death Certificate Document", "State Local Identifier.", true, ProfileURL.DeathCertificateDocument, true, 5)]
-        [FHIRPath("Bundle", "identifier")]
+        [Property("State Local Identifier1", Property.Types.String, "Death Certificate", "State Local Identifier.", true, ProfileURL.DeathCertificate, true, 5)]
+        [FHIRPath("Bundle.entry.resource.where($this is Composition)", "identifier")]
         public string StateLocalIdentifier1
         {
             get
             {
-                if (Bundle?.Identifier?.Extension != null)
+                if (Composition?.Identifier?.Extension != null)
                 {
                     Extension ext = Bundle.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
                     if (ext?.Value != null)
@@ -962,9 +972,12 @@ namespace VRDR
             }
             set
             {
-                if (Bundle?.Identifier?.Extension != null)
+                if(Composition == null){
+                    Composition = new Composition();
+                }
+                if (Composition?.Identifier?.Extension != null)
                 {
-                    Bundle.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
+                    Composition.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
                 }
 
                 if (!String.IsNullOrWhiteSpace(value))
@@ -972,12 +985,12 @@ namespace VRDR
                     Extension ext = new Extension();
                     ext.Url = ExtensionURL.AuxiliaryStateIdentifier1;
                     ext.Value = new FhirString(value);
-                    if (Bundle.Identifier == null)
+                    if (Composition.Identifier == null)
                     {
                         Identifier identifier = new Identifier();
-                        Bundle.Identifier = identifier;
+                        Composition.Identifier = identifier;
                     }
-                    Bundle.Identifier.Extension.Add(ext);
+                    Composition.Identifier.Extension.Add(ext);
                 }
 
             }
@@ -991,15 +1004,15 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"State local identifier: {ExampleDeathRecord.StateLocalIdentifier1}");</para>
         /// </example>
-        [Property("State Local Identifier2", Property.Types.String, "Death Certificate Document", "State Local Identifier.", true, ProfileURL.DeathCertificateDocument, true, 5)]
-        [FHIRPath("Bundle", "identifier")]
+        [Property("State Local Identifier2", Property.Types.String, "Death Certificate", "State Local Identifier.", true, ProfileURL.DeathCertificate, true, 5)]
+        [FHIRPath("Bundle.entry.resource.where($this is Composition)", "identifier")]
         public string StateLocalIdentifier2
         {
             get
             {
-                if (Bundle?.Identifier?.Extension != null)
+                if (Composition?.Identifier?.Extension != null)
                 {
-                    Extension ext = Bundle.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
+                    Extension ext = Composition.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
                     if (ext?.Value != null)
                     {
                         return Convert.ToString(ext.Value);
@@ -1010,9 +1023,12 @@ namespace VRDR
             }
             set
             {
-                if (Bundle?.Identifier?.Extension != null)
+                 if(Composition == null){
+                    Composition = new Composition();
+                }
+                if (Composition?.Identifier?.Extension != null)
                 {
-                    Bundle.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
+                    Composition.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
                 }
 
                 if (!String.IsNullOrWhiteSpace(value))
@@ -1020,12 +1036,12 @@ namespace VRDR
                     Extension ext = new Extension();
                     ext.Url = ExtensionURL.AuxiliaryStateIdentifier2;
                     ext.Value = new FhirString(value);
-                    if (Bundle.Identifier == null)
+                    if (Composition.Identifier == null)
                     {
                         Identifier identifier = new Identifier();
-                        Bundle.Identifier = identifier;
+                        Composition.Identifier = identifier;
                     }
-                    Bundle.Identifier.Extension.Add(ext);
+                    Composition.Identifier.Extension.Add(ext);
                 }
 
             }
@@ -5768,7 +5784,7 @@ namespace VRDR
                         // There's either a specific claim that there's no data or actually no data, so return null
                         return null;
                     }
-                    return (uint?)((UnsignedInt)part.Value).Value; // Untangle a FHIR UnsignedInt in an extension into a uint
+                    return (uint?)((Integer)part.Value).Value; // Untangle a FHIR UnsignedInt in an extension into a uint
                 }
             }
             return null;
@@ -10261,6 +10277,7 @@ namespace VRDR
                     }
                 }
             }
+            UpdateBundleIdentifier();
         }
 
         /// <summary>Helper function to set a codeable value based on a code and the set of allowed codes.</summary>


### PR DESCRIPTION
- Move the FILENO, AUXNO, and AUXNO2 fields to DeathCertificate (from DeathCertificateProcedure and DeathCertificateDocument)
- DeathCertificateDocument.identifier is the bundle identifier (YYYYJJNNNNNN)
- Updated tests.  
- Changes made, and accompanying changes made to the IG on branch moveIdentifier http://build.fhir.org/ig/HL7/vrdr/branches/moveIdentifier/IJE_File_Layouts_Version_2021_FHIR.html 