### PR TITLE
Death record identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v4.0.0.preview2 - 2022-05-09
+
+* Addressed inconsistencies in how identifiers were being handled
+
 ### v4.0.0.preview1 - 2022-05-07
 
 * Aligned VRDR library to latest VRDR IG at http://build.fhir.org/ig/HL7/vrdr/artifacts.html

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>4.0.0-preview1</Version>
+        <Version>4.0.0-preview2</Version>
         <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
         <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ This repository includes .NET (C#) code for
 <tr>
 <td style="text-align: center;">1.3.0 STU2 Post-Ballot Pre-Publication</td>
 <td style="text-align: center;">R4</td>
-<td style="text-align: center;">V4.0.0.preview1</td>
-<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR/4.0.0.preview1">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0.preview1"> github</a></td>
-<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR.Messaging/4.0.0.preview1">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0.preview1"> github</a></td>
+<td style="text-align: center;">V4.0.0.preview2</td>
+<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR/4.0.0.preview2">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0.preview2"> github</a></td>
+<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR.Messaging/4.0.0.preview2">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0.preview2"> github</a></td>
 </tr>
 </tbody>
 </table>
@@ -74,7 +74,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR" Version="4.0.0.preview1" />
+  <PackageReference Include="VRDR" Version="4.0.0.preview2" />
   ...
 </ItemGroup>
 ```
@@ -274,7 +274,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR.Messaging" Version="4.0.0.preview1" />
+  <PackageReference Include="VRDR.Messaging" Version="4.0.0.preview2" />
   ...
 </ItemGroup>
 ```

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -322,23 +322,23 @@ namespace VRDR.Tests
         }
 
         [Fact]
-        public void Set_BundleIdentifier()
+        public void Set_DeathRecordIdentifier()
         {
             DeathRecord empty = new DeathRecord();
-            Assert.Equal("0000XX000000", empty.BundleIdentifier);
+            Assert.Equal("0000XX000000", empty.DeathRecordIdentifier);
             empty.DateOfDeath = "2019-10-01";
-            Assert.Equal("2019XX000000", empty.BundleIdentifier);
+            Assert.Equal("2019XX000000", empty.DeathRecordIdentifier);
             empty.Identifier = "101";
-            Assert.Equal("2019XX000101", empty.BundleIdentifier);
+            Assert.Equal("2019XX000101", empty.DeathRecordIdentifier);
             empty.DeathLocationJurisdiction = "MA";  // 25 is the code for MA
-            Assert.Equal("2019MA000101", empty.BundleIdentifier);
+            Assert.Equal("2019MA000101", empty.DeathRecordIdentifier);
         }
 
         [Fact]
-        public void Get_BundleIdentifier()
+        public void Get_DeathRecordIdentifier()
         {
-            Assert.Equal("2019YC000182", ((DeathRecord)JSONRecords[0]).BundleIdentifier);
-            Assert.Equal("2019YC000182", ((DeathRecord)XMLRecords[0]).BundleIdentifier);
+            Assert.Equal("2019YC000182", ((DeathRecord)JSONRecords[0]).DeathRecordIdentifier);
+            Assert.Equal("2019YC000182", ((DeathRecord)XMLRecords[0]).DeathRecordIdentifier);
         }
 
         [Fact]

--- a/VRDR.Tests/fixtures/json/DeathRecord1.json
+++ b/VRDR.Tests/fixtures/json/DeathRecord1.json
@@ -1,6 +1,23 @@
 {
   "resourceType" : "Bundle",
   "id" : "DeathCertificateDocument-Example1",
+  "identifier" : {
+    "extension" : [
+      {
+        "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber",
+        "valueString" : "000182"
+      },
+      {
+        "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
+        "valueString" : "000000000042"
+      },
+      {
+        "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
+        "valueString" : "100000000001"
+      }
+    ],
+    "value" : "2022YC000182"
+  },
   "meta" : {
     "profile" : [
       "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document"
@@ -18,19 +35,6 @@
           "profile": [
             "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate"
           ]
-        },
-        "identifier" : {
-          "extension" : [
-            {
-              "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
-              "valueString" : "000000000042"
-            },
-            {
-              "url" : "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
-              "valueString" : "100000000001"
-            }
-          ],
-          "value" : "000182"
         },
         "extension" : [
           {

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -4,6 +4,22 @@
     <profile
              value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document"/>
   </meta>
+  <identifier>
+    <extension
+              url="http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber">
+      <valueString value="000182"/>
+    </extension>
+    <extension
+              url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1">
+      <valueString value="000000000042"/>
+    </extension>
+    <extension
+              url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2">
+      <valueString value="100000000001"/>
+    </extension>
+    <system value="http://nchs.cdc.gov/vrdr_id"/>
+    <value value="2002YC000182"/>
+  </identifier>
   <type value="document"/>
   <timestamp value="2020-10-20T14:48:35.401641-04:00"/>
   <entry>
@@ -35,18 +51,6 @@
         <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/StateSpecificField">
           <valueString value="State Specific Content"/>
         </extension>
-        <identifier>
-          <extension
-                    url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1">
-            <valueString value="000000000042"/>
-          </extension>
-          <extension
-                    url="http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2">
-            <valueString value="100000000001"/>
-          </extension>
-          <system value="http://nchs.cdc.gov/vrdr_id"/>
-          <value value="000182"/>
-        </identifier>
         <status value="final" />
         <type>
           <coding>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -666,7 +666,7 @@ namespace VRDR
             // Create a Navigator for this new death record.
             Navigator = Bundle.ToTypedElement();
 
-            UpdateBundleIdentifier();
+            UpdateDeathRecordIdentifier();
         }
 
         /// <summary>Constructor that takes a string that represents a FHIR Death Record in either XML or JSON format.</summary>
@@ -815,10 +815,8 @@ namespace VRDR
             string[] profile = { ProfileURL.CauseOfDeathCodedContentBundle };
             codccBundle.Meta.Profile = profile;
             codccBundle.Timestamp = DateTime.Now;
-            // Get the base identifiers, including certificate number and auxiliary state IDs; the identifiers can either be on
-            // the Composition (if this DeathRecord is constructed) or on the Bundle (if this DeathRecord was read from JSON)
-            // TODO: Make sure we're getting the identifiers from the right place, since we're thinking through where they go
-            codccBundle.Identifier = Composition != null ? Composition.Identifier : Bundle.Identifier;
+            // Make sure to include the base identifiers, including certificate number and auxiliary state IDs
+            codccBundle.Identifier = Bundle.Identifier;
             AddResourceToBundleIfPresent(ActivityAtTimeOfDeathObs, codccBundle);
             AddResourceToBundleIfPresent(AutomatedUnderlyingCauseOfDeathObs, codccBundle);
             AddResourceToBundleIfPresent(ManualUnderlyingCauseOfDeathObs, codccBundle);
@@ -865,10 +863,8 @@ namespace VRDR
             string[] profile = { ProfileURL.DemographicCodedContentBundle };
             dccBundle.Meta.Profile = profile;
             dccBundle.Timestamp = DateTime.Now;
-            // Get the base identifiers, including certificate number and auxiliary state IDs; the identifiers can either be on
-            // the Composition (if this DeathRecord is constructed) or on the Bundle (if this DeathRecord was read from JSON)
-            // TODO: Make sure we're getting the identifiers from the right place, since we're thinking through where they go
-            dccBundle.Identifier = Composition != null ? Composition.Identifier : Bundle.Identifier;
+            // Make sure to include the base identifiers, including certificate number and auxiliary state IDs
+            dccBundle.Identifier = Bundle.Identifier;
             AddResourceToBundleIfPresent(CodedRaceAndEthnicityObs, dccBundle);
             AddResourceToBundleIfPresent(InputRaceAndEthnicityObs, dccBundle);
             return dccBundle;
@@ -889,46 +885,47 @@ namespace VRDR
         /// <para>Console.WriteLine($"Death Certificate Number: {ExampleDeathRecord.Identifier}");</para>
         /// </example>
         [Property("Identifier", Property.Types.String, "Death Certification", "Death Certificate Number.", true, IGURL.DeathCertificate, true, 3)]
-        // [FHIRPath("Bundle.entry.resource.where($this is Procedure).where(code.coding.code='308646001')", "identifier")]
-         [FHIRPath("Bundle.entry.resource.where($this is Composition)", "identifier")]
+        [FHIRPath("Bundle", "identifier")]
         public string Identifier
         {
             get
             {
-                if(Composition != null && Composition.Identifier != null && Composition.Identifier.Value != null && Composition.Identifier.Value.Length > 0)
+                if (Bundle?.Identifier?.Extension != null)
                 {
-                    return Composition.Identifier.Value;
+                    Extension ext = Bundle.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.CertificateNumber);
+                    if (ext?.Value != null)
+                    {
+                        return Convert.ToString(ext.Value);
+                    }
                 }
                 return null;
-
             }
             set
             {
-                Identifier identifier = new Identifier();
-                identifier.Value = value;
-                if(Composition == null){
-                    Composition = new Composition();
+                Bundle.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.CertificateNumber);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Extension ext = new Extension(ExtensionURL.CertificateNumber, new FhirString(value));
+                    Bundle.Identifier.Extension.Add(ext);
                 }
-                Composition.Identifier = identifier;
-                UpdateBundleIdentifier();
+                UpdateDeathRecordIdentifier();
             }
         }
 
         /// <summary>Update the bundle identifier from the component fields.</summary>
-        private void UpdateBundleIdentifier()
+        private void UpdateDeathRecordIdentifier()
         {
             uint certificateNumber = 0;
-            if (Composition != null && Composition.Identifier != null && Composition.Identifier.Value != null)
+            if (Identifier != null)
             {
-                UInt32.TryParse(Composition.Identifier.Value, out certificateNumber);
+                UInt32.TryParse(Identifier, out certificateNumber);
             }
             uint deathYear = 0;
             if (this.DeathYear != null)
             {
                 deathYear = (uint)this.DeathYear;
             }
-
-            String jurisdictionId = this.DeathLocationJurisdiction; // this.DeathLocationAddress?["addressState"];
+            String jurisdictionId = this.DeathLocationJurisdiction;
             if (jurisdictionId == null || jurisdictionId.Trim().Length < 2)
             {
                 jurisdictionId = "XX";
@@ -937,21 +934,19 @@ namespace VRDR
             {
                 jurisdictionId = jurisdictionId.Trim().Substring(0, 2).ToUpper();
             }
-            this.BundleIdentifier = $"{deathYear.ToString("D4")}{jurisdictionId}{certificateNumber.ToString("D6")}";
+            this.DeathRecordIdentifier = $"{deathYear.ToString("D4")}{jurisdictionId}{certificateNumber.ToString("D6")}";
 
         }
 
         /// <summary>Death Record Bundle Identifier, NCHS identifier.</summary>
-        /// <value>a record bundle identification string.</value>
+        /// <value>a record bundle identification string, e.g., 2022MA000100, derived from year of death, jurisdiction of death, and certificate number</value>
         /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.BundleIdentifier = "42";</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"NCHS identifier: {ExampleDeathRecord.BundleIdentifier}");</para>
+        /// <para>Console.WriteLine($"NCHS identifier: {ExampleDeathRecord.DeathRecordIdentifier}");</para>
         /// </example>
-        [Property("Bundle Identifier", Property.Types.String, "Death Certification", "NCHS identifier.", true, IGURL.DeathCertificateDocument, true, 4)]
+        [Property("Death Record Identifier", Property.Types.String, "Death Certification", "Death Record identifier.", true, IGURL.DeathCertificate, true, 4)]
         [FHIRPath("Bundle", "identifier")]
-        public string BundleIdentifier
+        public string DeathRecordIdentifier
         {
             get
             {
@@ -961,6 +956,7 @@ namespace VRDR
                 }
                 return null;
             }
+            // The setter is pribate because the value is derived so should never be set directly
             private set
             {
                 if (Bundle.Identifier == null)
@@ -981,45 +977,29 @@ namespace VRDR
         /// <para>Console.WriteLine($"State local identifier: {ExampleDeathRecord.StateLocalIdentifier1}");</para>
         /// </example>
         [Property("State Local Identifier1", Property.Types.String, "Death Certificate", "State Local Identifier.", true, ProfileURL.DeathCertificate, true, 5)]
-        [FHIRPath("Bundle.entry.resource.where($this is Composition)", "identifier")]
+        [FHIRPath("Bundle", "identifier")]
         public string StateLocalIdentifier1
         {
             get
             {
-                if (Composition?.Identifier?.Extension != null)
+                if (Bundle?.Identifier?.Extension != null)
                 {
-                    Extension ext = Composition.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
+                    Extension ext = Bundle.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
                     if (ext?.Value != null)
                     {
                         return Convert.ToString(ext.Value);
                     }
                 }
-
                 return null;
             }
             set
             {
-                if(Composition == null){
-                    Composition = new Composition();
-                }
-                if (Composition?.Identifier?.Extension != null)
-                {
-                    Composition.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
-                }
-
+                Bundle.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier1);
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Extension ext = new Extension();
-                    ext.Url = ExtensionURL.AuxiliaryStateIdentifier1;
-                    ext.Value = new FhirString(value);
-                    if (Composition.Identifier == null)
-                    {
-                        Identifier identifier = new Identifier();
-                        Composition.Identifier = identifier;
-                    }
-                    Composition.Identifier.Extension.Add(ext);
+                    Extension ext = new Extension(ExtensionURL.AuxiliaryStateIdentifier1, new FhirString(value));
+                    Bundle.Identifier.Extension.Add(ext);
                 }
-
             }
         }
 
@@ -1032,45 +1012,29 @@ namespace VRDR
         /// <para>Console.WriteLine($"State local identifier: {ExampleDeathRecord.StateLocalIdentifier1}");</para>
         /// </example>
         [Property("State Local Identifier2", Property.Types.String, "Death Certificate", "State Local Identifier.", true, ProfileURL.DeathCertificate, true, 5)]
-        [FHIRPath("Bundle.entry.resource.where($this is Composition)", "identifier")]
+        [FHIRPath("Bundle", "identifier")]
         public string StateLocalIdentifier2
         {
             get
             {
-                if (Composition?.Identifier?.Extension != null)
+                if (Bundle?.Identifier?.Extension != null)
                 {
-                    Extension ext = Composition.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
+                    Extension ext = Bundle.Identifier.Extension.Find(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
                     if (ext?.Value != null)
                     {
                         return Convert.ToString(ext.Value);
                     }
                 }
-
                 return null;
             }
             set
             {
-                 if(Composition == null){
-                    Composition = new Composition();
-                }
-                if (Composition?.Identifier?.Extension != null)
-                {
-                    Composition.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
-                }
-
+                Bundle.Identifier.Extension.RemoveAll(ex => ex.Url == ExtensionURL.AuxiliaryStateIdentifier2);
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Extension ext = new Extension();
-                    ext.Url = ExtensionURL.AuxiliaryStateIdentifier2;
-                    ext.Value = new FhirString(value);
-                    if (Composition.Identifier == null)
-                    {
-                        Identifier identifier = new Identifier();
-                        Composition.Identifier = identifier;
-                    }
-                    Composition.Identifier.Extension.Add(ext);
+                    Extension ext = new Extension(ExtensionURL.AuxiliaryStateIdentifier2, new FhirString(value));
+                    Bundle.Identifier.Extension.Add(ext);
                 }
-
             }
         }
 
@@ -5958,7 +5922,7 @@ namespace VRDR
                     CreateDeathDateObs();
                 }
                 SetPartialDate(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), ExtensionURL.DateYear, value);
-                UpdateBundleIdentifier();
+                UpdateDeathRecordIdentifier();
             }
         }
 
@@ -6386,7 +6350,7 @@ namespace VRDR
                         currentAddress["addressState"] = value;
                     }
                     DeathLocationAddress = currentAddress;
-                    UpdateBundleIdentifier();
+                    UpdateDeathRecordIdentifier();
                 }
             }
         }
@@ -6444,7 +6408,7 @@ namespace VRDR
                     CreateDeathLocation();
                 }
                 DeathLocationLoc.Address = DictToAddress(value);
-                UpdateBundleIdentifier();
+                UpdateDeathRecordIdentifier();
             }
         }
 
@@ -10648,7 +10612,7 @@ namespace VRDR
                     }
                 }
             }
-            UpdateBundleIdentifier();
+            UpdateDeathRecordIdentifier();
         }
 
         /// <summary>Helper function to set a codeable value based on a code and the set of allowed codes.</summary>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -956,7 +956,7 @@ namespace VRDR
                 }
                 return null;
             }
-            // The setter is pribate because the value is derived so should never be set directly
+            // The setter is private because the value is derived so should never be set directly
             private set
             {
                 if (Bundle.Identifier == null)

--- a/VRDR/URLs.cs
+++ b/VRDR/URLs.cs
@@ -59,6 +59,9 @@ namespace VRDR
         /// <summary>URL for PlaceOfInjury</summary>
         public const string PlaceOfInjury = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-place-of-injury";
 
+        /// <summary>URL for CauseOfDeathCodedContentBundle</summary>
+        public const string CauseOfDeathCodedContentBundle = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-bundle";
+
         /// <summary>URL for EntityAxisCauseOfDeath</summary>
         public const string EntityAxisCauseOfDeath = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-entity-axis-cause-of-death";
 
@@ -101,9 +104,6 @@ namespace VRDR
         /// <summary>URL for CodedRaceAndEthnicity</summary>
         public const string CodedRaceAndEthnicity = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-coded-race-and-ethnicity";
 
-        /// <summary>URL for CauseOfDeathCodedContentBundle</summary>
-        public const string CauseOfDeathCodedContentBundle = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-content-bundle";
-
         /// <summary>URL for AutomatedUnderlyingCauseOfDeath</summary>
         public const string AutomatedUnderlyingCauseOfDeath = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-automated-underlying-cause-of-death";
 
@@ -113,11 +113,11 @@ namespace VRDR
         /// <summary>URL for DecedentUsualWork</summary>
         public const string DecedentUsualWork = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-usual-work";
 
+        /// <summary>URL for DemographicCodedContentBundle</summary>
+        public const string DemographicCodedContentBundle = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-bundle";
+
         /// <summary>URL for DispositionLocation</summary>
         public const string DispositionLocation = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location";
-
-        /// <summary>URL for DemographicCodedContentBundle</summary>
-        public const string DemographicCodedContentBundle = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-content-bundle";
 
         /// <summary>URL for Certifier</summary>
         public const string Certifier = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-certifier";
@@ -127,6 +127,7 @@ namespace VRDR
 
         /// <summary>URL for RecordAxisCauseOfDeath</summary>
         public const string RecordAxisCauseOfDeath = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-record-axis-cause-of-death";
+
     }
 
     /// <summary>Extension URLs</summary>
@@ -191,6 +192,9 @@ namespace VRDR
 
         /// <summary>URL for StreetName</summary>
         public const string StreetName = "http://hl7.org/fhir/us/vrdr/StructureDefinition/StreetName";
+
+        /// <summary>URL for CertificateNumber</summary>
+        public const string CertificateNumber = "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber";
 
         /// <summary>URL for LocationJurisdictionId</summary>
         public const string LocationJurisdictionId = "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id";
@@ -290,6 +294,9 @@ namespace VRDR
         /// <summary>URL for PlaceOfInjury</summary>
         public const string PlaceOfInjury = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-place-of-injury.html";
 
+        /// <summary>URL for CauseOfDeathCodedContentBundle</summary>
+        public const string CauseOfDeathCodedContentBundle = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-cause-of-death-coded-bundle.html";
+
         /// <summary>URL for DistrictCode</summary>
         public const string DistrictCode = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-DistrictCode.html";
 
@@ -359,6 +366,9 @@ namespace VRDR
         /// <summary>URL for DeathCertification</summary>
         public const string DeathCertification = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-death-certification.html";
 
+        /// <summary>URL for CertificateNumber</summary>
+        public const string CertificateNumber = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-CertificateNumber.html";
+
         /// <summary>URL for LocationJurisdictionId</summary>
         public const string LocationJurisdictionId = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-Location-Jurisdiction-Id.html";
 
@@ -370,9 +380,6 @@ namespace VRDR
 
         /// <summary>URL for ReplaceStatus</summary>
         public const string ReplaceStatus = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-ReplaceStatus.html";
-
-        /// <summary>URL for CauseOfDeathCodedContentBundle</summary>
-        public const string CauseOfDeathCodedContentBundle = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-cause-of-death-coded-content-bundle.html";
 
         /// <summary>URL for AutomatedUnderlyingCauseOfDeath</summary>
         public const string AutomatedUnderlyingCauseOfDeath = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-automated-underlying-cause-of-death.html";
@@ -386,14 +393,14 @@ namespace VRDR
         /// <summary>URL for DecedentUsualWork</summary>
         public const string DecedentUsualWork = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-decedent-usual-work.html";
 
+        /// <summary>URL for DemographicCodedContentBundle</summary>
+        public const string DemographicCodedContentBundle = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-demographic-coded-bundle.html";
+
         /// <summary>URL for DispositionLocation</summary>
         public const string DispositionLocation = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-disposition-location.html";
 
         /// <summary>URL for DateMonth</summary>
         public const string DateMonth = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-Date-Month.html";
-
-        /// <summary>URL for DemographicCodedContentBundle</summary>
-        public const string DemographicCodedContentBundle = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-demographic-coded-content-bundle.html";
 
         /// <summary>URL for Certifier</summary>
         public const string Certifier = "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-vrdr-certifier.html";

--- a/tools/generate_url_strings_from_VRDR_IG.rb
+++ b/tools/generate_url_strings_from_VRDR_IG.rb
@@ -1,7 +1,7 @@
 # This script takes the JSON files that are generated as part of the VRDR IG and creates an output
 # file with static URL strings for each StructureDefinition, Extension, and IG HTML page
 #
-# Usage: ruby tools/generate_concept_mappings_from_VRDR_IG.rb <path-to-json-files> > VRDR/URLs.cs
+# Usage: ruby tools/generate_url_strings_from_VRDR_IG.rb <path-to-json-files> > VRDR/URLs.cs
 #
 # If you need to generate the concept map JSON files, first install sushi (https://github.com/FHIR/sushi) then
 #


### PR DESCRIPTION
This pull request reorganizes identifiers based on IG consistency changes:

1. Everything is moved to the Bundle for all record types
2. The top level Identifier value is the Death Record Identifier (sometimes known as the NCHS Identifier)
3. CertificateNumber and Auxiliary State Identifiers appear as extensions to the Identifier

This pull request also bumps the version to 4.0.0-preview2