### PR TITLE
eliminate CauseOfDeathPathway, add lineNumber component to Part1Cause…

### DIFF
--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -130,10 +130,10 @@ namespace VRDR.CLI
                 deathRecord.Suffix = "Jr.";
 
                 // Gender
-                deathRecord.Gender = "male";
+                deathRecord.SexAtDeathHelper = "M";
 
                 // BirthSex
-                deathRecord.BirthSex = "F";
+                //deathRecord.BirthSex = "F";
 
                 // DateOfBirth
                 deathRecord.DateOfBirth = "1940-02-19";
@@ -150,7 +150,7 @@ namespace VRDR.CLI
                 deathRecord.Residence = raddress;
 
                 // ResidenceWithinCityLimits
-                deathRecord.ResidenceWithinCityLimitsBoolean = false;
+                deathRecord.ResidenceWithinCityLimitsHelper = ValueSets.YesNoUnknown.No;
 
                 // SSN
                 deathRecord.SSN = "123456789";

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -217,8 +217,6 @@ namespace VRDR.CLI
 
                 // UsualOccupation
                 deathRecord.UsualOccupation = "secretary";
-                deathRecord.UsualOccupationStart = "1965-01-01";
-                deathRecord.UsualOccupationEnd = "2010-01-01";
 
                 // UsualIndustry
                 deathRecord.UsualIndustry = "State agency";

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -338,7 +338,7 @@ namespace VRDR.CLI
                 deathRecord.InjuryDescription = "Example Injury Description";
 
                 // InjuryLocationDescription
-                deathRecord.InjuryLocationDescription = "Example Injury Location Description";
+                //deathRecord.InjuryLocationDescription = "Example Injury Location Description";
 
                 // InjuryDate
                 deathRecord.InjuryDate = "2018-02-19T16:48:06-05:00";

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -295,17 +295,17 @@ namespace VRDR.HTTP
                 }
             }
 
-            if (record.BirthSex != null)
-            {
-                if (record.BirthSex == "M")
-                {
-                    values["sex.sex"] = "Male";
-                }
-                else if (record.BirthSex == "F")
-                {
-                    values["sex.sex"] = "Female";
-                }
-            }
+            // if (record.BirthSex != null)
+            // {
+            //     if (record.BirthSex == "M")
+            //     {
+            //         values["sex.sex"] = "Male";
+            //     }
+            //     else if (record.BirthSex == "F")
+            //     {
+            //         values["sex.sex"] = "Female";
+            //     }
+            // }
 
             if (record.SSN != null && record.SSN.Length == 9)
             {
@@ -551,14 +551,14 @@ namespace VRDR.HTTP
                     break;
             }
 
-            if (GetValue(values, "sex.sex") == "Male")
-            {
-                deathRecord.BirthSex = "M";
-            }
-            else if (GetValue(values, "sex.sex") == "Female")
-            {
-                deathRecord.BirthSex = "F";
-            }
+            // if (GetValue(values, "sex.sex") == "Male")
+            // {
+            //     deathRecord.BirthSex = "M";
+            // }
+            // else if (GetValue(values, "sex.sex") == "Female")
+            // {
+            //     deathRecord.BirthSex = "F";
+            // }
 
             if (GetValue(values, "ssn.ssn1") != null && GetValue(values, "ssn.ssn2") != null && GetValue(values, "ssn.ssn3") != null)
             {

--- a/VRDR.HTTP/Nightingale.cs
+++ b/VRDR.HTTP/Nightingale.cs
@@ -165,7 +165,7 @@ namespace VRDR.HTTP
             }
             SetStringValueDictionary(values, "personCompletingCauseOfDeathName.lastName", record.CertifierFamilyName);
 
-            SetStringValueDictionary(values, "detailsOfInjury.detailsOfInjury", record.InjuryLocationDescription);
+            //SetStringValueDictionary(values, "detailsOfInjury.detailsOfInjury", record.InjuryLocationDescription);
 
             if (record.EducationLevelHelper != null)
             {

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Update="fixtures/json/Bundle-DeathCertificateDocument-Example2.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/xml/Bundle-DeathCertificateDocument-Example2.xml" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecord1.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordNoIdentifiers.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/AcknowledgementMessage.json" CopyToOutputDirectory="PreserveNewest" />

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1754,7 +1754,6 @@ namespace VRDR.Tests
         {
             SetterDeathRecord.BirthRecordId = "242123";
             Assert.Equal("242123", SetterDeathRecord.BirthRecordId);
-            Assert.False(SetterDeathRecord.BirthRecordIdentifierDataAbsentBoolean);
         }
 
         [Fact]
@@ -1769,7 +1768,6 @@ namespace VRDR.Tests
         {
             SetterDeathRecord.BirthRecordId = "";
             Assert.Null(SetterDeathRecord.BirthRecordId);
-            Assert.True(SetterDeathRecord.BirthRecordIdentifierDataAbsentBoolean);
         }
 
         [Fact]
@@ -1777,23 +1775,6 @@ namespace VRDR.Tests
         {
             DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecordBirthRecordDataAbsent.json")));
             Assert.Null(dr.BirthRecordId);
-            Assert.True(dr.BirthRecordIdentifierDataAbsentBoolean);
-        }
-
-        [Fact]
-        public void Set_BirthRecordDataAbsentReason()
-        {
-            SetterDeathRecord.BirthRecordId = "12121212"; // Will be nulled by the setter below
-            SetterDeathRecord.BirthRecordIdentifierDataAbsentReason = new Dictionary<string, string>() {
-                { "code", "unknown" },
-                { "system", CodeSystems.Data_Absent_Reason_HL7_V3 },
-                { "display", "unknown" }
-            };
-            Assert.Null(SetterDeathRecord.BirthRecordId);
-            Assert.True(SetterDeathRecord.BirthRecordIdentifierDataAbsentBoolean);
-            Assert.Equal("unknown", SetterDeathRecord.BirthRecordIdentifierDataAbsentReason["code"]);
-            Assert.Equal(CodeSystems.Data_Absent_Reason_HL7_V3, SetterDeathRecord.BirthRecordIdentifierDataAbsentReason["system"]);
-            Assert.Equal("unknown", SetterDeathRecord.BirthRecordIdentifierDataAbsentReason["display"]);
         }
 
         [Fact]
@@ -1801,12 +1782,10 @@ namespace VRDR.Tests
         {
             DeathRecord dr = ((DeathRecord)JSONRecords[0]);
             Assert.Equal("242123",dr.BirthRecordId);
-            Assert.False(dr.BirthRecordIdentifierDataAbsentBoolean);
             IJEMortality ije1 = new IJEMortality(dr);
             Assert.Equal("242123", ije1.BCNO);
             DeathRecord dr2 = ije1.ToDeathRecord();
             Assert.Equal("242123",dr2.BirthRecordId);
-            Assert.False(dr.BirthRecordIdentifierDataAbsentBoolean);
         }
 
      [Fact]
@@ -1817,7 +1796,6 @@ namespace VRDR.Tests
             Assert.Equal("", ije1.BCNO);
             DeathRecord dr2 = ije1.ToDeathRecord();
             Assert.Null(dr.BirthRecordId);
-            Assert.True(dr.BirthRecordIdentifierDataAbsentBoolean);
         }
         [Theory]
         [InlineData("MA")]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -22,6 +22,7 @@ namespace VRDR.Tests
         {
             XMLRecords = new ArrayList();
             XMLRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/xml/DeathRecord1.xml"))));
+            XMLRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/xml/Bundle-DeathCertificateDocument-Example2.xml"))));
             JSONRecords = new ArrayList();
             JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/DeathRecord1.json"))));
             JSONRecords.Add(new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/Bundle-DeathCertificateDocument-Example2.json"))));
@@ -709,7 +710,7 @@ namespace VRDR.Tests
         public void Get_COD1A()
         {
             Assert.Equal("Cardiopulmonary arrest", ((DeathRecord)JSONRecords[1]).COD1A);
-            Assert.Equal("Rupture of myocardium", ((DeathRecord)XMLRecords[0]).COD1A);
+            Assert.Equal("Cardiopulmonary arrest", ((DeathRecord)XMLRecords[1]).COD1A);
         }
 
         [Fact]
@@ -722,8 +723,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_INTERVAL1A()
         {
-            Assert.Equal("minutes", ((DeathRecord)JSONRecords[0]).INTERVAL1A);
-            Assert.Equal("minutes", ((DeathRecord)XMLRecords[0]).INTERVAL1A);
+            Assert.Equal("4 hours", ((DeathRecord)JSONRecords[1]).INTERVAL1A);
+            Assert.Equal("4 hours", ((DeathRecord)XMLRecords[1]).INTERVAL1A);
         }
 
         // [Fact]
@@ -760,8 +761,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_COD1B()
         {
-            Assert.Equal("Acute myocardial infarction", ((DeathRecord)JSONRecords[0]).COD1B);
-            Assert.Equal("Acute myocardial infarction", ((DeathRecord)XMLRecords[0]).COD1B);
+            Assert.Equal("Eclampsia", ((DeathRecord)JSONRecords[1]).COD1B);
+            Assert.Equal("Eclampsia", ((DeathRecord)XMLRecords[1]).COD1B);
         }
 
         [Fact]
@@ -774,8 +775,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_INTERVAL1B()
         {
-            Assert.Equal("6 days", ((DeathRecord)JSONRecords[0]).INTERVAL1B);
-            Assert.Equal("6 days", ((DeathRecord)XMLRecords[0]).INTERVAL1B);
+            Assert.Equal("3 months", ((DeathRecord)JSONRecords[1]).INTERVAL1B);
+            Assert.Equal("3 months", ((DeathRecord)XMLRecords[1]).INTERVAL1B);
         }
 
         // [Fact]
@@ -812,8 +813,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_COD1C()
         {
-            Assert.Equal("Coronary artery thrombosis", ((DeathRecord)JSONRecords[0]).COD1C);
-            Assert.Equal("Coronary artery thrombosis", ((DeathRecord)XMLRecords[0]).COD1C);
+            Assert.Equal("Coronary artery thrombosis", ((DeathRecord)JSONRecords[1]).COD1C);
+            Assert.Equal("Coronary artery thrombosis", ((DeathRecord)XMLRecords[1]).COD1C);
         }
 
         [Fact]
@@ -826,8 +827,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_INTERVAL1C()
         {
-            Assert.Equal("5 years", ((DeathRecord)JSONRecords[0]).INTERVAL1C);
-            Assert.Equal("5 years", ((DeathRecord)XMLRecords[0]).INTERVAL1C);
+            Assert.Equal("3 months", ((DeathRecord)JSONRecords[1]).INTERVAL1C);
+            Assert.Equal("3 months", ((DeathRecord)XMLRecords[1]).INTERVAL1C);
         }
 
         // [Fact]
@@ -853,8 +854,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_COD1D()
         {
-            Assert.Equal("Atherosclerotic coronary artery disease", ((DeathRecord)JSONRecords[0]).COD1D);
-            Assert.Equal("Atherosclerotic coronary artery disease", ((DeathRecord)XMLRecords[0]).COD1D);
+            Assert.Equal("Atherosclerotic coronary artery disease", ((DeathRecord)JSONRecords[1]).COD1D);
+            Assert.Equal("Atherosclerotic coronary artery disease", ((DeathRecord)XMLRecords[1]).COD1D);
         }
 
         [Fact]
@@ -867,8 +868,8 @@ namespace VRDR.Tests
         [Fact]
         public void Get_INTERVAL1D()
         {
-            Assert.Equal("7 years", ((DeathRecord)JSONRecords[0]).INTERVAL1D);
-            Assert.Equal("7 years", ((DeathRecord)XMLRecords[0]).INTERVAL1D);
+            Assert.Equal("3 months", ((DeathRecord)JSONRecords[1]).INTERVAL1D);
+            Assert.Equal("3 months", ((DeathRecord)XMLRecords[1]).INTERVAL1D);
         }
 
         // [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1153,15 +1153,12 @@ namespace VRDR.Tests
         [Fact]
         public void Get_ResidenceWithinCityLimits()
         {
-            SetterDeathRecord.ResidenceWithinCityLimitsBoolean = false;
+            SetterDeathRecord.ResidenceWithinCityLimitsHelper = ValueSets.YesNoUnknown.No;
             Assert.Equal("N", SetterDeathRecord.ResidenceWithinCityLimits["code"]);
-            Assert.False(SetterDeathRecord.ResidenceWithinCityLimitsBoolean);
-            SetterDeathRecord.ResidenceWithinCityLimitsBoolean = true;
+            SetterDeathRecord.ResidenceWithinCityLimitsHelper = ValueSets.YesNoUnknown.Yes;
             Assert.Equal("Y", SetterDeathRecord.ResidenceWithinCityLimits["code"]);
-            Assert.True(SetterDeathRecord.ResidenceWithinCityLimitsBoolean);
-            SetterDeathRecord.ResidenceWithinCityLimitsBoolean = null;
-            Assert.Equal("NA", SetterDeathRecord.ResidenceWithinCityLimits["code"]);
-            Assert.Null(SetterDeathRecord.ResidenceWithinCityLimitsBoolean);
+            SetterDeathRecord.ResidenceWithinCityLimitsHelper = ValueSets.YesNoUnknown.Unknown;
+            Assert.Equal("UNK", SetterDeathRecord.ResidenceWithinCityLimits["code"]);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1838,13 +1838,8 @@ namespace VRDR.Tests
         public void Get_UsualOccupation()
         {
             Assert.Equal("Executive secretary", ((DeathRecord)JSONRecords[0]).UsualOccupation);
-            Assert.Equal("secretary", ((DeathRecord)JSONRecords[0]).UsualOccupationCode["display"]);
-            Assert.Equal("1965-01-01", ((DeathRecord)JSONRecords[0]).UsualOccupationStart);
-            Assert.Equal("2010-01-01", ((DeathRecord)JSONRecords[0]).UsualOccupationEnd);
             Assert.Equal("Executive secretary", ((DeathRecord)XMLRecords[0]).UsualOccupation);
-            Assert.Equal("secretary", ((DeathRecord)XMLRecords[0]).UsualOccupationCode["display"]);
-            Assert.Equal("1965-01-01", ((DeathRecord)XMLRecords[0]).UsualOccupationStart);
-            Assert.Equal("2010-01-01", ((DeathRecord)XMLRecords[0]).UsualOccupationEnd);
+
         }
 
         [Fact]
@@ -1857,8 +1852,6 @@ namespace VRDR.Tests
         [Fact]
         public void Get_UsualIndustry()
         {
-            Assert.Equal("State agency", ((DeathRecord)JSONRecords[0]).UsualIndustryCode["display"]);
-            Assert.Equal("State agency", ((DeathRecord)XMLRecords[0]).UsualIndustryCode["display"]);
             Assert.Equal("State department of agriculture", ((DeathRecord)JSONRecords[0]).UsualIndustry);
             Assert.Equal("State department of agriculture", ((DeathRecord)XMLRecords[0]).UsualIndustry);
         }

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -694,7 +694,7 @@ namespace VRDR.Tests
         [Fact]
         public void Get_ContributingConditions()
         {
-            Assert.Equal("Example Contributing Conditions", ((DeathRecord)JSONRecords[0]).ContributingConditions);
+            Assert.Equal("hypertensive heart disease", ((DeathRecord)JSONRecords[1]).ContributingConditions);
             Assert.Equal("Example Contributing Conditions", ((DeathRecord)XMLRecords[0]).ContributingConditions);
         }
 
@@ -708,7 +708,7 @@ namespace VRDR.Tests
         [Fact]
         public void Get_COD1A()
         {
-            Assert.Equal("Rupture of myocardium", ((DeathRecord)JSONRecords[0]).COD1A);
+            Assert.Equal("Cardiopulmonary arrest", ((DeathRecord)JSONRecords[1]).COD1A);
             Assert.Equal("Rupture of myocardium", ((DeathRecord)XMLRecords[0]).COD1A);
         }
 

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2180,19 +2180,9 @@ namespace VRDR.Tests
         [Fact]
         public void Set_AutopsyResultsAvailable()
         {
-            Dictionary<string, string> ara = new Dictionary<string, string>();
-            ara.Add("code", "Y");
-            ara.Add("system", VRDR.CodeSystems.YesNo);
-            ara.Add("display", "Yes");
-            SetterDeathRecord.AutopsyResultsAvailable = ara;
-            Assert.Equal("Y", SetterDeathRecord.AutopsyResultsAvailable["code"]);
-            Assert.Equal(VRDR.CodeSystems.YesNo, SetterDeathRecord.AutopsyResultsAvailable["system"]);
-            Assert.Equal("Yes", SetterDeathRecord.AutopsyResultsAvailable["display"]);
+            SetterDeathRecord.AutopsyResultsAvailableHelper = VRDR.ValueSets.YesNoUnknown.Yes;
             Assert.Equal("Y",SetterDeathRecord.AutopsyResultsAvailableHelper);
             SetterDeathRecord.AutopsyResultsAvailableHelper = "N";
-            Assert.Equal("N", SetterDeathRecord.AutopsyResultsAvailable["code"]);
-            Assert.Equal(VRDR.CodeSystems.YesNo, SetterDeathRecord.AutopsyResultsAvailable["system"]);
-            Assert.Equal("No", SetterDeathRecord.AutopsyResultsAvailable["display"]);
             Assert.Equal("N",SetterDeathRecord.AutopsyResultsAvailableHelper);
             SetterDeathRecord.AutopsyResultsAvailableHelper = "NA";
             Assert.Equal("NA", SetterDeathRecord.AutopsyResultsAvailable["code"]);
@@ -2571,19 +2561,19 @@ namespace VRDR.Tests
             Assert.Equal("Example Injury Location Name", ((DeathRecord)XMLRecords[0]).InjuryLocationName);
         }
 
-        [Fact]
-        public void Set_InjuryLocationDescription()
-        {
-            SetterDeathRecord.InjuryLocationDescription = "Example Injury Location Description";
-            Assert.Equal("Example Injury Location Description", SetterDeathRecord.InjuryLocationDescription);
-        }
+        // [Fact]
+        // public void Set_InjuryLocationDescription()
+        // {
+        //     SetterDeathRecord.InjuryLocationDescription = "Example Injury Location Description";
+        //     Assert.Equal("Example Injury Location Description", SetterDeathRecord.InjuryLocationDescription);
+        // }
 
-        [Fact]
-        public void Get_InjuryLocationDescription()
-        {
-            Assert.Equal("Example Injury Location Description", ((DeathRecord)JSONRecords[0]).InjuryLocationDescription);
-            Assert.Equal("Example Injury Location Description", ((DeathRecord)XMLRecords[0]).InjuryLocationDescription);
-        }
+        // [Fact]
+        // public void Get_InjuryLocationDescription()
+        // {
+        //     Assert.Equal("Example Injury Location Description", ((DeathRecord)JSONRecords[0]).InjuryLocationDescription);
+        //     Assert.Equal("Example Injury Location Description", ((DeathRecord)XMLRecords[0]).InjuryLocationDescription);
+        // }
 
         [Fact]
         public void Set_InjuryDate()

--- a/VRDR.Tests/fixtures/json/Bundle-DeathCertificateDocument-Example2.json
+++ b/VRDR.Tests/fixtures/json/Bundle-DeathCertificateDocument-Example2.json
@@ -60,19 +60,6 @@
             ]
           }
         ],
-        "identifier": {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
-              "valueString": "000000000001"
-            },
-            {
-              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
-              "valueString": "100000000001"
-            }
-          ],
-          "value": "000182"
-        },
         "section": [
           {
             "code": {
@@ -185,9 +172,6 @@
               },
               {
                 "reference": "Observation/CauseOfDeathPart2-Example1"
-              },
-              {
-                "reference": "List/CauseOfDeathPathway-Example1"
               }
             ]
           },
@@ -1585,6 +1569,17 @@
             "code": {
               "coding": [
                 {
+                  "code": "lineNumber",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+                }
+              ]
+            },
+            "valueInteger": 1
+          },
+          {
+            "code": {
+              "coding": [
+                {
                   "code": "69440-6",
                   "system": "http://loinc.org",
                   "display": "Disease onset to death interval"
@@ -1628,6 +1623,17 @@
           ]
         },
         "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "lineNumber",
+                  "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+                }
+              ]
+            },
+            "valueInteger": 2
+          },
           {
             "code": {
               "coding": [
@@ -1688,44 +1694,6 @@
         "status": "final"
       },
       "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart2-Example1"
-    },
-    {
-      "resource": {
-        "resourceType": "List",
-        "id": "CauseOfDeathPathway-Example1",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-pathway"
-          ]
-        },
-        "status": "current",
-        "mode": "snapshot",
-        "orderedBy": {
-          "coding": [
-            {
-              "code": "priority",
-              "system": "http://terminology.hl7.org/CodeSystem/list-order",
-              "display": "Sorted by Priority"
-            }
-          ]
-        },
-        "source": {
-          "reference": "Practitioner/Certifier-Example1"
-        },
-        "entry": [
-          {
-            "item": {
-              "reference": "Observation/CauseOfDeathPart1-Example1"
-            }
-          },
-          {
-            "item": {
-              "reference": "Observation/CauseOfDeathPart1-Example2"
-            }
-          }
-        ]
-      },
-      "fullUrl": "http://www.example.org/fhir/List/CauseOfDeathPathway-Example1"
     },
     {
       "resource": {

--- a/VRDR.Tests/fixtures/json/Bundle-DeathCertificateDocument-Example2.json
+++ b/VRDR.Tests/fixtures/json/Bundle-DeathCertificateDocument-Example2.json
@@ -1663,6 +1663,122 @@
       "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2"
     },
     {
+    "resource": {
+      "resourceType": "Observation",
+      "id": "CauseOfDeathPart1-Example2",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
+        ]
+      },
+      "code": {
+        "coding": [
+          {
+            "code": "69453-9",
+            "system": "http://loinc.org",
+            "display": "Cause of death [US Standard Certificate of Death]"
+          }
+        ]
+      },
+      "component": [
+        {
+          "code": {
+            "coding": [
+              {
+                "code": "lineNumber",
+                "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+              }
+            ]
+          },
+          "valueInteger": 3
+        },
+        {
+          "code": {
+            "coding": [
+              {
+                "code": "69440-6",
+                "system": "http://loinc.org",
+                "display": "Disease onset to death interval"
+              }
+            ]
+          },
+          "valueString": "3 months"
+        }
+      ],
+      "valueCodeableConcept": {
+        "text": "Coronary artery thrombosis"
+      },
+      "subject": {
+        "reference": "Patient/Decedent-Example1"
+      },
+      "performer": [
+        {
+          "reference": "Practitioner/Certifier-Example1"
+        }
+      ],
+      "status": "final"
+    },
+    "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2"
+  },
+  {
+  "resource": {
+    "resourceType": "Observation",
+    "id": "CauseOfDeathPart1-Example2",
+    "meta": {
+      "profile": [
+        "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
+      ]
+    },
+    "code": {
+      "coding": [
+        {
+          "code": "69453-9",
+          "system": "http://loinc.org",
+          "display": "Cause of death [US Standard Certificate of Death]"
+        }
+      ]
+    },
+    "component": [
+      {
+        "code": {
+          "coding": [
+            {
+              "code": "lineNumber",
+              "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs"
+            }
+          ]
+        },
+        "valueInteger": 4
+      },
+      {
+        "code": {
+          "coding": [
+            {
+              "code": "69440-6",
+              "system": "http://loinc.org",
+              "display": "Disease onset to death interval"
+            }
+          ]
+        },
+        "valueString": "3 months"
+      }
+    ],
+    "valueCodeableConcept": {
+      "text": "Atherosclerotic coronary artery disease"
+    },
+    "subject": {
+      "reference": "Patient/Decedent-Example1"
+    },
+    "performer": [
+      {
+        "reference": "Practitioner/Certifier-Example1"
+      }
+    ],
+    "status": "final"
+  },
+  "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2"
+},
+    {
       "resource": {
         "resourceType": "Observation",
         "id": "CauseOfDeathPart2-Example1",

--- a/VRDR.Tests/fixtures/xml/Bundle-DeathCertificateDocument-Example2.xml
+++ b/VRDR.Tests/fixtures/xml/Bundle-DeathCertificateDocument-Example2.xml
@@ -1,0 +1,1943 @@
+<Bundle xmlns="http://hl7.org/fhir">
+  <id value="DeathCertificateDocument-Example2" />
+  <meta>
+    <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document" />
+  </meta>
+  <identifier>
+    <system value="http://nchs.cdc.gov/vrdr_id" />
+    <value value="2020NY000000" />
+  </identifier>
+  <type value="document" />
+  <timestamp value="2020-10-20T14:48:35.401641-04:00" />
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Bundle/DeathCertificate-Example2" />
+    <resource>
+      <Composition>
+        <id value="DeathCertificate-Example2" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate" />
+        </meta>
+        <status value="final" />
+        <type>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="64297-5" />
+            <display value="Death certificate" />
+          </coding>
+        </type>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <date value="2020-11-15T16:39:54-05:00" />
+        <author>
+          <reference value="Practitioner/Certifier-Example1" />
+        </author>
+        <title value="Death Certificate" />
+        <attester>
+          <mode value="legal" />
+          <time value="2020-11-14T16:39:40-05:00" />
+          <party>
+            <reference value="Practitioner/Certifier-Example1" />
+          </party>
+        </attester>
+        <event>
+          <code>
+            <coding>
+              <system value="http://snomed.info/sct" />
+              <code value="103693007" />
+              <display value="Diagnostic procedure (procedure)" />
+            </coding>
+          </code>
+          <detail>
+            <reference value="Procedure/DeathCertification-Example1" />
+          </detail>
+        </event>
+        <section>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs" />
+              <code value="DecedentDemographics" />
+            </coding>
+          </code>
+          <entry>
+            <reference value="Patient/Decedent-Example1" />
+          </entry>
+          <entry>
+            <reference value="RelatedPerson/DecedentFather-Example1" />
+          </entry>
+          <entry>
+            <reference value="RelatedPerson/DecedentMother-Example1" />
+          </entry>
+          <entry>
+            <reference value="RelatedPerson/DecedentSpouse-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DecedentAge-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/BirthRecordIdentifier-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DecedentEducationLevel-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DecedentMilitaryService-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DecedentUsualWork-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/InputRaceAndEthnicity-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/EmergingIssues-Example1" />
+          </entry>
+        </section>
+        <section>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs" />
+              <code value="DeathInvestigation" />
+            </coding>
+          </code>
+          <entry>
+            <reference value="Observation/ExaminerContacted-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DecedentPregnancyStatus-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/TobaccoUseContributedToDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/AutopsyPerformedIndicator-Example1" />
+          </entry>
+          <entry>
+            <reference value="Location/DeathLocation-Example1" />
+          </entry>
+          <entry>
+            <reference value="Location/InjuryLocation-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/InjuryIncident-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DeathDate-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/SurgeryDate-Example1" />
+          </entry>
+        </section>
+        <section>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs" />
+              <code value="DeathCertification" />
+            </coding>
+          </code>
+          <entry>
+            <reference value="Practitioner/Certifier-Example1" />
+          </entry>
+          <entry>
+            <reference value="Procedure/DeathCertification-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/MannerOfDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/CauseOfDeathPart1-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/CauseOfDeathPart1-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/CauseOfDeathPart2-Example1" />
+          </entry>
+        </section>
+        <section>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs" />
+              <code value="DecedentDisposition" />
+            </coding>
+          </code>
+          <entry>
+            <reference value="Location/DispositionLocation-Example1" />
+          </entry>
+          <entry>
+            <reference value="Organization/FuneralHome-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/DecedentDispositionMethod-Example1" />
+          </entry>
+          <entry>
+            <reference value="Practitioner/Mortician-Example1" />
+          </entry>
+        </section>
+        <section>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs" />
+              <code value="CodedContent" />
+            </coding>
+          </code>
+          <entry>
+            <reference value="Observation/ActivityAtTimeOfDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/PlaceOfInjury-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/CodedRaceAndEthnicity-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/ManualUnderlyingCauseOfDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/AutomatedUnderlyingCauseOfDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/RecordAxisCauseOfDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Observation/EntityAxisCauseOfDeath-Example1" />
+          </entry>
+          <entry>
+            <reference value="Parameters/CodingStatusValues-Example1" />
+          </entry>
+        </section>
+      </Composition>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Patient/Decedent-Example1" />
+    <resource>
+      <Patient>
+        <id value="Decedent-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent" />
+        </meta>
+        <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/SpouseAlive">
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+              <code value="Y" />
+            </coding>
+          </valueCodeableConcept>
+        </extension>
+        <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath">
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/administrative-gender" />
+              <code value="unknown" />
+              <display value="Unknown" />
+            </coding>
+          </valueCodeableConcept>
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/patient-birthPlace">
+          <valueAddress>
+            <city value="Roanoke" />
+            <state value="VA" />
+            <country value="US" />
+          </valueAddress>
+        </extension>
+        <identifier>
+          <type>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v2-0203" />
+              <code value="SB" />
+              <display value="Social Beneficiary Identifier" />
+            </coding>
+          </type>
+          <system value="http://hl7.org/fhir/sid/us-ssn" />
+          <value value="987654321" />
+        </identifier>
+        <name>
+          <use value="official" />
+          <family value="Patel" />
+          <given value="Madelyn" />
+        </name>
+        <gender value="female" />
+        <birthDate>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDate">
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day">
+              <valueUnsignedInt value="10" />
+            </extension>
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year">
+              <valueUnsignedInt value="2004" />
+            </extension>
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month">
+              <valueUnsignedInt value="11" />
+            </extension>
+          </extension>
+        </birthDate>
+        <address>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/WithinCityLimitsIndicator">
+            <valueCoding>
+              <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+              <code value="Y" />
+              <display value="Yes" />
+            </valueCoding>
+          </extension>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/StreetName">
+            <valueString value="Lockwood" />
+          </extension>
+          <line value="5590 Lockwood Drive" />
+          <city value="Danville">
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/CityCode">
+              <valuePositiveInt value="1234" />
+            </extension>
+          </city>
+          <district value="Fairfax">
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/DistrictCode">
+              <valuePositiveInt value="321" />
+            </extension>
+          </district>
+          <state value="VA" />
+          <country value="US" />
+        </address>
+        <maritalStatus>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag">
+            <valueCodeableConcept>
+              <coding>
+                <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs" />
+                <code value="0" />
+              </coding>
+            </valueCodeableConcept>
+          </extension>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-MaritalStatus" />
+            <code value="S" />
+            <display value="Never Married" />
+          </coding>
+        </maritalStatus>
+        <contact>
+          <relationship>
+            <text value="Friend of family" />
+          </relationship>
+          <name>
+            <text value="Joe Smith" />
+          </name>
+        </contact>
+      </Patient>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/RelatedPerson/DecedentFather-Example1" />
+    <resource>
+      <RelatedPerson>
+        <id value="DecedentFather-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-father" />
+        </meta>
+        <patient>
+          <reference value="Patient/Decedent-Example1" />
+        </patient>
+        <relationship>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-RoleCode" />
+            <code value="FTH" />
+            <display value="father" />
+          </coding>
+        </relationship>
+        <name>
+          <use value="official" />
+          <text value="Decedent Dad" />
+          <family value="Smith" />
+          <given value="John" />
+          <suffix value="Sr" />
+        </name>
+      </RelatedPerson>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/RelatedPerson/DecedentMother-Example1" />
+    <resource>
+      <RelatedPerson>
+        <id value="DecedentMother-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-mother" />
+        </meta>
+        <patient>
+          <reference value="Patient/Decedent-Example1" />
+        </patient>
+        <relationship>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-RoleCode" />
+            <code value="MTH" />
+            <display value="mother" />
+          </coding>
+        </relationship>
+        <name>
+          <use value="maiden" />
+          <text value="Decedent Mom" />
+          <family value="Suzette" />
+          <given value="Jane" />
+        </name>
+      </RelatedPerson>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/RelatedPerson/DecedentSpouse-Example1" />
+    <resource>
+      <RelatedPerson>
+        <id value="DecedentSpouse-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-spouse" />
+        </meta>
+        <patient>
+          <reference value="Patient/Decedent-Example1" />
+        </patient>
+        <relationship>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-RoleCode" />
+            <code value="SPS" />
+            <display value="spouse" />
+          </coding>
+        </relationship>
+        <name>
+          <use value="maiden" />
+          <text value="Decedent Spouse" />
+          <family value="Gazette" />
+          <given value="Samuel" />
+          <suffix value="III" />
+        </name>
+      </RelatedPerson>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DecedentAge-Example1" />
+    <resource>
+      <Observation>
+        <id value="DecedentAge-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-age" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="39016-1" />
+            <display value="Age at death" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueQuantity>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag">
+            <valueCodeableConcept>
+              <coding>
+                <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs" />
+                <code value="0" />
+                <display value="Edit Passed" />
+              </coding>
+            </valueCodeableConcept>
+          </extension>
+          <value value="42" />
+          <unit value="a" />
+        </valueQuantity>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/InputRaceAndEthnicity-Example1" />
+    <resource>
+      <Observation>
+        <id value="InputRaceAndEthnicity-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-input-race-and-ethnicity" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs" />
+            <code value="inputraceandethnicity" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="White" />
+            </coding>
+          </code>
+          <valueBoolean value="true" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="BlackOrAfricanAmerican" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="AmericanIndianOrAlaskaNative" />
+            </coding>
+          </code>
+          <valueBoolean value="true" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="AsianIndian" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="Chinese" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="Filipino" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="Japanese" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="Korean" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="Vietnamese" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="OtherAsian" />
+            </coding>
+          </code>
+          <valueBoolean value="true" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="NativeHawaiian" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="GuamanianOrChamorro" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="Samoan" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="OtherPacificIslander" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="OtherRace" />
+            </coding>
+          </code>
+          <valueBoolean value="false" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="FirstOtherAsianLiteral" />
+            </coding>
+          </code>
+          <valueString value="Malaysian" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="FirstAmericanIndianOrAlaskaNativeLiteral" />
+            </coding>
+          </code>
+          <valueString value="Arikara" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="HispanicMexican" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+              <code value="Y" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/BirthRecordIdentifier-Example1" />
+    <resource>
+      <Observation>
+        <id value="BirthRecordIdentifier-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-birth-record-identifier" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0203" />
+            <code value="BR" />
+            <display value="Birth registry number" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueString value="717171" />
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="21842-0" />
+              <display value="Birthplace" />
+            </coding>
+          </code>
+          <valueString value="YC" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="80904-6" />
+              <display value="Birth year" />
+            </coding>
+          </code>
+          <valueDateTime value="1961" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DecedentEducationLevel-Example1" />
+    <resource>
+      <Observation>
+        <id value="DecedentEducationLevel-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-education-level" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80913-7" />
+            <display value="Highest level of education [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-EducationLevel" />
+            <code value="SEC" />
+            <display value="Some secondary or high school education" />
+          </coding>
+          <text value="11th grade" />
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DecedentMilitaryService-Example1" />
+    <resource>
+      <Observation>
+        <id value="DecedentMilitaryService-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-military-service" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="55280-2" />
+            <display value="Military service Narrative" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+            <code value="Y" />
+            <display value="Yes" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DecedentUsualWork-Example1" />
+    <resource>
+      <Observation>
+        <id value="DecedentUsualWork-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-usual-work" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="21843-8" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <effectivePeriod>
+          <start value="2001" />
+          <end value="2005" />
+        </effectivePeriod>
+        <valueCodeableConcept>
+          <coding>
+            <system value="urn:oid:2.16.840.1.114222.4.5.314" />
+            <code value="5700" />
+            <display value="Secretaries and administrative assistants" />
+          </coding>
+          <text value="secretary" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="21844-6" />
+              <display value="History of Usual industry" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="urn:oid:2.16.840.1.114222.4.5.315" />
+              <code value="9390" />
+              <display value="Other general government and support" />
+            </coding>
+            <text value="State agency" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/EmergingIssues-Example1" />
+    <resource>
+      <Observation>
+        <id value="EmergingIssues-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <code value="emergingissues" />
+            <display value="NCHS-required Parameter Slots for Emerging Issues" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="EmergingIssue1_1" />
+            </coding>
+          </code>
+          <valueString value="H" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DecedentPregnancyStatus-Example1" />
+    <resource>
+      <Observation>
+        <id value="DecedentPregnancyStatus-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-pregnancy-status" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69442-2" />
+            <display value="Timing of recent pregnancy in relation to death" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueCodeableConcept>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag">
+            <valueCodeableConcept>
+              <coding>
+                <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs" />
+                <code value="2" />
+                <display value="Edit Failed, Data Queried, but not Verified" />
+              </coding>
+            </valueCodeableConcept>
+          </extension>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs" />
+            <code value="2" />
+            <display value="Pregnant at time of death" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/TobaccoUseContributedToDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="TobaccoUseContributedToDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-tobacco-use-contributed-to-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69443-0" />
+            <display value="Did tobacco use contribute to death" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="373066001" />
+            <display value="Yes" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DeathDate-Example1" />
+    <resource>
+      <Observation>
+        <id value="DeathDate-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-date" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="81956-5" />
+            <display value="Date+time of death" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <effectiveDateTime value="2020-11-12T16:39:40-05:00" />
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueDateTime>
+          <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDateTime">
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day">
+              <valueUnsignedInt value="12" />
+            </extension>
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year">
+              <valueUnsignedInt value="2020" />
+            </extension>
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month">
+              <valueUnsignedInt value="11" />
+            </extension>
+            <extension url="http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time">
+              <valueTime value="12:13:14" />
+            </extension>
+          </extension>
+        </valueDateTime>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="80616-6" />
+              <display value="Date and time pronounced dead [US Standard Certificate of Death]" />
+            </coding>
+          </code>
+          <valueDateTime value="2020-11-13T16:39:40-05:00" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="58332-8" />
+              <display value="Location of death" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://snomed.info/sct" />
+              <code value="16983000" />
+              <display value="Death in hospital" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/SurgeryDate-Example1" />
+    <resource>
+      <Observation>
+        <id value="SurgeryDate-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-surgery-date" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80992-1" />
+            <display value="Date and time of surgery" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <effectiveDateTime value="2019-11-12" />
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/ExaminerContacted-Example1" />
+    <resource>
+      <Observation>
+        <id value="ExaminerContacted-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-examiner-contacted" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="74497-9" />
+            <display value="Medical examiner or coroner was contacted [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+            <code value="Y" />
+            <display value="Yes" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/MannerOfDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="MannerOfDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-manner-of-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69449-7" />
+            <display value="Manner of death" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="38605008" />
+            <display value="Natural death" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Location/DeathLocation-Example1" />
+    <resource>
+      <Location>
+        <id value="DeathLocation-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location" />
+        </meta>
+        <name value="Pecan Grove Nursing Home" />
+        <description value="nursing home" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="death" />
+          </coding>
+        </type>
+        <address>
+          <city value="Albany" />
+          <state value="NY" />
+          <country value="US" />
+        </address>
+        <position>
+          <longitude value="-77.050636" />
+          <latitude value="38.889248" />
+        </position>
+      </Location>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Location/InjuryLocation-Example1" />
+    <resource>
+      <Location>
+        <id value="InjuryLocation-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-location" />
+        </meta>
+        <name value="Home" />
+        <description value="5590 Lockwood Drive 20621 US" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="injury" />
+          </coding>
+        </type>
+        <address>
+          <text value="5590 Lockwood Drive 20621 US" />
+        </address>
+      </Location>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/InjuryIncident-Example1" />
+    <resource>
+      <Observation>
+        <id value="InjuryIncident-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-incident" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="11374-6" />
+            <display value="Injury incident description Narrative" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <effectiveDateTime value="2019-11-02T13:00:00-05:00" />
+        <valueCodeableConcept>
+          <text value="drug toxicity" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69444-8" />
+              <display value="Did death result from injury at work" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+              <code value="N" />
+              <display value="No" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69450-5" />
+              <display value="Place of injury Facility" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <text value="Home" />
+          </valueCodeableConcept>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69451-3" />
+              <display value="Transportation role of decedent" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor" />
+              <code value="OTH" />
+              <display value="Other" />
+            </coding>
+            <text value="Hoverboard Rider" />
+          </valueCodeableConcept>
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Practitioner/Certifier-Example1" />
+    <resource>
+      <Practitioner>
+        <id value="Certifier-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-certifier" />
+        </meta>
+        <identifier>
+          <system value="http://hl7.org/fhir/sid/us-npi" />
+          <value value="414444AB" />
+        </identifier>
+        <name>
+          <use value="official" />
+          <family value="Black" />
+          <given value="Jim" />
+        </name>
+        <address>
+          <line value="44 South Street" />
+          <city value="Bird in Hand" />
+          <state value="PA" />
+          <postalCode value="17505" />
+          <country value="US" />
+        </address>
+        <qualification>
+          <code>
+            <coding>
+              <system value="http://snomed.info/sct" />
+              <code value="434641000124105" />
+            </coding>
+          </code>
+        </qualification>
+      </Practitioner>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Procedure/DeathCertification-Example1" />
+    <resource>
+      <Procedure>
+        <id value="DeathCertification-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certification" />
+        </meta>
+        <identifier>
+          <value value="180" />
+        </identifier>
+        <status value="completed" />
+        <category>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="103693007" />
+            <display value="Diagnostic procedure" />
+          </coding>
+        </category>
+        <code>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="308646001" />
+            <display value="Death certification" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performedDateTime value="2020-11-14T16:39:40-05:00" />
+        <performer>
+          <function>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor" />
+              <code value="OTH" />
+            </coding>
+            <text value="Nurse Practitioner" />
+          </function>
+          <actor>
+            <reference value="Practitioner/Certifier-Example1" />
+          </actor>
+        </performer>
+      </Procedure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example1" />
+    <resource>
+      <Observation>
+        <id value="CauseOfDeathPart1-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <text value="Cardiopulmonary arrest" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+            </coding>
+          </code>
+          <valueInteger value="1" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueString value="4 hours" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2" />
+    <resource>
+      <Observation>
+        <id value="CauseOfDeathPart1-Example2" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <text value="Eclampsia" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+            </coding>
+          </code>
+          <valueInteger value="2" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueString value="3 months" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2" />
+    <resource>
+      <Observation>
+        <id value="CauseOfDeathPart1-Example2" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <text value="Coronary artery thrombosis" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+            </coding>
+          </code>
+          <valueInteger value="3" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueString value="3 months" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2" />
+    <resource>
+      <Observation>
+        <id value="CauseOfDeathPart1-Example2" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69453-9" />
+            <display value="Cause of death [US Standard Certificate of Death]" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <text value="Atherosclerotic coronary artery disease" />
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+            </coding>
+          </code>
+          <valueInteger value="4" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69440-6" />
+              <display value="Disease onset to death interval" />
+            </coding>
+          </code>
+          <valueString value="3 months" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/CauseOfDeathPart2-Example1" />
+    <resource>
+      <Observation>
+        <id value="CauseOfDeathPart2-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="69441-4" />
+            <display value="Other significant causes or conditions of death" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Certifier-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <text value="hypertensive heart disease" />
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Location/DispositionLocation-Example1" />
+    <resource>
+      <Location>
+        <id value="DispositionLocation-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location" />
+        </meta>
+        <name value="Rosewood Cemetary" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs" />
+            <code value="disposition" />
+          </coding>
+        </type>
+        <address>
+          <line value="303 Rosewood Ave" />
+          <city value="Danville" />
+          <state value="VA" />
+          <postalCode value="24541" />
+          <country value="US" />
+        </address>
+        <physicalType>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/location-physical-type" />
+            <code value="si" />
+            <display value="Site" />
+          </coding>
+        </physicalType>
+      </Location>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Organization/FuneralHome-Example1" />
+    <resource>
+      <Organization>
+        <id value="FuneralHome-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home" />
+        </meta>
+        <active value="true" />
+        <type>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs" />
+            <code value="funeralhome" />
+            <display value="Funeral Home" />
+          </coding>
+        </type>
+        <name value="Lancaster Funeral Home and Crematory" />
+        <address>
+          <line value="211 High Street" />
+          <city value="Lancaster" />
+          <state value="PA" />
+          <postalCode value="17573" />
+          <country value="US" />
+        </address>
+      </Organization>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/DecedentDispositionMethod-Example1" />
+    <resource>
+      <Observation>
+        <id value="DecedentDispositionMethod-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-disposition-method" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80905-3" />
+            <display value="Body disposition method" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <performer>
+          <reference value="Practitioner/Mortician-Example1" />
+        </performer>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="449971000124106" />
+            <display value="Patient status determination, deceased and buried" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/AutopsyPerformedIndicator-Example1" />
+    <resource>
+      <Observation>
+        <id value="AutopsyPerformedIndicator-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-autopsy-performed-indicator" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="85699-7" />
+            <display value="Autopsy was performed" />
+          </coding>
+        </code>
+        <subject>
+          <reference value="Patient/Decedent-Example1" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+            <code value="Y" />
+            <display value="Yes" />
+          </coding>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://loinc.org" />
+              <code value="69436-4" />
+              <display value="Autopsy results available" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v2-0136" />
+              <code value="Y" />
+              <display value="Yes" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Practitioner/Mortician-Example1" />
+    <resource>
+      <Practitioner>
+        <id value="Mortician-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner" />
+        </meta>
+        <identifier>
+          <system value="http://hl7.org/fhir/sid/us-npi" />
+          <value value="212222AB" />
+        </identifier>
+        <name>
+          <use value="official" />
+          <family value="Smith" />
+          <given value="Ronald" />
+          <given value="Q" />
+        </name>
+      </Practitioner>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/ActivityAtTimeOfDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="ActivityAtTimeOfDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-activity-at-time-of-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80626-5" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-activity-at-time-of-death-cs" />
+            <code value="1" />
+            <display value="While engaged in leisure activities." />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/CodedRaceAndEthnicity-Example1" />
+    <resource>
+      <Observation>
+        <id value="CodedRaceAndEthnicity-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-coded-race-and-ethnicity" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs" />
+            <code value="codedraceandethnicity" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="FirstEditedCode" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-race-code-cs" />
+              <code value="101" />
+              <display value="White" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="SecondEditedCode" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-race-code-cs" />
+              <code value="122" />
+              <display value="Israeli" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="FirstAmericanIndianCode" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-race-code-cs" />
+              <code value="A31" />
+              <display value="Arikara" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="RaceRecode40" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-race-recode-40-cs" />
+              <code value="20" />
+              <display value="AIAN and Asian" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="HispanicCode" />
+            </coding>
+          </code>
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-hispanic-origin-cs" />
+              <code value="233" />
+              <display value="Chilean" />
+            </coding>
+          </valueCodeableConcept>
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/ManualUnderlyingCauseOfDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="ManualUnderlyingCauseOfDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-manual-underlying-cause-of-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80359-3" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://hl7.org/fhir/sid/icd-10" />
+            <code value="J96.0" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/AutomatedUnderlyingCauseOfDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="AutomatedUnderlyingCauseOfDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-automated-underlying-cause-of-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80358-5" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://hl7.org/fhir/sid/icd-10" />
+            <code value="J96.0" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/RecordAxisCauseOfDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="RecordAxisCauseOfDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-record-axis-cause-of-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80357-7" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://hl7.org/fhir/sid/icd-10" />
+            <code value="J96.0" />
+          </coding>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="position" />
+            </coding>
+          </code>
+          <valueInteger value="1" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/EntityAxisCauseOfDeath-Example1" />
+    <resource>
+      <Observation>
+        <id value="EntityAxisCauseOfDeath-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-entity-axis-cause-of-death" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="80356-9" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://hl7.org/fhir/sid/icd-10" />
+            <code value="J96.0" />
+          </coding>
+        </valueCodeableConcept>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+            </coding>
+          </code>
+          <valueInteger value="1" />
+        </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="position" />
+            </coding>
+          </code>
+          <valueInteger value="1" />
+        </component>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Observation/PlaceOfInjury-Example1" />
+    <resource>
+      <Observation>
+        <id value="PlaceOfInjury-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-place-of-injury" />
+        </meta>
+        <status value="final" />
+        <code>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="11376-1" />
+          </coding>
+        </code>
+        <subject>
+          <display value="NCHS generated" />
+        </subject>
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://loinc.org" />
+            <code value="LA14084-0" />
+            <display value="Home" />
+          </coding>
+        </valueCodeableConcept>
+      </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://www.example.org/fhir/Parameter/CodingStatusValues-Example1" />
+    <resource>
+      <Parameters>
+        <id value="CodingStatusValues-Example1" />
+        <meta>
+          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-coding-status-values" />
+        </meta>
+        <parameter>
+          <name value="shipmentNumber" />
+          <valueString value="A2B2" />
+        </parameter>
+        <parameter>
+          <name value="receiptDate" />
+          <valueDate value="2021-12-12" />
+        </parameter>
+        <parameter>
+          <name value="coderStatus" />
+          <valueInteger value="5" />
+        </parameter>
+        <parameter>
+          <name value="intentionalReject" />
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-intentional-reject-cs" />
+              <code value="1" />
+            </coding>
+          </valueCodeableConcept>
+        </parameter>
+        <parameter>
+          <name value="acmeSystemReject" />
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-system-reject-cs" />
+              <code value="0" />
+            </coding>
+          </valueCodeableConcept>
+        </parameter>
+        <parameter>
+          <name value="transaxConversion" />
+          <valueCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-transax-conversion-cs" />
+              <code value="3" />
+            </coding>
+          </valueCodeableConcept>
+        </parameter>
+      </Parameters>
+    </resource>
+  </entry>
+</Bundle>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -838,7 +838,7 @@
               <display value="lineNumber" />
             </coding>
           </code>
-          <valueUnsignedInt value="1"/>
+          <valueInteger value="1" />
         </component>
       </Observation>
     </resource>
@@ -892,7 +892,7 @@
               <display value="lineNumber" />
             </coding>
           </code>
-          <valuePositiveInt value="2"/>
+          <valueInteger value="2" />
         </component>
       </Observation>
     </resource>
@@ -941,7 +941,7 @@
               <display value="lineNumber" />
             </coding>
           </code>
-          <valuePositiveInt value="3"/>
+          <valueInteger value="3" />
         </component>
 
       </Observation>
@@ -991,7 +991,7 @@
               <display value="lineNumber" />
             </coding>
           </code>
-          <valuePositiveInt value="4"/>
+          <valueInteger value="4" />
         </component>
       </Observation>
     </resource>

--- a/VRDR.Tests/fixtures/xml/DeathRecord1.xml
+++ b/VRDR.Tests/fixtures/xml/DeathRecord1.xml
@@ -687,49 +687,6 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:9d567f0e-553d-4a58-aa3c-22b3b64e4add" />
-    <resource>
-      <List>
-        <id value="9d567f0e-553d-4a58-aa3c-22b3b64e4add" />
-        <meta>
-          <profile value="http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway" />
-        </meta>
-        <status value="current" />
-        <mode value="snapshot" />
-        <source>
-          <reference value="urn:uuid:c99651c4-7c84-499f-bb37-7db96f9929c4" />
-        </source>
-        <orderedBy>
-          <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/list-order" />
-            <code value="priority" />
-            <display value="Sorted by Priority" />
-          </coding>
-        </orderedBy>
-        <entry>
-          <item>
-            <reference value="urn:uuid:e3328799-6392-4f6b-9db9-556a9b8a88d3" />
-          </item>
-        </entry>
-        <entry>
-          <item>
-            <reference value="urn:uuid:5c0a0509-8297-4a53-a0ef-725daaaf9736" />
-          </item>
-        </entry>
-        <entry>
-          <item>
-            <reference value="urn:uuid:826a3c27-c712-4c65-b454-46cc4ca76c99" />
-          </item>
-        </entry>
-        <entry>
-          <item>
-            <reference value="urn:uuid:46c9ed22-34f6-4d40-bdfa-9b7d6b3e9da6" />
-          </item>
-        </entry>
-      </List>
-    </resource>
-  </entry>
-  <entry>
     <fullUrl value="9bebc631-70b1-4052-bb61-7909caa7f5d4" />
     <resource>
       <Location>
@@ -873,6 +830,16 @@
             <text value="minutes" />
           </valueCodeableConcept>
         </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+              <display value="lineNumber" />
+            </coding>
+          </code>
+          <valueUnsignedInt value="1"/>
+        </component>
       </Observation>
     </resource>
   </entry>
@@ -917,6 +884,16 @@
             <text value="6 days" />
           </valueCodeableConcept>
         </component>
+        <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+              <display value="lineNumber" />
+            </coding>
+          </code>
+          <valuePositiveInt value="2"/>
+        </component>
       </Observation>
     </resource>
   </entry>
@@ -955,6 +932,16 @@
           <valueCodeableConcept>
             <text value="5 years" />
           </valueCodeableConcept>
+        </component>
+                <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+              <display value="lineNumber" />
+            </coding>
+          </code>
+          <valuePositiveInt value="3"/>
         </component>
 
       </Observation>
@@ -995,6 +982,16 @@
           <valueCodeableConcept>
             <text value="7 years" />
           </valueCodeableConcept>
+        </component>
+                <component>
+          <code>
+            <coding>
+              <system value="http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs" />
+              <code value="lineNumber" />
+              <display value="lineNumber" />
+            </coding>
+          </code>
+          <valuePositiveInt value="4"/>
         </component>
       </Observation>
     </resource>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -39,6 +39,20 @@ namespace VRDR
         /// <summary>The Decedent's Race and Ethnicity provided by Jurisdiction.</summary>
         private Observation InputRaceAndEthnicityObs;
 
+        /// <summary> Create Input Race and Ethnicity </summary>
+
+        private void CreateInputRaceEthnicityObs() {
+            InputRaceAndEthnicityObs = new Observation();
+            InputRaceAndEthnicityObs.Id = Guid.NewGuid().ToString();
+            InputRaceAndEthnicityObs.Meta = new Meta();
+            string[] raceethnicity_profile = { ProfileURL.InputRaceAndEthnicity };
+            InputRaceAndEthnicityObs.Meta.Profile = raceethnicity_profile;
+            InputRaceAndEthnicityObs.Status = ObservationStatus.Final;
+            InputRaceAndEthnicityObs.Code = new CodeableConcept(CodeSystems.ObservationCode, "inputraceandethnicity", "Input Race and Ethnicity", null);
+            InputRaceAndEthnicityObs.Subject = new ResourceReference("urn:uuid:" + InputRaceAndEthnicityObs.Id);
+            AddReferenceToComposition(InputRaceAndEthnicityObs.Id, "DecedentDemographics");
+            Bundle.AddResourceEntry(InputRaceAndEthnicityObs, "urn:uuid:" + InputRaceAndEthnicityObs.Id);
+        }
         // ///<summary>The Pronouncer of death.</summary>
         //private Practitioner Pronouncer;
 
@@ -369,22 +383,6 @@ namespace VRDR
             Bundle.AddResourceEntry(SurgeryDateObs, "urn:uuid:" + SurgeryDateObs.Id);
         }
 
-        private void CreateRaceEthnicityObs() {
-            InputRaceAndEthnicityObs = new Observation();
-            InputRaceAndEthnicityObs.Id = Guid.NewGuid().ToString();
-            InputRaceAndEthnicityObs.Meta = new Meta();
-            string[] raceethnicity_profile = { ProfileURL.InputRaceAndEthnicity };
-            InputRaceAndEthnicityObs.Meta.Profile = raceethnicity_profile;
-            InputRaceAndEthnicityObs.Status = ObservationStatus.Final;
-            Dictionary<string, string> coding = new Dictionary<string, string>();
-            coding.Add("code", "inputraceandethnicity");
-            coding.Add("system", "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observation-cs");
-            InputRaceAndEthnicityObs.Code = DictToCodeableConcept(coding);
-            InputRaceAndEthnicityObs.Subject = new ResourceReference("urn:uuid:" + InputRaceAndEthnicityObs.Id);
-            AddReferenceToComposition(InputRaceAndEthnicityObs.Id, "DecedentDemographics");
-            Bundle.AddResourceEntry(InputRaceAndEthnicityObs, "urn:uuid:" + InputRaceAndEthnicityObs.Id);
-        }
-
         /// <summary>Decedent Pregnancy Status.</summary>
         private Observation PregnancyObs;
 
@@ -567,7 +565,7 @@ namespace VRDR
             Bundle.Id = Guid.NewGuid().ToString();
             Bundle.Type = Bundle.BundleType.Document; // By default, Bundle type is "document".
             Bundle.Meta = new Meta();
-            string[] bundle_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document" };
+            string[] bundle_profile = { ProfileURL.DeathCertificateDocument };
             Bundle.Timestamp = DateTime.Now;
             Bundle.Meta.Profile = bundle_profile;
 
@@ -578,17 +576,9 @@ namespace VRDR
             string[] decedent_profile = { ProfileURL.Decedent };
             Decedent.Meta.Profile = decedent_profile;
 
-            // Start with an empty race and ethinicity observation
-            InputRaceAndEthnicityObs = new Observation();
-            InputRaceAndEthnicityObs.Id = Guid.NewGuid().ToString();
-            InputRaceAndEthnicityObs.Meta = new Meta();
-            string[] raceethnicity_profile = { ProfileURL.InputRaceAndEthnicity };
-            InputRaceAndEthnicityObs.Meta.Profile = raceethnicity_profile;
-            InputRaceAndEthnicityObs.Status = ObservationStatus.Final;
-            InputRaceAndEthnicityObs.Code = new CodeableConcept(CodeSystems.ObservationCode, "inputraceandethnicity", "Input Race and Ethnicity", null);
-            InputRaceAndEthnicityObs.Subject = new ResourceReference("urn:uuid:" + InputRaceAndEthnicityObs.Id);
 
-            // Start with an empty certifier.
+
+            // Start with an empty certifier. - why?
             CreateCertifier();
 
             // // Start with an empty pronouncer.
@@ -601,13 +591,13 @@ namespace VRDR
             // Start with an empty mortician.
            // InitializeMorticianIfNull();
 
-            // Start with an empty certification.
+            // Start with an empty certification. - why?
             CreateEmptyDeathCertification();
 
-            // Start with an empty funeral home.
+            // Start with an empty funeral home. - why?
             CreateFuneralHome();
 
-            // Location of Disposition
+            // Location of Disposition -why?
             CreateDispositionLocation();
 
             // Add Composition to bundle. As the record is filled out, new entries will be added to this element.
@@ -631,17 +621,10 @@ namespace VRDR
             Composition.Event.Add(eventComponent);
             Bundle.AddResourceEntry(Composition, "urn:uuid:" + Composition.Id);
 
-            // Start with an empty Cause of Death Pathway
-            // CauseOfDeathConditionPathway = new List();
-            // CauseOfDeathConditionPathway.Id = Guid.NewGuid().ToString();
-            // CauseOfDeathConditionPathway.Meta = new Meta();
-            // string[] causeofdeathconditionpathway_profile = { ProfileURL.CauseOfDeathPathway };
-            // CauseOfDeathConditionPathway.Meta.Profile = causeofdeathconditionpathway_profile;
-            // CauseOfDeathConditionPathway.Status = List.ListStatus.Current;
-            // CauseOfDeathConditionPathway.Mode = Hl7.Fhir.Model.ListMode.Snapshot;
-            // CauseOfDeathConditionPathway.Source = new ResourceReference("urn:uuid:" + Certifier.Id);
-            // CauseOfDeathConditionPathway.OrderedBy = new CodeableConcept("http://terminology.hl7.org/CodeSystem/list-order", "priority", "Sorted by Priority", null);
+             // Start with an empty race and ethinicity observation - why?
+            CreateInputRaceEthnicityObs();
 
+            // Start with an empty coding status values. - why?
             CreateEmptyCodingStatusValues();
 
             // Add references back to the Decedent, Certifier, Certification, etc.
@@ -1363,7 +1346,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Manner Of Death Type: {ExampleDeathRecord.MannerOfDeathType['display']}");</para>
         /// </example>
-        [Property("Manner Of Death Type", Property.Types.Dictionary, "Death Certification", "Manner of Death Type.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Manner-of-Death.html", true, 49)]
+        [Property("Manner Of Death Type", Property.Types.Dictionary, "Death Certification", "Manner of Death Type.", true, IGURL.MannerOfDeath, true, 49)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -1416,7 +1399,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Manner Of Death Type: {ExampleDeathRecord.MannerOfDeathTypeHelper}");</para>
         /// </example>
-        [Property("Manner Of Death Type", Property.Types.String, "Death Certification", "Manner of Death Type.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Manner-of-Death.html", true, 49)]
+        [Property("Manner Of Death Type", Property.Types.String, "Death Certification", "Manner of Death Type.", true, IGURL.MannerOfDeath, true, 49)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69449-7')", "")]
 
@@ -3026,7 +3009,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
                 var coding = EmptyRaceEthnicityCodeDict();
@@ -3105,7 +3088,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
                 var coding = EmptyRaceEthnicityCodeDict();
@@ -3184,7 +3167,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
                 var coding = EmptyRaceEthnicityCodeDict();
@@ -3263,7 +3246,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
                 var coding = EmptyRaceEthnicityCodeDict();
@@ -3336,7 +3319,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
                 var coding = EmptyRaceEthnicityCodeDict();
@@ -3412,7 +3395,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 var booleanRaceCodes = NvssRace.GetBooleanRaceCodes();
                 foreach (Tuple<string, string> element in value)
@@ -3480,7 +3463,7 @@ namespace VRDR
             {
                 if (InputRaceAndEthnicityObs == null)
                 {
-                    CreateRaceEthnicityObs();
+                    CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssRace.MissingValueReason);
                 var coding = EmptyRaceEthnicityCodeDict();
@@ -4938,7 +4921,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Military Service: {ExampleDeathRecord.MilitaryService['display']}");</para>
         /// </example>
-        [Property("Military Service", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Military Service.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Military-Service.html", false, 22)]
+        [Property("Military Service", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Military Service.", true, IGURL.DecedentMilitaryService, false, 22)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -4984,7 +4967,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Military Service: {ExampleDeathRecord.MilitaryServiceHelper}");</para>
         /// </example>
-        [Property("Military Service Helper", Property.Types.String, "Decedent Demographics", "Decedent's Military Service.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Military-Service.html", false, 23)]
+        [Property("Military Service Helper", Property.Types.String, "Decedent Demographics", "Decedent's Military Service.", true, IGURL.DecedentMilitaryService, false, 23)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='55280-2')", "")]
          public string MilitaryServiceHelper
         {
@@ -5260,7 +5243,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Funeral Home Name: {ExampleDeathRecord.FuneralHomeName}");</para>
         /// </example>
-        [Property("Funeral Home Name", Property.Types.String, "Decedent Disposition", "Name of Funeral Home.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Funeral-Home.html", false, 94)]
+        [Property("Funeral Home Name", Property.Types.String, "Decedent Disposition", "Name of Funeral Home.", true, IGURL.FuneralHome, false, 94)]
         [FHIRPath("Bundle.entry.resource.where($this is Organization).where(type.coding.code='bus')", "name")]
         public string FuneralHomeName
         {
@@ -5460,7 +5443,7 @@ namespace VRDR
                     DispositionMethod = new Observation();
                     DispositionMethod.Id = Guid.NewGuid().ToString();
                     DispositionMethod.Meta = new Meta();
-                    string[] dispositionmethod_profile = { "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method" };
+                    string[] dispositionmethod_profile = { ProfileURL.DecedentDispositionMethod };
                     DispositionMethod.Meta.Profile = dispositionmethod_profile;
                     DispositionMethod.Status = ObservationStatus.Final;
                     DispositionMethod.Code = new CodeableConcept(CodeSystems.LOINC, "80905-3", "Body disposition method", null);
@@ -5553,7 +5536,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Autopsy Performed Indicator: {ExampleDeathRecord.AutopsyPerformedIndicator['display']}");</para>
         /// </example>
-        [Property("Autopsy Performed Indicator", Property.Types.Dictionary, "Death Investigation", "Autopsy Performed Indicator.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Autopsy-Performed-Indicator.html", true, 28)]
+        [Property("Autopsy Performed Indicator", Property.Types.Dictionary, "Death Investigation", "Autopsy Performed Indicator.", true, IGURL.AutopsyPerformedIndicator, true, 28)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6074,7 +6057,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Date of Death Pronouncement: {ExampleDeathRecord.DateOfDeathPronouncement}");</para>
         /// </example>
-        [Property("Date/Time Of Death Pronouncement", Property.Types.StringDateTime, "Death Investigation", "Decedent's Date/Time of Death Pronouncement.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Date.html", false, 20)]
+        [Property("Date/Time Of Death Pronouncement", Property.Types.StringDateTime, "Death Investigation", "Decedent's Date/Time of Death Pronouncement.", true, IGURL.DeathDate, false, 20)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80616-6')", "")]
         public string DateOfDeathPronouncement
         {
@@ -6258,7 +6241,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Autopsy Results Available: {ExampleDeathRecord.AutopsyResultsAvailable['display']}");</para>
         /// </example>
-        [Property("Autopsy Results Available", Property.Types.Dictionary, "Death Investigation", "Autopsy results available, used to complete cause of death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Autopsy-Performed-Indicator.html", true, 30)]
+        [Property("Autopsy Results Available", Property.Types.Dictionary, "Death Investigation", "Autopsy results available, used to complete cause of death.", true, IGURL.AutopsyPerformedIndicator, true, 30)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6533,7 +6516,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Description: {ExampleDeathRecord.DeathLocationDescription}");</para>
         /// </example>
-        [Property("Death Location Description", Property.Types.String, "Death Investigation", "Description of Death Location.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Location.html", false, 18)]
+        [Property("Death Location Description", Property.Types.String, "Death Investigation", "Description of Death Location.", true, IGURL.DeathLocation, false, 18)]
         [FHIRPath("Bundle.entry.resource.where($this is Location).where(type='death')", "description")]
         public string DeathLocationDescription
         {
@@ -6555,7 +6538,7 @@ namespace VRDR
                     string[] deathlocation_profile = { ProfileURL.DeathLocation };
                     DeathLocationLoc.Meta.Profile = deathlocation_profile;
                     DeathLocationLoc.Description = value;
-                    DeathLocationLoc.Type.Add(new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs", "death", "death location", null));
+                    DeathLocationLoc.Type.Add(new CodeableConcept(CodeSystems.LocationType, "death", "death location", null));
                     // LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
                     AddReferenceToComposition(DeathLocationLoc.Id, "DeathInvestigation");
                     Bundle.AddResourceEntry(DeathLocationLoc, "urn:uuid:" + DeathLocationLoc.Id);
@@ -6583,7 +6566,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Type: {ExampleDeathRecord.DeathLocationType['display']}");</para>
         /// </example>
-        [Property("Death Location Type", Property.Types.Dictionary, "Death Investigation", "Type of Death Location.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Location.html", false, 19)]
+        [Property("Death Location Type", Property.Types.Dictionary, "Death Investigation", "Type of Death Location.", true, IGURL.DeathLocation, false, 19)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6638,7 +6621,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Type: {ExampleDeathRecord.DeathLocationTypeHelper}");</para>
         /// </example>
-        [Property("Death Location Type Helper", Property.Types.String, "Death Investigation", "Type of Death Location.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Death-Location.html", false, 19)]
+        [Property("Death Location Type Helper", Property.Types.String, "Death Investigation", "Type of Death Location.", true, IGURL.DeathLocation, false, 19)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "component")]
         public string DeathLocationTypeHelper
@@ -6892,7 +6875,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Pregnancy Status: {ExampleDeathRecord.PregnancyObs['display']}");</para>
         /// </example>
-        [Property("Pregnancy Status", Property.Types.Dictionary, "Death Investigation", "Pregnancy Status At Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Pregnancy.html", true, 33)]
+        [Property("Pregnancy Status", Property.Types.Dictionary, "Death Investigation", "Pregnancy Status At Death.", true, IGURL.DecedentPregnancyStatus, true, 33)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6927,7 +6910,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Pregnancy Status: {ExampleDeathRecord.PregnancyStatusHelper}");</para>
         /// </example>
-        [Property("Pregnancy Status", Property.Types.String, "Death Investigation", "Pregnancy Status At Death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Pregnancy.html", true, 33)]
+        [Property("Pregnancy Status", Property.Types.String, "Death Investigation", "Pregnancy Status At Death.", true, IGURL.DecedentPregnancyStatus, true, 33)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69442-2')", "")]
         public string PregnancyStatusHelper
@@ -7253,7 +7236,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Injury Location Name: {ExampleDeathRecord.InjuryLocationName}");</para>
         /// </example>
-        [Property("Injury Location Name", Property.Types.String, "Death Investigation", "Name of Injury Location.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Injury-Location.html", true, 35)]
+        [Property("Injury Location Name", Property.Types.String, "Death Investigation", "Name of Injury Location.", true, IGURL.InjuryLocation, true, 35)]
         [FHIRPath("Bundle.entry.resource.where($this is Location).where(type='injury')", "name")]
         public string InjuryLocationName
         {
@@ -7663,11 +7646,11 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Transportation Role: {ExampleDeathRecord.TransportationRole['display']}");</para>
         /// </example>
-        [Property("Transportation Role", Property.Types.Dictionary, "Death Investigation", "Transportation Role in death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Transportation-Role.html", true, 45)]
+        [Property("Transportation Role", Property.Types.Dictionary, "Death Investigation", "Transportation Role in death.", true, IGURL.InjuryIncident, true, 45)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69451-3')", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]  // The component  code is '69451-3'
         public Dictionary<string, string> TransportationRole
         {
             get
@@ -7718,7 +7701,7 @@ namespace VRDR
         /// </example>
         [Property("Transportation Role Helper", Property.Types.String, "Death Investigation", "Transportation Role in death.", true, "http://build.fhir.org/ig/HL7/vrdr/StructureDefinition-VRDR-Decedent-Transportation-Role.html", true, 45)]
         [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69451-3')", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]  // The component  code is '69451-3'
         public string TransportationRoleHelper
         {
             get
@@ -7848,7 +7831,7 @@ namespace VRDR
                     string[] tb_profile = { ProfileURL.EmergingIssues };
                     EmergingIssues.Meta.Profile = tb_profile;
                     EmergingIssues.Status = ObservationStatus.Final;
-                    EmergingIssues.Code = new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observation-cs", "emergingissues", "Emerging Issues", null);
+                    EmergingIssues.Code = new CodeableConcept(CodeSystems.ObservationCode, "emergingissues", "Emerging Issues", null);
                     EmergingIssues.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
                     AddReferenceToComposition(EmergingIssues.Id, "DecedentDemographics");
                     Bundle.AddResourceEntry(EmergingIssues, "urn:uuid:" + EmergingIssues.Id);
@@ -7856,7 +7839,7 @@ namespace VRDR
                 // Remove existing component (if it exists) and add an appropriate component.
                 EmergingIssues.Component.RemoveAll( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == identifier );
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = new CodeableConcept("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs", identifier, null, null);
+                component.Code = new CodeableConcept(CodeSystems.ComponentCode, identifier, null, null);
                 component.Value = new FhirString(value);
                 EmergingIssues.Component.Add(component);
         }
@@ -7885,7 +7868,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue1_1}");</para>
         /// </example>
-        [Property("Emerging Issue Field Length 1 Number 1", Property.Types.String, "Decedent Demographics", "One-Byte Field 1", true, "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues", false, 50)]
+        [Property("Emerging Issue Field Length 1 Number 1", Property.Types.String, "Decedent Demographics", "One-Byte Field 1", true, IGURL.EmergingIssues, false, 50)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
         public string EmergingIssue1_1
         {

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -41,7 +41,8 @@ namespace VRDR
 
         /// <summary> Create Input Race and Ethnicity </summary>
 
-        private void CreateInputRaceEthnicityObs() {
+        private void CreateInputRaceEthnicityObs()
+        {
             InputRaceAndEthnicityObs = new Observation();
             InputRaceAndEthnicityObs.Id = Guid.NewGuid().ToString();
             InputRaceAndEthnicityObs.Meta = new Meta();
@@ -59,11 +60,12 @@ namespace VRDR
         /// <summary>The Certifier.</summary>
         private Practitioner Certifier;
         /// <summary>Create Certifier.</summary>
-        private void CreateCertifier(){
+        private void CreateCertifier()
+        {
             Certifier = new Practitioner();
             Certifier.Id = Guid.NewGuid().ToString();
             Certifier.Meta = new Meta();
-            string[] certifier_profile = { ProfileURL.Certifier  };
+            string[] certifier_profile = { ProfileURL.Certifier };
             Certifier.Meta.Profile = certifier_profile;
             // Not linked to Composition or inserted in bundle, since this is run before the composition exists.
         }
@@ -80,7 +82,8 @@ namespace VRDR
         // }
 
         /// <summary>Create Death Certification.</summary>
-        private void CreateDeathCertification(){
+        private void CreateDeathCertification()
+        {
             DeathCertification = new Procedure();
             DeathCertification.Id = Guid.NewGuid().ToString();
             DeathCertification.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
@@ -100,23 +103,24 @@ namespace VRDR
         private Observation ConditionContributingToDeath;
 
         /// <summary>Create a Cause Of Death Condition </summary>
-        private Observation CauseOfDeathCondition(int index){
-                    Observation CodCondition;
-                    CodCondition = new Observation();
-                    CodCondition.Id = Guid.NewGuid().ToString();
-                    CodCondition.Meta = new Meta();
-                    string[] condition_profile = { ProfileURL.CauseOfDeathPart1 };
-                    CodCondition.Meta.Profile = condition_profile;
-                    CodCondition.Code = new CodeableConcept(CodeSystems.LOINC, "69453-9", "Cause of death [US Standard Certificate of Death]", null);
-                    CodCondition.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    CodCondition.Performer.Add (new ResourceReference("urn:uuid:" + Certifier.Id));
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.ComponentCode, "lineNumber", "line number", null);
-                    component.Value = new Integer (index + 1); // index is 0-3, linenumbers are 1-4
-                    CodCondition.Component.Add(component);
-                    AddReferenceToComposition(CodCondition.Id, "DeathCertification");
-                    Bundle.AddResourceEntry(CodCondition, "urn:uuid:" + CodCondition.Id);
-                    return (CodCondition);
+        private Observation CauseOfDeathCondition(int index)
+        {
+            Observation CodCondition;
+            CodCondition = new Observation();
+            CodCondition.Id = Guid.NewGuid().ToString();
+            CodCondition.Meta = new Meta();
+            string[] condition_profile = { ProfileURL.CauseOfDeathPart1 };
+            CodCondition.Meta.Profile = condition_profile;
+            CodCondition.Code = new CodeableConcept(CodeSystems.LOINC, "69453-9", "Cause of death [US Standard Certificate of Death]", null);
+            CodCondition.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+            CodCondition.Performer.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
+            Observation.ComponentComponent component = new Observation.ComponentComponent();
+            component.Code = new CodeableConcept(CodeSystems.ComponentCode, "lineNumber", "line number", null);
+            component.Value = new Integer(index + 1); // index is 0-3, linenumbers are 1-4
+            CodCondition.Component.Add(component);
+            AddReferenceToComposition(CodCondition.Id, "DeathCertification");
+            Bundle.AddResourceEntry(CodCondition, "urn:uuid:" + CodCondition.Id);
+            return (CodCondition);
         }
 
 
@@ -135,8 +139,9 @@ namespace VRDR
         /// <summary>Decedent's Father.</summary>
         private RelatedPerson Father;
 
-                /// <summary>Create Spouse.</summary>
-        private void CreateFather(){
+        /// <summary>Create Spouse.</summary>
+        private void CreateFather()
+        {
             Father = new RelatedPerson();
             Father.Id = Guid.NewGuid().ToString();
             Father.Meta = new Meta();
@@ -152,7 +157,8 @@ namespace VRDR
         private RelatedPerson Mother;
 
         /// <summary>Create Mother.</summary>
-        private void CreateMother(){
+        private void CreateMother()
+        {
             Mother = new RelatedPerson();
             Mother.Id = Guid.NewGuid().ToString();
             Mother.Meta = new Meta();
@@ -168,7 +174,8 @@ namespace VRDR
         private RelatedPerson Spouse;
 
         /// <summary>Create Spouse.</summary>
-        private void CreateSpouse(){
+        private void CreateSpouse()
+        {
             Spouse = new RelatedPerson();
             Spouse.Id = Guid.NewGuid().ToString();
             Spouse.Meta = new Meta();
@@ -224,7 +231,8 @@ namespace VRDR
             Bundle.AddResourceEntry(CodingStatusValues, "urn:uuid:" + CodingStatusValues.Id);
         }
 
-        private void CreateBirthRecordIdentifier(){
+        private void CreateBirthRecordIdentifier()
+        {
             BirthRecordIdentifier = new Observation();
             BirthRecordIdentifier.Id = Guid.NewGuid().ToString();
             BirthRecordIdentifier.Meta = new Meta();
@@ -233,7 +241,7 @@ namespace VRDR
             BirthRecordIdentifier.Status = ObservationStatus.Final;
             BirthRecordIdentifier.Code = new CodeableConcept(CodeSystems.HL7_identifier_type, "BR", "Birth registry number", null);
             BirthRecordIdentifier.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-            BirthRecordIdentifier.Value = (FhirString) null;
+            BirthRecordIdentifier.Value = (FhirString)null;
             BirthRecordIdentifier.DataAbsentReason = new CodeableConcept(CodeSystems.Data_Absent_Reason_HL7_V3, "unknown", "Unknown", null);
 
             AddReferenceToComposition(BirthRecordIdentifier.Id, "DecedentDemographics");
@@ -243,7 +251,8 @@ namespace VRDR
         private Observation UsualWork;
 
         /// <summary>Create Usual Work.</summary>
-        private void CreateUsualWork(){
+        private void CreateUsualWork()
+        {
             UsualWork = new Observation();
             UsualWork.Id = Guid.NewGuid().ToString();
             UsualWork.Meta = new Meta();
@@ -251,7 +260,7 @@ namespace VRDR
             UsualWork.Meta.Profile = usualwork_profile;
             UsualWork.Status = ObservationStatus.Final;
             UsualWork.Code = new CodeableConcept(CodeSystems.LOINC, "21843-8", "History of Usual occupation", null);
-            UsualWork.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory,"social-history",null, null));
+            UsualWork.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "social-history", null, null));
             UsualWork.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
             UsualWork.Effective = new Period();
             AddReferenceToComposition(UsualWork.Id, "DecedentDemographics");
@@ -266,13 +275,14 @@ namespace VRDR
 
 
         /// <summary>Create Funeral Home.</summary>
-        private void CreateFuneralHome(){
+        private void CreateFuneralHome()
+        {
             FuneralHome = new Organization();
             FuneralHome.Id = Guid.NewGuid().ToString();
             FuneralHome.Meta = new Meta();
             string[] funeralhome_profile = { ProfileURL.FuneralHome };
             FuneralHome.Meta.Profile = funeralhome_profile;
-            FuneralHome.Type.Add(new CodeableConcept(CodeSystems.OrganizationType, "funeralhome", "Funeral Home",null));
+            FuneralHome.Type.Add(new CodeableConcept(CodeSystems.OrganizationType, "funeralhome", "Funeral Home", null));
             FuneralHome.Active = true;
         }
         // /// <summary>The Funeral Home Director.</summary>
@@ -283,7 +293,8 @@ namespace VRDR
         private Location DispositionLocation;
 
         /// <summary>Create Disposition Location.</summary>
-        private void CreateDispositionLocation(){
+        private void CreateDispositionLocation()
+        {
             DispositionLocation = new Location();
             DispositionLocation.Id = Guid.NewGuid().ToString();
             DispositionLocation.Meta = new Meta();
@@ -292,7 +303,7 @@ namespace VRDR
             Coding pt = new Coding(CodeSystems.HL7_location_physical_type, "si", "Site");
             DispositionLocation.PhysicalType = new CodeableConcept();
             DispositionLocation.PhysicalType.Coding.Add(pt);
-            DispositionLocation.Type.Add(new CodeableConcept( CodeSystems.LocationType, "disposition", "disposition location", null));
+            DispositionLocation.Type.Add(new CodeableConcept(CodeSystems.LocationType, "disposition", "disposition location", null));
             AddReferenceToComposition(DispositionLocation.Id, "DispositionLocation");
             Bundle.AddResourceEntry(DispositionLocation, "urn:uuid:" + DispositionLocation.Id);
         }
@@ -304,7 +315,8 @@ namespace VRDR
         private Observation AutopsyPerformed;
 
         /// <summary>Create Autopsy Performed </summary>
-        private void CreateAutopsyPerformed(){
+        private void CreateAutopsyPerformed()
+        {
             AutopsyPerformed = new Observation();
             AutopsyPerformed.Id = Guid.NewGuid().ToString();
             AutopsyPerformed.Meta = new Meta();
@@ -320,8 +332,9 @@ namespace VRDR
         /// <summary>Age At Death.</summary>
         private Observation AgeAtDeathObs;
 
-         /// <summary>Create Age At Death Obs</summary>
-        private void CreateAgeAtDeathObs(){
+        /// <summary>Create Age At Death Obs</summary>
+        private void CreateAgeAtDeathObs()
+        {
             AgeAtDeathObs = new Observation();
             AgeAtDeathObs.Id = Guid.NewGuid().ToString();
             AgeAtDeathObs.Meta = new Meta();
@@ -359,7 +372,8 @@ namespace VRDR
             return partialDateTime;
         }
 
-        private void CreateDeathDateObs() {
+        private void CreateDeathDateObs()
+        {
             DeathDateObs = new Observation();
             DeathDateObs.Id = Guid.NewGuid().ToString();
             DeathDateObs.Meta = new Meta();
@@ -377,7 +391,8 @@ namespace VRDR
             Bundle.AddResourceEntry(DeathDateObs, "urn:uuid:" + DeathDateObs.Id);
         }
 
-        private void CreateSurgeryDateObs() {
+        private void CreateSurgeryDateObs()
+        {
             SurgeryDateObs = new Observation();
             SurgeryDateObs.Id = Guid.NewGuid().ToString();
             SurgeryDateObs.Meta = new Meta();
@@ -397,7 +412,8 @@ namespace VRDR
         private Observation PregnancyObs;
 
         /// <summary> Create Pregnancy Status. </summary>
-        private void CreatePregnancyObs(){
+        private void CreatePregnancyObs()
+        {
             PregnancyObs = new Observation();
             PregnancyObs.Id = Guid.NewGuid().ToString();
             PregnancyObs.Meta = new Meta();
@@ -422,12 +438,13 @@ namespace VRDR
         /// <summary>Injury Location.</summary>
         private Location InjuryLocationLoc;
 
-          /// <summary>Create Injury Location.</summary>
-          private void CreateInjuryLocationLoc(){
+        /// <summary>Create Injury Location.</summary>
+        private void CreateInjuryLocationLoc()
+        {
             InjuryLocationLoc = new Location();
             InjuryLocationLoc.Id = Guid.NewGuid().ToString();
             InjuryLocationLoc.Meta = new Meta();
-            string[] injurylocation_profile = {ProfileURL.InjuryLocation };
+            string[] injurylocation_profile = { ProfileURL.InjuryLocation };
             InjuryLocationLoc.Meta.Profile = injurylocation_profile;
             InjuryLocationLoc.Address = DictToAddress(EmptyAddrDict());
             InjuryLocationLoc.Type.Add(new CodeableConcept(CodeSystems.LocationType, "injury", "injury location", null));
@@ -436,25 +453,27 @@ namespace VRDR
         /// <summary>Injury Incident.</summary>
         private Observation InjuryIncidentObs;
 
-       /// <summary>Create Injury Incident.</summary>
-        private void CreateInjuryIncidentObs(){
-                    InjuryIncidentObs = new Observation();
-                    InjuryIncidentObs.Id = Guid.NewGuid().ToString();
-                    InjuryIncidentObs.Meta = new Meta();
-                    string[] iio_profile = { ProfileURL.InjuryIncident };
-                    InjuryIncidentObs.Meta.Profile = iio_profile;
-                    InjuryIncidentObs.Status = ObservationStatus.Final;
-                    InjuryIncidentObs.Code = new CodeableConcept(CodeSystems.LOINC, "11374-6", "Injury incident description Narrative", null);
-                    InjuryIncidentObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    InjuryIncidentObs.Effective = new FhirDateTime();
-                    InjuryIncidentObs.Effective.Extension.Add(NewBlankPartialDateTimeExtension(true));
-                    AddReferenceToComposition(InjuryIncidentObs.Id, "OBE");
-                    Bundle.AddResourceEntry(InjuryIncidentObs, "urn:uuid:" + InjuryIncidentObs.Id);
+        /// <summary>Create Injury Incident.</summary>
+        private void CreateInjuryIncidentObs()
+        {
+            InjuryIncidentObs = new Observation();
+            InjuryIncidentObs.Id = Guid.NewGuid().ToString();
+            InjuryIncidentObs.Meta = new Meta();
+            string[] iio_profile = { ProfileURL.InjuryIncident };
+            InjuryIncidentObs.Meta.Profile = iio_profile;
+            InjuryIncidentObs.Status = ObservationStatus.Final;
+            InjuryIncidentObs.Code = new CodeableConcept(CodeSystems.LOINC, "11374-6", "Injury incident description Narrative", null);
+            InjuryIncidentObs.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+            InjuryIncidentObs.Effective = new FhirDateTime();
+            InjuryIncidentObs.Effective.Extension.Add(NewBlankPartialDateTimeExtension(true));
+            AddReferenceToComposition(InjuryIncidentObs.Id, "OBE");
+            Bundle.AddResourceEntry(InjuryIncidentObs, "urn:uuid:" + InjuryIncidentObs.Id);
         }
         /// <summary>Death Location.</summary>
         private Location DeathLocationLoc;
         /// <summary>Create Death Location </summary>
-        private void CreateDeathLocation(){
+        private void CreateDeathLocation()
+        {
             DeathLocationLoc = new Location();
             DeathLocationLoc.Id = Guid.NewGuid().ToString();
             DeathLocationLoc.Meta = new Meta();
@@ -599,7 +618,7 @@ namespace VRDR
             // Pronouncer.Meta.Profile = pronouncer_profile;
 
             // Start with an empty mortician.
-           // InitializeMorticianIfNull();
+            // InitializeMorticianIfNull();
 
             // Start with an empty certification. - need reference in Composition
             CreateDeathCertification();
@@ -651,9 +670,12 @@ namespace VRDR
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
         public DeathRecord(string record, bool permissive = false)
         {
-            ParserSettings parserSettings = new ParserSettings { AcceptUnknownMembers = permissive,
-                                                                 AllowUnrecognizedEnums = permissive,
-                                                                 PermissiveParsing = permissive };
+            ParserSettings parserSettings = new ParserSettings
+            {
+                AcceptUnknownMembers = permissive,
+                AllowUnrecognizedEnums = permissive,
+                PermissiveParsing = permissive
+            };
             // XML?
             Boolean maybeXML = record.TrimStart().StartsWith("<");
             Boolean maybeJSON = record.TrimStart().StartsWith("{");
@@ -664,10 +686,12 @@ namespace VRDR
                 {
                     List<string> entries = new List<string>();
                     ISourceNode node = null;
-                    if (maybeXML) {
+                    if (maybeXML)
+                    {
                         node = FhirXmlNode.Parse(record, new FhirXmlParsingSettings { PermissiveParsing = permissive });
                     }
-                    else {
+                    else
+                    {
                         node = FhirJsonNode.Parse(record, "Bundle", new FhirJsonParsingSettings { PermissiveParsing = permissive });
                     }
                     foreach (Hl7.Fhir.Utility.ExceptionNotification problem in node.VisitAndCatch())
@@ -682,11 +706,13 @@ namespace VRDR
                 // Try Parse
                 try
                 {
-                    if(maybeXML) {
+                    if (maybeXML)
+                    {
                         FhirXmlParser parser = new FhirXmlParser(parserSettings);
                         Bundle = parser.Parse<Bundle>(record);
                     }
-                    else {
+                    else
+                    {
                         FhirJsonParser parser = new FhirJsonParser(parserSettings);
                         Bundle = parser.Parse<Bundle>(record);
                     }
@@ -1030,7 +1056,8 @@ namespace VRDR
                 if (DeathCertification != null && DeathCertification.Performed != null)
                 {
                     return Convert.ToString(DeathCertification.Performed);
-                } else if (Composition.Attester != null && Composition.Attester.FirstOrDefault() != null && Composition.Attester.First().Time != null)
+                }
+                else if (Composition.Attester != null && Composition.Attester.FirstOrDefault() != null && Composition.Attester.First().Time != null)
                 {
                     return Composition.Attester.First().Time;
                 }
@@ -1293,19 +1320,22 @@ namespace VRDR
             {
                 if (CertificationRole.ContainsKey("code"))
                 {
-                    string code = CertificationRole["code"] ;
-                    if (code == "OTH"){
-                        if (CertificationRole.ContainsKey("text")){
+                    string code = CertificationRole["code"];
+                    if (code == "OTH")
+                    {
+                        if (CertificationRole.ContainsKey("text"))
+                        {
                             return (CertificationRole["text"]);
                         }
-                        return("Other");
+                        return ("Other");
                     }
                 }
                 return null;
             }
             set
             {
-                if ((value != null) && !VRDR.Mappings.CertifierTypes.FHIRToIJE.ContainsKey(value)){ //other
+                if ((value != null) && !VRDR.Mappings.CertifierTypes.FHIRToIJE.ContainsKey(value))
+                { //other
                     if (DeathCertification == null)
                     {
                         CreateDeathCertification();
@@ -1581,7 +1611,8 @@ namespace VRDR
         {
             get
             {
-                if (Certifier == null){
+                if (Certifier == null)
+                {
                     return (new Dictionary<string, string>());
                 }
                 return AddressToDict(Certifier.Address.FirstOrDefault());
@@ -1640,7 +1671,8 @@ namespace VRDR
                 {
                     Certifier.Identifier.Clear();
                 }
-                if(value.ContainsKey("system") && value.ContainsKey("value")) {
+                if (value.ContainsKey("system") && value.ContainsKey("value"))
+                {
                     Identifier identifier = new Identifier();
                     identifier.System = value["system"];
                     identifier.Value = value["value"];
@@ -1732,7 +1764,7 @@ namespace VRDR
                     string[] condition_profile = { ProfileURL.CauseOfDeathPart2 };
                     ConditionContributingToDeath.Meta.Profile = condition_profile;
                     ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
-                    ConditionContributingToDeath.Value= new CodeableConcept(null, null, null, value);
+                    ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
                     AddReferenceToComposition(ConditionContributingToDeath.Id, "OBE");
                     Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
                 }
@@ -1836,11 +1868,11 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionA == null)
+                if (CauseOfDeathConditionA == null)
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
-                CauseOfDeathConditionA.Value= new CodeableConcept(null, null, null, value);
+                CauseOfDeathConditionA.Value = new CodeableConcept(null, null, null, value);
             }
         }
 
@@ -1859,8 +1891,8 @@ namespace VRDR
             {
                 if (CauseOfDeathConditionA != null && CauseOfDeathConditionA.Component != null)
                 {
-                    var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                     if (intervalComp?.Value != null)
                     {
                         return intervalComp.Value.ToString();
@@ -1870,20 +1902,20 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionA == null)
+                if (CauseOfDeathConditionA == null)
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
                 // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
+                var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
+                if (intervalComp != null)
+                {
 
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
-                    }
-                    else
-                    {
+                }
+                else
+                {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
                     component.Value = new FhirString(value);
@@ -1963,7 +1995,7 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionB == null)
+                if (CauseOfDeathConditionB == null)
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
@@ -1979,15 +2011,15 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Interval: {ExampleDeathRecord.INTERVAL1B}");</para>
         /// </example>
-     [Property("INTERVAL1B", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
-       public string INTERVAL1B
+        [Property("INTERVAL1B", Property.Types.String, "Death Certification", "Cause of Death Part I Interval, Line b.", false, IGURL.CauseOfDeathPart1, false, 100)]
+        public string INTERVAL1B
         {
             get
             {
                 if (CauseOfDeathConditionB != null && CauseOfDeathConditionB.Component != null)
                 {
-                    var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                     if (intervalComp?.Value != null)
                     {
                         return intervalComp.Value.ToString();
@@ -1997,20 +2029,20 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionB == null)
+                if (CauseOfDeathConditionB == null)
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
                 // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                     if (intervalComp != null)
-                    {
+                var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
+                if (intervalComp != null)
+                {
 
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
-                    }
-                    else
-                    {
+                }
+                else
+                {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
                     component.Value = new FhirString(value);
@@ -2089,7 +2121,7 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionC == null)
+                if (CauseOfDeathConditionC == null)
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
@@ -2114,8 +2146,8 @@ namespace VRDR
             {
                 if (CauseOfDeathConditionC != null && CauseOfDeathConditionC.Component != null)
                 {
-                    var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                     if (intervalComp?.Value != null)
                     {
                         return intervalComp.Value.ToString();
@@ -2125,25 +2157,25 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionC == null)
+                if (CauseOfDeathConditionC == null)
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
                 // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                        if (intervalComp != null)
-                        {
+                var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
+                if (intervalComp != null)
+                {
 
-                        ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
-                        }
-                        else
-                        {
-                        Observation.ComponentComponent component = new Observation.ComponentComponent();
-                        component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                        component.Value = new FhirString(value);
-                        CauseOfDeathConditionC.Component.Add(component);
-                        }
+                    ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
+                }
+                else
+                {
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
+                    component.Value = new FhirString(value);
+                    CauseOfDeathConditionC.Component.Add(component);
+                }
             }
         }
 
@@ -2240,8 +2272,8 @@ namespace VRDR
             {
                 if (CauseOfDeathConditionD != null && CauseOfDeathConditionD.Component != null)
                 {
-                    var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
+                    var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                     if (intervalComp?.Value != null)
                     {
                         return intervalComp.Value.ToString();
@@ -2251,20 +2283,20 @@ namespace VRDR
             }
             set
             {
-                if(CauseOfDeathConditionD == null)
+                if (CauseOfDeathConditionD == null)
                 {
                     CauseOfDeathConditionD = CauseOfDeathCondition(3);
                 }
                 // Find correct component; if doesn't exist add another
-                var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
+                var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                       ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
+                if (intervalComp != null)
+                {
 
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
-                    }
-                    else
-                    {
+                }
+                else
+                {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
                     component.Value = new FhirString(value);
@@ -2484,7 +2516,7 @@ namespace VRDR
             }
             set
             {
-                switch(value)
+                switch (value)
                 {
                     case "male":
                     case "Male":
@@ -2783,7 +2815,8 @@ namespace VRDR
             }
             set
             {
-                if (Decedent.Address == null){
+                if (Decedent.Address == null)
+                {
                     Decedent.Address = new List<Address>();
                 }
                 Decedent.Address.Clear();
@@ -2905,7 +2938,7 @@ namespace VRDR
             set
             {
                 var code = EmptyCodeDict();
-                switch(value)
+                switch (value)
                 {
                     case true:
                         code["code"] = "Y";
@@ -3339,13 +3372,13 @@ namespace VRDR
                 var booleanRaceCodes = NvssRace.GetBooleanRaceCodes();
                 List<string> raceCodes = booleanRaceCodes.Concat(NvssRace.GetLiteralRaceCodes()).ToList();
 
-                var races = new List<Tuple<string, string>>(){};
+                var races = new List<Tuple<string, string>>() { };
 
                 if (InputRaceAndEthnicityObs == null)
                 {
                     return races.ToArray();
                 }
-                foreach(string raceCode in raceCodes)
+                foreach (string raceCode in raceCodes)
                 {
                     Observation.ComponentComponent component = InputRaceAndEthnicityObs.Component.Where(c => c.Code.Coding[0].Code == raceCode).FirstOrDefault();
                     if (component != null)
@@ -3528,7 +3561,7 @@ namespace VRDR
         {
             get
             {
-                Extension addressExt = Decedent.Extension.FirstOrDefault( extension => extension.Url == OtherExtensionURL.PatientBirthPlace );
+                Extension addressExt = Decedent.Extension.FirstOrDefault(extension => extension.Url == OtherExtensionURL.PatientBirthPlace);
                 if (addressExt != null)
                 {
                     Address address = (Address)addressExt.Value;
@@ -3674,7 +3707,8 @@ namespace VRDR
                 Extension ext = new Extension();
                 ext.Url = ExtensionURL.BypassEditFlag;
                 ext.Value = DictToCodeableConcept(value);
-                if (Decedent.MaritalStatus == null){
+                if (Decedent.MaritalStatus == null)
+                {
                     Decedent.MaritalStatus = new CodeableConcept();
                 }
                 Decedent.MaritalStatus.Extension.Add(ext);
@@ -3782,13 +3816,14 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Father Given Name(s): {string.Join(", ", ExampleDeathRecord.FatherGivenNames)}");</para>
         /// </example>
-        [Property("Father Given Names", Property.Types.StringArr, "Decedent Demographics", "Given name(s) of decedent's father.", true, IGURL.DecedentFather , false, 28)]
+        [Property("Father Given Names", Property.Types.StringArr, "Decedent Demographics", "Given name(s) of decedent's father.", true, IGURL.DecedentFather, false, 28)]
         [FHIRPath("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='FTH')", "name")]
         public string[] FatherGivenNames
         {
             get
             {
-                if (Father != null && Father.Name != null ) {
+                if (Father != null && Father.Name != null)
+                {
                     // Evaluation of method System.Linq.Enumerable.SingleOrDefault requires calling method System.Reflection.TypeInfo.get_DeclaredFields, which cannot be called in this context.
                     //HumanName name = Father.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                     string[] names = GetAllString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='FTH').name.where(use='official').given");
@@ -3802,7 +3837,7 @@ namespace VRDR
                 {
                     CreateFather();
                 }
-                   HumanName name = Father.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+                HumanName name = Father.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                 if (name != null && value != null)
                 {
                     name.Given = value;
@@ -3830,9 +3865,10 @@ namespace VRDR
         [FHIRPath("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='FTH')", "name")]
         public string FatherFamilyName
         {
-           get
+            get
             {
-                if (Father != null && Father.Name != null ) {
+                if (Father != null && Father.Name != null)
+                {
                     return GetFirstString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='FTH').name.where(use='official').family");
                 }
                 return null;
@@ -3912,7 +3948,8 @@ namespace VRDR
         {
             get
             {
-                if (Mother != null && Mother.Name != null ) {
+                if (Mother != null && Mother.Name != null)
+                {
                     // Evaluation of method System.Linq.Enumerable.SingleOrDefault requires calling method System.Reflection.TypeInfo.get_DeclaredFields, which cannot be called in this context.
                     //HumanName name = Mother.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                     string[] names = GetAllString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='MTH').name.where(use='official').given");
@@ -3926,7 +3963,7 @@ namespace VRDR
                 {
                     CreateMother();
                 }
-                   HumanName name = Mother.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+                HumanName name = Mother.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                 if (name != null && value != null)
                 {
                     name.Given = value;
@@ -3957,7 +3994,8 @@ namespace VRDR
             get
             {
 
-                if (Mother != null && Mother.Name != null ) {
+                if (Mother != null && Mother.Name != null)
+                {
                     return GetFirstString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='MTH').name.where(use='maiden').family");
                 }
                 return null;
@@ -4037,7 +4075,8 @@ namespace VRDR
         {
             get
             {
-                if (Spouse != null && Spouse.Name != null ) {
+                if (Spouse != null && Spouse.Name != null)
+                {
                     // Evaluation of method System.Linq.Enumerable.SingleOrDefault requires calling method System.Reflection.TypeInfo.get_DeclaredFields, which cannot be called in this context.
                     //HumanName name = Spouse.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                     string[] names = GetAllString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='SPS').name.where(use='official').given");
@@ -4051,7 +4090,7 @@ namespace VRDR
                 {
                     CreateSpouse();
                 }
-                   HumanName name = Spouse.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+                HumanName name = Spouse.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                 if (name != null && value != null)
                 {
                     name.Given = value;
@@ -4081,7 +4120,8 @@ namespace VRDR
         {
             get
             {
-                if (Spouse != null && Spouse.Name != null ) {
+                if (Spouse != null && Spouse.Name != null)
+                {
                     return GetFirstString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='SPS').name.where(use='official').family");
                 }
                 return null;
@@ -4161,7 +4201,8 @@ namespace VRDR
             get
             {
 
-                if (Spouse != null && Spouse.Name != null ) {
+                if (Spouse != null && Spouse.Name != null)
+                {
                     return GetFirstString("Bundle.entry.resource.where($this is RelatedPerson).where(relationship.coding.code='SPS').name.where(use='maiden').family");
                 }
                 return null;
@@ -4211,8 +4252,9 @@ namespace VRDR
         {
             get
             {
-                Extension spouseExt = Decedent.Extension.FirstOrDefault( extension => extension.Url == ExtensionURL.SpouseAlive);
-                if (spouseExt != null && spouseExt.Value != null && spouseExt.Value as CodeableConcept != null) {
+                Extension spouseExt = Decedent.Extension.FirstOrDefault(extension => extension.Url == ExtensionURL.SpouseAlive);
+                if (spouseExt != null && spouseExt.Value != null && spouseExt.Value as CodeableConcept != null)
+                {
 
                     return CodeableConceptToDict((CodeableConcept)spouseExt.Value);
                 }
@@ -4364,12 +4406,14 @@ namespace VRDR
                 {
                     CreateEducationLevelObs();
                 }
-                if (DecedentEducationLevel.Value != null && DecedentEducationLevel.Value.Extension != null){
+                if (DecedentEducationLevel.Value != null && DecedentEducationLevel.Value.Extension != null)
+                {
                     DecedentEducationLevel.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
                 }
                 Extension editFlag = new Extension();
                 editFlag.Url = ExtensionURL.BypassEditFlag;
-                if(DecedentEducationLevel.Value == null){
+                if (DecedentEducationLevel.Value == null)
+                {
                     DecedentEducationLevel.Value = new CodeableConcept();
                 }
                 editFlag.Value = DictToCodeableConcept(value);
@@ -4434,11 +4478,13 @@ namespace VRDR
                 {
                     BirthRecordIdentifier.Value = new FhirString(value);
                     BirthRecordIdentifierDataAbsentBoolean = false;
-                } else {
-                    BirthRecordIdentifier.Value = (FhirString) null;
+                }
+                else
+                {
+                    BirthRecordIdentifier.Value = (FhirString)null;
                     BirthRecordIdentifierDataAbsentBoolean = true;
                 }
-             }
+            }
         }
         /// <summary>Birth Record Identifier Data Absent Reason (Code).</summary>
         /// <value>Data Absent Reason for the Birth Record Identifier. A Dictionary representing a code, containing the following key/value pairs:
@@ -4473,7 +4519,7 @@ namespace VRDR
             }
             set
             {
-               if (BirthRecordIdentifier == null)
+                if (BirthRecordIdentifier == null)
                 {
                     CreateBirthRecordIdentifier();
 
@@ -4481,9 +4527,10 @@ namespace VRDR
                 // If an empty dict is provided then this will reset the `BirthRecordIdentifier.Value`
                 // Since `EmptyCodeableDict()` is returned via the getter, implementers trying to
                 // copy one death record to another would get their BirthRecordId cleared when copying this field.
-                if(!IsDictEmptyOrDefault(value)) {
+                if (!IsDictEmptyOrDefault(value))
+                {
                     BirthRecordIdentifier.DataAbsentReason = DictToCodeableConcept(value);
-                    BirthRecordIdentifier.Value = (FhirString) null; // If reason is set the data must be null;
+                    BirthRecordIdentifier.Value = (FhirString)null; // If reason is set the data must be null;
                 }
             }
         }
@@ -4500,7 +4547,7 @@ namespace VRDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='30525-0').dataAbsentReason", "")]
         public bool BirthRecordIdentifierDataAbsentBoolean
         {
-           get
+            get
             {
                 return (BirthRecordIdentifier == null || BirthRecordIdentifier.DataAbsentReason != null);
             }
@@ -4508,7 +4555,8 @@ namespace VRDR
             {
                 if (value == false)
                 {
-                    if (BirthRecordIdentifier != null) {  // if it has been created, reset the DataAbsentReason, otherwise, nothing to do.
+                    if (BirthRecordIdentifier != null)
+                    {  // if it has been created, reset the DataAbsentReason, otherwise, nothing to do.
                         BirthRecordIdentifier.DataAbsentReason = (CodeableConcept)null;
                     }
                 }
@@ -4520,7 +4568,8 @@ namespace VRDR
 
                     }
                     // If there already is a data absent reason do not overwrite it with the default
-                    if(BirthRecordIdentifier.DataAbsentReason == null) {
+                    if (BirthRecordIdentifier.DataAbsentReason == null)
+                    {
                         BirthRecordIdentifierDataAbsentReason = new Dictionary<string, string>() {
                             { "system", CodeSystems.Data_Absent_Reason_HL7_V3 },
                             { "code", "unknown" },
@@ -4528,7 +4577,7 @@ namespace VRDR
                             { "text", null }
                         };
                     }
-                    BirthRecordIdentifier.Value = (FhirString) null; // If reason is set the data must be null;
+                    BirthRecordIdentifier.Value = (FhirString)null; // If reason is set the data must be null;
                 }
             }
         }
@@ -4561,18 +4610,18 @@ namespace VRDR
                 if (BirthRecordIdentifier != null && BirthRecordIdentifier.Component.Count > 0)
                 {
                     // Find correct component
-                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "21842-0" );
+                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "21842-0");
                     if (stateComp != null && stateComp.Value != null)
                     {
-                        return(Convert.ToString(stateComp.Value));
+                        return (Convert.ToString(stateComp.Value));
                     }
                 }
                 return "";
             }
             set
             {
-            //    CodeableConcept state = DictToCodeableConcept(value);
-               if (BirthRecordIdentifier == null)
+                //    CodeableConcept state = DictToCodeableConcept(value);
+                if (BirthRecordIdentifier == null)
                 {
                     CreateBirthRecordIdentifier();
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
@@ -4583,7 +4632,7 @@ namespace VRDR
                 else
                 {
                     // Find correct component; if doesn't exist add another
-                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "21842-0" );
+                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "21842-0");
                     if (stateComp != null)
                     {
                         ((Observation.ComponentComponent)stateComp).Value = new FhirString(value);
@@ -4616,7 +4665,7 @@ namespace VRDR
                 if (BirthRecordIdentifier != null && BirthRecordIdentifier.Component.Count > 0)
                 {
                     // Find correct component
-                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80904-6" );
+                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80904-6");
                     if (stateComp != null)
                     {
                         return Convert.ToString(stateComp.Value);
@@ -4637,7 +4686,7 @@ namespace VRDR
                 else
                 {
                     // Find correct component; if doesn't exist add another
-                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80904-6" );
+                    var stateComp = BirthRecordIdentifier.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80904-6");
                     if (stateComp != null)
                     {
                         ((Observation.ComponentComponent)stateComp).Value = new FhirDateTime(value);
@@ -4822,7 +4871,7 @@ namespace VRDR
             {
                 if (UsualWork != null)
                 {
-                    Observation.ComponentComponent component = UsualWork.Component.FirstOrDefault( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6" );
+                    Observation.ComponentComponent component = UsualWork.Component.FirstOrDefault(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6");
                     if (component != null && component.Value != null && component.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)component.Value);
@@ -4837,7 +4886,7 @@ namespace VRDR
                     CreateUsualWork();
                 }
 
-                UsualWork.Component.RemoveAll( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6" );
+                UsualWork.Component.RemoveAll(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6");
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
 
@@ -4943,13 +4992,13 @@ namespace VRDR
         /// </example>
         [Property("Military Service Helper", Property.Types.String, "Decedent Demographics", "Decedent's Military Service.", true, IGURL.DecedentMilitaryService, false, 23)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='55280-2')", "")]
-         public string MilitaryServiceHelper
+        public string MilitaryServiceHelper
         {
             get
             {
                 if (MilitaryService.ContainsKey("code"))
                 {
-                    return(MilitaryService["code"]);
+                    return (MilitaryService["code"]);
                 }
                 return null;
             }
@@ -5422,7 +5471,7 @@ namespace VRDR
                     DispositionMethod.Status = ObservationStatus.Final;
                     DispositionMethod.Code = new CodeableConcept(CodeSystems.LOINC, "80905-3", "Body disposition method", null);
                     DispositionMethod.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-//                    DispositionMethod.Performer.Add(new ResourceReference("urn:uuid:" + Mortician.Id));
+                    //                    DispositionMethod.Performer.Add(new ResourceReference("urn:uuid:" + Mortician.Id));
                     DispositionMethod.Value = DictToCodeableConcept(value);
                     // LinkObservationToLocation(DispositionMethod, DispositionLocation);
                     AddReferenceToComposition(DispositionMethod.Id, "DecedentDisposition");
@@ -5814,7 +5863,7 @@ namespace VRDR
             }
             if (dateTimeOffset != null)
             {
-                switch(partURL)
+                switch (partURL)
                 {
                     case ExtensionURL.DateYear:
                         return (uint?)((DateTimeOffset)dateTimeOffset).Year;
@@ -6035,12 +6084,12 @@ namespace VRDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80616-6')", "")]
         public string DateOfDeathPronouncement
         {
-         get
+            get
             {
                 if (DeathDateObs != null && DeathDateObs.Component.Count > 0) // if there is a value for death location type, return it
                 {
-                    var pronComp = DeathDateObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80616-6" );
+                    var pronComp = DeathDateObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80616-6");
                     if (pronComp != null && pronComp.Value != null)
                     {
                         return Convert.ToString(pronComp.Value);
@@ -6057,8 +6106,8 @@ namespace VRDR
                 }
 
                 // Find correct component; if doesn't exist add another
-                var pronComp = DeathDateObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80616-6" );
+                var pronComp = DeathDateObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80616-6");
                 if (pronComp != null)
                 {
                     ((Observation.ComponentComponent)pronComp).Value = new FhirDateTime(value);
@@ -6070,7 +6119,7 @@ namespace VRDR
                     component.Value = new FhirDateTime(value);
                     DeathDateObs.Component.Add(component);
                 }
-              }
+            }
 
         }
 
@@ -6548,15 +6597,15 @@ namespace VRDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "component")]
         public Dictionary<string, string> DeathLocationType
         {
-         get
+            get
             {
                 if (DeathDateObs != null && DeathDateObs.Component.Count > 0) // if there is a value for death location type, return it
                 {
-                    var placeComp = DeathDateObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "58332-8" );
+                    var placeComp = DeathDateObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "58332-8");
                     if (placeComp != null && placeComp.Value != null && placeComp.Value as CodeableConcept != null)
                     {
-                        return(CodeableConceptToDict((CodeableConcept)placeComp.Value));
+                        return (CodeableConceptToDict((CodeableConcept)placeComp.Value));
                     }
                 }
                 return null;
@@ -6570,8 +6619,8 @@ namespace VRDR
                 }
 
                 // Find correct component; if doesn't exist add another
-                var placeComp = DeathDateObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "58332-8" );
+                var placeComp = DeathDateObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "58332-8");
                 if (placeComp != null)
                 {
                     ((Observation.ComponentComponent)placeComp).Value = DictToCodeableConcept(value);
@@ -6583,7 +6632,7 @@ namespace VRDR
                     component.Value = DictToCodeableConcept(value);
                     DeathDateObs.Component.Add(component);
                 }
-              }
+            }
 
         }
 
@@ -6654,7 +6703,8 @@ namespace VRDR
                 }
                 string extractedValue = GetValue(value, "units");
                 // If the value or unit is null, put out a data absent reason
-                if ( !String.IsNullOrWhiteSpace(extractedValue) ){  // if there is a value for age, set it
+                if (!String.IsNullOrWhiteSpace(extractedValue))
+                {  // if there is a value for age, set it
                     Quantity quantity = (Quantity)AgeAtDeathObs.Value;
                     quantity.Value = Convert.ToDecimal(extractedValue);
                     AgeAtDeathObs.Value = quantity;
@@ -6668,7 +6718,7 @@ namespace VRDR
                     AgeAtDeathObs.Value = quantity;
                     AgeAtDeathDataAbsentBoolean = false; // if age is present, cancel the data absent reason
                 }
-              }
+            }
         }
 
         /// <summary>Decedent's Age At Death Edit Flag.</summary>
@@ -6761,7 +6811,7 @@ namespace VRDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='39016-1').dataAbsentReason", "")]
         public Dictionary<string, string> AgeAtDeathDataAbsentReason
         {
-           get
+            get
             {
                 if (AgeAtDeathObs?.DataAbsentReason != null && AgeAtDeathObs.DataAbsentReason as CodeableConcept != null)
                 {
@@ -6778,10 +6828,12 @@ namespace VRDR
                 // If an empty dict is provided then this will reset the `AgeAtDeathObs.Value`
                 // Since `EmptyCodeableDict()` is returned via the getter, implementers trying to
                 // copy one death record to another would get their AgeAtDeath cleared when copying this field.
-                if(!IsDictEmptyOrDefault(value)) {
+                if (!IsDictEmptyOrDefault(value))
+                {
                     AgeAtDeathObs.DataAbsentReason = DictToCodeableConcept(value);
                     AgeAtDeathObs.Value = (Quantity)null;  // this is either or with the data absent reason
-                } else
+                }
+                else
                 {
                     AgeAtDeathObs.DataAbsentReason = DictToCodeableConcept(EmptyCodeableDict());
                 }
@@ -6800,7 +6852,7 @@ namespace VRDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='39016-1').dataAbsentReason", "")]
         public bool AgeAtDeathDataAbsentBoolean
         {
-           get
+            get
             {
                 return (AgeAtDeathObs == null || AgeAtDeathObs.DataAbsentReason != null);
             }
@@ -6808,7 +6860,8 @@ namespace VRDR
             {
                 if (value == false)
                 {
-                    if (AgeAtDeathObs != null) {  // if it has been created, reset the DataAbsentReason, otherwise, nothing to do.
+                    if (AgeAtDeathObs != null)
+                    {  // if it has been created, reset the DataAbsentReason, otherwise, nothing to do.
                         AgeAtDeathObs.DataAbsentReason = (CodeableConcept)null;
                     }
                 }
@@ -6819,7 +6872,8 @@ namespace VRDR
                         CreateAgeAtDeathObs();
                     }
                     // If there already is a data absent reason do not overwrite it with the default
-                    if(AgeAtDeathObs.DataAbsentReason == null) {
+                    if (AgeAtDeathObs.DataAbsentReason == null)
+                    {
                         AgeAtDeathDataAbsentReason = new Dictionary<string, string>() {
                             { "system", CodeSystems.Data_Absent_Reason_HL7_V3 },
                             { "code", "unknown" },
@@ -6943,13 +6997,15 @@ namespace VRDR
                 {
                     CreatePregnancyObs();
                 }
-                if (PregnancyObs.Value != null && PregnancyObs.Value.Extension != null){
+                if (PregnancyObs.Value != null && PregnancyObs.Value.Extension != null)
+                {
                     PregnancyObs.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
                 }
                 Extension editFlag = new Extension();
                 editFlag.Url = ExtensionURL.BypassEditFlag;
                 editFlag.Value = DictToCodeableConcept(value);
-                if(PregnancyObs.Value == null){
+                if (PregnancyObs.Value == null)
+                {
                     PregnancyObs.Value = new CodeableConcept();
                 }
                 PregnancyObs.Value.Extension.Add(editFlag);
@@ -7483,13 +7539,14 @@ namespace VRDR
                 if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
                 {
                     // Find correct component
-                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
+                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                         && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5");
                     if (placeComp != null && placeComp.Value != null && placeComp.Value as CodeableConcept != null)
                     {
                         Dictionary<string, string> dict = CodeableConceptToDict((CodeableConcept)placeComp.Value);
-                        if ( dict.ContainsKey("text")){
-                                    return (dict["text"]);
+                        if (dict.ContainsKey("text"))
+                        {
+                            return (dict["text"]);
                         }
                     }
                 }
@@ -7497,12 +7554,13 @@ namespace VRDR
             }
             set
             {
-                if (InjuryIncidentObs == null){
+                if (InjuryIncidentObs == null)
+                {
                     CreateInjuryIncidentObs();
                 }
                 // Find correct component; if doesn't exist add another
-                var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5" );
+                var placeComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69450-5");
                 if (placeComp != null)
                 {
                     ((Observation.ComponentComponent)placeComp).Value = new CodeableConcept(null, null, null, value);
@@ -7545,8 +7603,8 @@ namespace VRDR
                 if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
                 {
                     // Find correct component
-                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null
-                    && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69444-8" );
+                    var placeComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                    && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69444-8");
                     if (placeComp != null && placeComp.Value != null && placeComp.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)placeComp.Value);
@@ -7562,7 +7620,7 @@ namespace VRDR
                 }
 
                 // Find correct component; if doesn't exist add another
-                var placeComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69444-8" );
+                var placeComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69444-8");
                 if (placeComp != null)
                 {
                     ((Observation.ComponentComponent)placeComp).Value = DictToCodeableConcept(value);
@@ -7632,8 +7690,8 @@ namespace VRDR
                 if (InjuryIncidentObs != null && InjuryIncidentObs.Component.Count > 0)
                 {
                     // Find correct component
-                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                    ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3" );
+                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                    ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3");
                     if (transportComp != null && transportComp.Value != null && transportComp.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)transportComp.Value);
@@ -7648,8 +7706,8 @@ namespace VRDR
                     CreateInjuryIncidentObs();
                 }
                 // Find correct component; if doesn't exist add another
-                var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3" );
+                var transportComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3");
                 if (transportComp != null)
                 {
                     ((Observation.ComponentComponent)transportComp).Value = DictToCodeableConcept(value);
@@ -7660,7 +7718,7 @@ namespace VRDR
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69451-3", "Transportation role of decedent", null);
                     component.Value = DictToCodeableConcept(value);
                     InjuryIncidentObs.Component.Add(component);
-                    }
+                }
             }
         }
         /// <summary>Transportation Role in death helper.</summary>
@@ -7682,12 +7740,14 @@ namespace VRDR
             {
                 if (TransportationRole.ContainsKey("code"))
                 {
-                    string code = TransportationRole["code"] ;
-                    if (code == "OTH"){
-                        if (TransportationRole.ContainsKey("text")){
+                    string code = TransportationRole["code"];
+                    if (code == "OTH")
+                    {
+                        if (TransportationRole.ContainsKey("text"))
+                        {
                             return (TransportationRole["text"]);
                         }
-                        return("Other");
+                        return ("Other");
                     }
                 }
                 return null;
@@ -7697,8 +7757,8 @@ namespace VRDR
                 if ((value != null) && !VRDR.Mappings.TransportationIncidentRole.FHIRToIJE.ContainsKey(value))
                 { //other
                     //Find the component, or create it
-                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
-                    ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3" );
+                    var transportComp = InjuryIncidentObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
+                    ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69451-3");
                     if (transportComp == null)
                     {
                         transportComp = new Observation.ComponentComponent();
@@ -7730,7 +7790,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Tobacco Use: {ExampleDeathRecord.TobaccoUse['display']}");</para>
         /// </example>
-        [Property("Tobacco Use", Property.Types.Dictionary, "Death Investigation", "If Tobacco Use Contributed To Death.", true, IGURL.TobaccoUseContributedToDeath , true, 32)]
+        [Property("Tobacco Use", Property.Types.Dictionary, "Death Investigation", "If Tobacco Use Contributed To Death.", true, IGURL.TobaccoUseContributedToDeath, true, 32)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -7797,40 +7857,41 @@ namespace VRDR
         /// <summary>Set an emerging issue value, creating an empty EmergingIssues Observation as needed.</summary>
         private void SetEmergingIssue(string identifier, string value)
         {
-                if (EmergingIssues == null)
-                {
-                    EmergingIssues = new Observation();
-                    EmergingIssues.Id = Guid.NewGuid().ToString();
-                    EmergingIssues.Meta = new Meta();
-                    string[] tb_profile = { ProfileURL.EmergingIssues };
-                    EmergingIssues.Meta.Profile = tb_profile;
-                    EmergingIssues.Status = ObservationStatus.Final;
-                    EmergingIssues.Code = new CodeableConcept(CodeSystems.ObservationCode, "emergingissues", "Emerging Issues", null);
-                    EmergingIssues.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    AddReferenceToComposition(EmergingIssues.Id, "DecedentDemographics");
-                    Bundle.AddResourceEntry(EmergingIssues, "urn:uuid:" + EmergingIssues.Id);
-                }
-                // Remove existing component (if it exists) and add an appropriate component.
-                EmergingIssues.Component.RemoveAll( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == identifier );
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = new CodeableConcept(CodeSystems.ComponentCode, identifier, null, null);
-                component.Value = new FhirString(value);
-                EmergingIssues.Component.Add(component);
+            if (EmergingIssues == null)
+            {
+                EmergingIssues = new Observation();
+                EmergingIssues.Id = Guid.NewGuid().ToString();
+                EmergingIssues.Meta = new Meta();
+                string[] tb_profile = { ProfileURL.EmergingIssues };
+                EmergingIssues.Meta.Profile = tb_profile;
+                EmergingIssues.Status = ObservationStatus.Final;
+                EmergingIssues.Code = new CodeableConcept(CodeSystems.ObservationCode, "emergingissues", "Emerging Issues", null);
+                EmergingIssues.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                AddReferenceToComposition(EmergingIssues.Id, "DecedentDemographics");
+                Bundle.AddResourceEntry(EmergingIssues, "urn:uuid:" + EmergingIssues.Id);
+            }
+            // Remove existing component (if it exists) and add an appropriate component.
+            EmergingIssues.Component.RemoveAll(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == identifier);
+            Observation.ComponentComponent component = new Observation.ComponentComponent();
+            component.Code = new CodeableConcept(CodeSystems.ComponentCode, identifier, null, null);
+            component.Value = new FhirString(value);
+            EmergingIssues.Component.Add(component);
         }
 
         /// <summary>Get an emerging issue value.</summary>
         private string GetEmergingIssue(string identifier)
         {
-                if (EmergingIssues == null)
-                {
-                    return null;
-                }
-                // Remove existing component (if it exists) and add an appropriate component.
-                Observation.ComponentComponent issue = EmergingIssues.Component.FirstOrDefault(c => c.Code.Coding[0].Code == identifier);
-                if (issue != null){
-                    return issue.Value.ToString() ;
-                }
+            if (EmergingIssues == null)
+            {
                 return null;
+            }
+            // Remove existing component (if it exists) and add an appropriate component.
+            Observation.ComponentComponent issue = EmergingIssues.Component.FirstOrDefault(c => c.Code.Coding[0].Code == identifier);
+            if (issue != null)
+            {
+                return issue.Value.ToString();
+            }
+            return null;
         }
 
 
@@ -8124,7 +8185,7 @@ namespace VRDR
             }
         }
 
-       /// <summary>Decedent's Automated Underlying Cause of Death</summary>
+        /// <summary>Decedent's Automated Underlying Cause of Death</summary>
         /// <value>Decedent's Automated Underlying Cause of Death.</value>
         /// <example>
         /// <para>// Setter:</para>
@@ -8156,7 +8217,7 @@ namespace VRDR
             }
         }
 
-       /// <summary>Decedent's Manual Underlying Cause of Death</summary>
+        /// <summary>Decedent's Manual Underlying Cause of Death</summary>
         /// <value>Decedent's Manual Underlying Cause of Death.</value>
         /// <example>
         /// <para>// Setter:</para>
@@ -9719,7 +9780,7 @@ namespace VRDR
                 List<Tuple<string, string, string, string>> eac = new List<Tuple<string, string, string, string>>();
                 if (EntityAxisCauseOfDeathObsList != null)
                 {
-                    foreach(Observation ob in EntityAxisCauseOfDeathObsList)
+                    foreach (Observation ob in EntityAxisCauseOfDeathObsList)
                     {
                         string icd10code = "";
                         string lineNumber = "";
@@ -9730,17 +9791,17 @@ namespace VRDR
                         {
                             icd10code = valueCC.Coding[0].Code;
                         }
-                        Observation.ComponentComponent positionComp = ob.Component.Where(c => c.Code.Coding[0].Code=="position").FirstOrDefault();
+                        Observation.ComponentComponent positionComp = ob.Component.Where(c => c.Code.Coding[0].Code == "position").FirstOrDefault();
                         if (positionComp != null && positionComp.Value != null)
                         {
                             position = positionComp.Value.ToString();
                         }
-                        Observation.ComponentComponent lineNumComp = ob.Component.Where(c => c.Code.Coding[0].Code=="lineNumber").FirstOrDefault();
+                        Observation.ComponentComponent lineNumComp = ob.Component.Where(c => c.Code.Coding[0].Code == "lineNumber").FirstOrDefault();
                         if (lineNumComp != null && lineNumComp.Value != null)
                         {
                             lineNumber = lineNumComp.Value.ToString();
                         }
-                        Observation.ComponentComponent ecodeComp = ob.Component.Where(c => c.Code.Coding[0].Code=="eCodeIndicator").FirstOrDefault();
+                        Observation.ComponentComponent ecodeComp = ob.Component.Where(c => c.Code.Coding[0].Code == "eCodeIndicator").FirstOrDefault();
                         if (ecodeComp != null && ecodeComp.Value != null)
                         {
                             ecode = ecodeComp.Value.ToString() == "true" ? "&" : " ";
@@ -9754,7 +9815,7 @@ namespace VRDR
             set
             {
                 // clear all existing eac
-                Bundle.Entry.RemoveAll( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "80356-9"));
+                Bundle.Entry.RemoveAll(entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "80356-9"));
                 if (EntityAxisCauseOfDeathObsList != null)
                 {
                     EntityAxisCauseOfDeathObsList.Clear();
@@ -9764,7 +9825,7 @@ namespace VRDR
                     EntityAxisCauseOfDeathObsList = new List<Observation>();
                 }
                 // Rebuild the list of observations
-                foreach(Tuple<string, string, string, string> eac in value)
+                foreach (Tuple<string, string, string, string> eac in value)
                 {
                     string lineNumber = eac.Item1;
                     string position = eac.Item2;
@@ -9828,7 +9889,7 @@ namespace VRDR
                 List<Tuple<string, string, string>> rac = new List<Tuple<string, string, string>>();
                 if (RecordAxisCauseOfDeathObsList != null)
                 {
-                    foreach(Observation ob in RecordAxisCauseOfDeathObsList)
+                    foreach (Observation ob in RecordAxisCauseOfDeathObsList)
                     {
                         string icd10code = "";
                         string position = "";
@@ -9838,12 +9899,12 @@ namespace VRDR
                         {
                             icd10code = valueCC.Coding[0].Code;
                         }
-                        Observation.ComponentComponent positionComp = ob.Component.Where(c => c.Code.Coding[0].Code=="position").FirstOrDefault();
+                        Observation.ComponentComponent positionComp = ob.Component.Where(c => c.Code.Coding[0].Code == "position").FirstOrDefault();
                         if (positionComp != null && positionComp.Value != null)
                         {
                             position = positionComp.Value.ToString();
                         }
-                        Observation.ComponentComponent pregComp = ob.Component.Where(c => c.Code.Coding[0].Code=="wouldBeUnderlyingCauseOfDeathWithoutPregnancy").FirstOrDefault();
+                        Observation.ComponentComponent pregComp = ob.Component.Where(c => c.Code.Coding[0].Code == "wouldBeUnderlyingCauseOfDeathWithoutPregnancy").FirstOrDefault();
                         if (pregComp != null && pregComp.Value != null)
                         {
                             string preg = pregComp.Value.ToString();
@@ -9860,7 +9921,7 @@ namespace VRDR
             set
             {
                 // clear all existing eac
-                Bundle.Entry.RemoveAll( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "80357-7"));
+                Bundle.Entry.RemoveAll(entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "80357-7"));
                 if (RecordAxisCauseOfDeathObsList != null)
                 {
                     RecordAxisCauseOfDeathObsList.Clear();
@@ -9870,7 +9931,7 @@ namespace VRDR
                     RecordAxisCauseOfDeathObsList = new List<Observation>();
                 }
                 // Rebuild the list of observations
-                foreach(Tuple<string, string, string> rac in value)
+                foreach (Tuple<string, string, string> rac in value)
                 {
                     string position = rac.Item1;
                     string icd10code = rac.Item2;
@@ -10069,7 +10130,7 @@ namespace VRDR
         /// </summary>
         [Property("IntentionalReject", Property.Types.Dictionary, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
         [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
-        public  Dictionary<string, string> IntentionalReject
+        public Dictionary<string, string> IntentionalReject
         {
             get
             {
@@ -10289,7 +10350,7 @@ namespace VRDR
         private void RestoreReferences(bool fullRecord = true)
         {
             // Grab Composition
-            var compositionEntry = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Composition );
+            var compositionEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource.ResourceType == ResourceType.Composition);
             if (compositionEntry != null)
             {
                 Composition = (Composition)compositionEntry.Resource;
@@ -10304,7 +10365,7 @@ namespace VRDR
             {
                 throw new System.ArgumentException("The Composition is missing a subject (a reference to the Decedent resource).");
             }
-            var patientEntry = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Patient );
+            var patientEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource.ResourceType == ResourceType.Patient);
             if (patientEntry != null)
             {
                 Decedent = (Patient)patientEntry.Resource;
@@ -10319,7 +10380,7 @@ namespace VRDR
             {
                 throw new System.ArgumentException("The Composition is missing an attestor (a reference to the Certifier/Practitioner resource).");
             }
-            var practitionerEntry = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Practitioner && (entry.FullUrl == Composition.Attester.First().Party.Reference ||
+            var practitionerEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource.ResourceType == ResourceType.Practitioner && (entry.FullUrl == Composition.Attester.First().Party.Reference ||
             (entry.Resource.Id != null && entry.Resource.Id == Composition.Attester.First().Party.Reference)));
             if (practitionerEntry != null)
             {
@@ -10341,7 +10402,7 @@ namespace VRDR
             // }
 
             // Grab Death Certification
-            var procedureEntry = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Procedure );
+            var procedureEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource.ResourceType == ResourceType.Procedure);
             if (procedureEntry != null)
             {
                 DeathCertification = (Procedure)procedureEntry.Resource;
@@ -10355,8 +10416,8 @@ namespace VRDR
             // }
 
             // Grab Funeral Home  - Organization with type="funeral"
-            var funeralHome = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Organization &&
-                    ((Organization)entry.Resource).Type.FirstOrDefault() != null  && (CodeableConceptToDict(((Organization)entry.Resource).Type.First())["code"] == "funeralhome"));
+            var funeralHome = Bundle.Entry.FirstOrDefault(entry => entry.Resource.ResourceType == ResourceType.Organization &&
+                    ((Organization)entry.Resource).Type.FirstOrDefault() != null && (CodeableConceptToDict(((Organization)entry.Resource).Type.First())["code"] == "funeralhome"));
             if (funeralHome != null)
             {
                 FuneralHome = (Organization)funeralHome.Resource;
@@ -10382,138 +10443,139 @@ namespace VRDR
 
 
             // Grab Coding Status
-            var parameterEntry = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Parameters );
+            var parameterEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource.ResourceType == ResourceType.Parameters);
             if (parameterEntry != null)
             {
                 CodingStatusValues = (Parameters)parameterEntry.Resource;
             }
             // Scan through all Observations to make sure they all have codes!
-            foreach (var ob in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Observation ))
+            foreach (var ob in Bundle.Entry.Where(entry => entry.Resource.ResourceType == ResourceType.Observation))
             {
                 Observation obs = (Observation)ob.Resource;
                 if (obs.Code == null || obs.Code.Coding == null || obs.Code.Coding.FirstOrDefault() == null || obs.Code.Coding.First().Code == null)
                 {
                     throw new System.ArgumentException("Found an Observation resource that did not contain a code. All Observations must include a code to specify what the Observation is referring to.");
                 }
-                switch(obs.Code.Coding.First().Code)
+                switch (obs.Code.Coding.First().Code)
                 {
-                case "69449-7":
-                    MannerOfDeath = (Observation)obs;
-                    break;
-                case "80905-3":
-                    DispositionMethod = (Observation)obs;
-                    // Link the Mortician based on the performer of this observation
-                    break;
-                case "69441-4":
-                    ConditionContributingToDeath = (Observation)obs;
-                    break;
-                case "69453-9":
+                    case "69449-7":
+                        MannerOfDeath = (Observation)obs;
+                        break;
+                    case "80905-3":
+                        DispositionMethod = (Observation)obs;
+                        // Link the Mortician based on the performer of this observation
+                        break;
+                    case "69441-4":
+                        ConditionContributingToDeath = (Observation)obs;
+                        break;
+                    case "69453-9":
                         var lineNumber = 0;
-                        Observation.ComponentComponent lineNumComp = obs.Component.Where(c => c.Code.Coding[0].Code=="lineNumber").FirstOrDefault();
+                        Observation.ComponentComponent lineNumComp = obs.Component.Where(c => c.Code.Coding[0].Code == "lineNumber").FirstOrDefault();
                         if (lineNumComp != null && lineNumComp.Value != null)
                         {
                             lineNumber = Int32.Parse(lineNumComp.Value.ToString());
                         }
-                    switch(lineNumber){
-                        case 1:
-                            CauseOfDeathConditionA = obs;
-                            break;
+                        switch (lineNumber)
+                        {
+                            case 1:
+                                CauseOfDeathConditionA = obs;
+                                break;
 
-                        case 2:
-                            CauseOfDeathConditionB = obs;
-                            break;
+                            case 2:
+                                CauseOfDeathConditionB = obs;
+                                break;
 
-                        case 3:
-                            CauseOfDeathConditionC = obs;
-                            break;
+                            case 3:
+                                CauseOfDeathConditionC = obs;
+                                break;
 
-                        case 4:
-                            CauseOfDeathConditionD = obs;
-                            break;
+                            case 4:
+                                CauseOfDeathConditionD = obs;
+                                break;
 
-                        default: // invalid position, should we go kaboom?
+                            default: // invalid position, should we go kaboom?
+                                break;
+                        }
                         break;
-                    }
-                    break;
-                case "80913-7":
-                    DecedentEducationLevel = (Observation)obs;
-                    break;
-                case "21843-8":
-                    UsualWork = (Observation)obs;
-                    break;
-                case "55280-2":
-                    MilitaryServiceObs = (Observation)obs;
-                    break;
-                case "BR":
-                    BirthRecordIdentifier = (Observation)obs;
-                    break;
-                case "emergingissues":
-                    EmergingIssues = (Observation)obs;
-                    break;
-                case "codedraceandethnicity":
-                    CodedRaceAndEthnicityObs = (Observation)obs;
-                    break;
-                case "inputraceandethnicity":
-                    InputRaceAndEthnicityObs = (Observation)obs;
-                    break;
-                case "11376-1":
-                    PlaceOfInjuryObs = (Observation)obs;
-                    break;
-                case "80358-5":
-                    AutomatedUnderlyingCauseOfDeathObs = (Observation)obs;
-                    break;
-                case "80359-3":
-                    ManualUnderlyingCauseOfDeathObs = (Observation)obs;
-                    break;
-                case "80626-5":
-                    ActivityAtTimeOfDeathObs = (Observation)obs;
-                    break;
-               case "80992-1":
-                    SurgeryDateObs = (Observation)obs;
-                    break;
-                case "81956-5":
-                    DeathDateObs = (Observation)obs;
-                    break;
-                case "11374-6":
-                    InjuryIncidentObs = (Observation)obs;
-                    break;
-                case "69443-0":
-                    TobaccoUseObs = (Observation)obs;
-                    break;
-                case "74497-9":
-                    ExaminerContactedObs = (Observation)obs;
-                    break;
-                case "69442-2":
-                    PregnancyObs = (Observation)obs;
-                    break;
-                case "39016-1":
-                    AgeAtDeathObs = (Observation)obs;
-                    break;
-                case "85699-7":
-                    AutopsyPerformed = (Observation)obs;
-                    break;
-                case "80356-9":
-                    if (EntityAxisCauseOfDeathObsList == null)
-                    {
-                         EntityAxisCauseOfDeathObsList = new List<Observation>();
-                    }
-                    EntityAxisCauseOfDeathObsList.Add((Observation)obs);
-                    break;
-                case "80357-7":
-                    if (RecordAxisCauseOfDeathObsList == null)
-                    {
-                        RecordAxisCauseOfDeathObsList = new List<Observation>();
-                    }
-                    RecordAxisCauseOfDeathObsList.Add((Observation)obs);
-                    break;
-                default:
-                    // skip
-                    break;
+                    case "80913-7":
+                        DecedentEducationLevel = (Observation)obs;
+                        break;
+                    case "21843-8":
+                        UsualWork = (Observation)obs;
+                        break;
+                    case "55280-2":
+                        MilitaryServiceObs = (Observation)obs;
+                        break;
+                    case "BR":
+                        BirthRecordIdentifier = (Observation)obs;
+                        break;
+                    case "emergingissues":
+                        EmergingIssues = (Observation)obs;
+                        break;
+                    case "codedraceandethnicity":
+                        CodedRaceAndEthnicityObs = (Observation)obs;
+                        break;
+                    case "inputraceandethnicity":
+                        InputRaceAndEthnicityObs = (Observation)obs;
+                        break;
+                    case "11376-1":
+                        PlaceOfInjuryObs = (Observation)obs;
+                        break;
+                    case "80358-5":
+                        AutomatedUnderlyingCauseOfDeathObs = (Observation)obs;
+                        break;
+                    case "80359-3":
+                        ManualUnderlyingCauseOfDeathObs = (Observation)obs;
+                        break;
+                    case "80626-5":
+                        ActivityAtTimeOfDeathObs = (Observation)obs;
+                        break;
+                    case "80992-1":
+                        SurgeryDateObs = (Observation)obs;
+                        break;
+                    case "81956-5":
+                        DeathDateObs = (Observation)obs;
+                        break;
+                    case "11374-6":
+                        InjuryIncidentObs = (Observation)obs;
+                        break;
+                    case "69443-0":
+                        TobaccoUseObs = (Observation)obs;
+                        break;
+                    case "74497-9":
+                        ExaminerContactedObs = (Observation)obs;
+                        break;
+                    case "69442-2":
+                        PregnancyObs = (Observation)obs;
+                        break;
+                    case "39016-1":
+                        AgeAtDeathObs = (Observation)obs;
+                        break;
+                    case "85699-7":
+                        AutopsyPerformed = (Observation)obs;
+                        break;
+                    case "80356-9":
+                        if (EntityAxisCauseOfDeathObsList == null)
+                        {
+                            EntityAxisCauseOfDeathObsList = new List<Observation>();
+                        }
+                        EntityAxisCauseOfDeathObsList.Add((Observation)obs);
+                        break;
+                    case "80357-7":
+                        if (RecordAxisCauseOfDeathObsList == null)
+                        {
+                            RecordAxisCauseOfDeathObsList = new List<Observation>();
+                        }
+                        RecordAxisCauseOfDeathObsList.Add((Observation)obs);
+                        break;
+                    default:
+                        // skip
+                        break;
                 }
             }
 
             // Scan through all RelatedPerson to make sure they all have relationship codes!
-            foreach (var rp in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.RelatedPerson ))
+            foreach (var rp in Bundle.Entry.Where(entry => entry.Resource.ResourceType == ResourceType.RelatedPerson))
             {
                 RelatedPerson rpn = (RelatedPerson)rp.Resource;
                 if (rpn.Relationship == null || rpn.Relationship.FirstOrDefault() == null || rpn.Relationship.FirstOrDefault().Coding == null || rpn.Relationship.FirstOrDefault().Coding.FirstOrDefault() == null ||
@@ -10521,7 +10583,8 @@ namespace VRDR
                 {
                     throw new System.ArgumentException("Found a RelatedPerson resource that did not contain a relationship code. All RelatedPersons must include a relationship code to specify how the RelatedPerson is related to the subject.");
                 }
-                switch(rpn.Relationship.FirstOrDefault().Coding.First().Code){
+                switch (rpn.Relationship.FirstOrDefault().Coding.First().Code)
+                {
                     case "FTH":
                         Father = (RelatedPerson)rpn;
                         break;
@@ -10536,15 +10599,17 @@ namespace VRDR
                         break;
                 }
             }
-            foreach (var rp in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.Location )){
+            foreach (var rp in Bundle.Entry.Where(entry => entry.Resource.ResourceType == ResourceType.Location))
+            {
                 Location lcn = (Location)rp.Resource;
-                if ( (lcn.Type.FirstOrDefault() == null)  || lcn.Type.FirstOrDefault().Coding == null || lcn.Type.FirstOrDefault().Coding.First().Code  == null )
+                if ((lcn.Type.FirstOrDefault() == null) || lcn.Type.FirstOrDefault().Coding == null || lcn.Type.FirstOrDefault().Coding.First().Code == null)
                 {
                     // throw new System.ArgumentException("Found a Location resource that did not contain a type code. All Locations must include a type code to specify the role of the location.");
                 }
                 else
                 {
-                    switch(lcn.Type.FirstOrDefault().Coding.First().Code){
+                    switch (lcn.Type.FirstOrDefault().Coding.First().Code)
+                    {
                         case "death":
                             DeathLocationLoc = lcn;
                             break;
@@ -10570,7 +10635,8 @@ namespace VRDR
         private void SetCodeValue(string field, string code, string[,] options)
         {
             // If string is empty don't bother to set the value
-            if (code == null || code == "") {
+            if (code == null || code == "")
+            {
                 return;
             }
             // Iterate over the allowed options and see if the code supplies is one of them
@@ -10898,7 +10964,7 @@ namespace VRDR
                     dictionary["addressLine2"] = addr.Line.Last();
                 }
 
-                if(addr.CityElement != null)
+                if (addr.CityElement != null)
                 {
                     Extension cityCode = addr.CityElement.Extension.Where(ext => ext.Url == ExtensionURL.CityCode).FirstOrDefault();
                     if (cityCode != null)
@@ -10907,10 +10973,11 @@ namespace VRDR
                     }
                 }
 
-                if(addr.DistrictElement != null)
+                if (addr.DistrictElement != null)
                 {
                     Extension districtCode = addr.DistrictElement.Extension.Where(ext => ext.Url == ExtensionURL.DistrictCode).FirstOrDefault();
-                    if (districtCode != null){
+                    if (districtCode != null)
+                    {
                         dictionary["addressCountyC"] = districtCode.Value.ToString();
                     }
                 }
@@ -11159,11 +11226,11 @@ namespace VRDR
         private static Dictionary<string, string> UpdateDictionary(Dictionary<string, string> a, Dictionary<string, string> b)
         {
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
-            foreach(KeyValuePair<string, string> entry in a)
+            foreach (KeyValuePair<string, string> entry in a)
             {
                 dictionary[entry.Key] = entry.Value;
             }
-            foreach(KeyValuePair<string, string> entry in b)
+            foreach (KeyValuePair<string, string> entry in b)
             {
                 dictionary[entry.Key] = entry.Value;
             }
@@ -11178,7 +11245,7 @@ namespace VRDR
         {
             Dictionary<string, Dictionary<string, dynamic>> description = new Dictionary<string, Dictionary<string, dynamic>>();
             // the priority values should order the categories as: Decedent Demographics, Decedent Disposition, Death Investigation, Death Certification
-            foreach(PropertyInfo property in typeof(DeathRecord).GetProperties().OrderBy(p => ((Property)p.GetCustomAttributes().First()).Priority))
+            foreach (PropertyInfo property in typeof(DeathRecord).GetProperties().OrderBy(p => ((Property)p.GetCustomAttributes().First()).Priority))
             {
                 // Grab property annotation for this property
                 Property info = (Property)property.GetCustomAttributes().First();
@@ -11216,7 +11283,7 @@ namespace VRDR
                         // Make sure to grab all of the Conditions for COD
                         string xml = "";
                         string json = "";
-                        foreach(var match in matches)
+                        foreach (var match in matches)
                         {
                             xml += match.ToXml();
                             json += match.ToJson() + ",";
@@ -11239,9 +11306,9 @@ namespace VRDR
                         {
                             category[property.Name]["SnippetXML"] = "";
                         }
-                         Dictionary<string, dynamic> jsonRoot =
-                            JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(matches.First().ToJson(),
-                                new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
+                        Dictionary<string, dynamic> jsonRoot =
+                           JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(matches.First().ToJson(),
+                               new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
                         if (jsonRoot != null && jsonRoot.Keys.Contains(path.Element))
                         {
                             category[property.Name]["SnippetJSON"] = "{" + $"\"{path.Element}\": \"{jsonRoot[path.Element]}\"" + "}";
@@ -11307,10 +11374,10 @@ namespace VRDR
                 JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, dynamic>>>(contents,
                     new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
             // Loop over each category
-            foreach(KeyValuePair<string, Dictionary<string, dynamic>> category in description)
+            foreach (KeyValuePair<string, Dictionary<string, dynamic>> category in description)
             {
                 // Loop over each property
-                foreach(KeyValuePair<string, dynamic> property in category.Value)
+                foreach (KeyValuePair<string, dynamic> property in category.Value)
                 {
                     if (!property.Value.ContainsKey("Value") || property.Value["Value"] == null)
                     {
@@ -11348,7 +11415,7 @@ namespace VRDR
                         Dictionary<string, Dictionary<string, string>> moreInfo =
                             property.Value["Value"].ToObject<Dictionary<string, Dictionary<string, string>>>();
                         Dictionary<string, string> result = new Dictionary<string, string>();
-                        foreach(KeyValuePair<string, Dictionary<string, string>> entry in moreInfo)
+                        foreach (KeyValuePair<string, Dictionary<string, string>> entry in moreInfo)
                         {
                             result[entry.Key] = entry.Value["Value"];
                         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -5954,7 +5954,11 @@ namespace VRDR
         {
             get
             {
-                var performed = DeathDateObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                if (AutopsyPerformed == null || AutopsyPerformed.Component == null)
+                {
+                    return EmptyCodeDict();
+                }
+                var performed = AutopsyPerformed.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
                     && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69436-4");
                 if(performed != null){
                     return CodeableConceptToDict((CodeableConcept)performed.Value);
@@ -9653,13 +9657,17 @@ namespace VRDR
             }
         }
 
-        // TODO: Appropriate FHIRPath attributes on the next several properties (supporting Coding Status)
 
-        /// <summary>
-        /// The year NCHS received the death record.
-        /// </summary>
+        /// <summary>The year NCHS received the death record.</summary>
+        /// <value>year</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.ReceiptYear = 2022 </para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Receipt Year: {ExampleDeathRecord.ReceiptYear}");</para>
+        /// </example>
         [Property("ReceiptYear", Property.Types.UInt32, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public uint? ReceiptYear
         {
             get
@@ -9681,8 +9689,16 @@ namespace VRDR
         /// <summary>
         /// The month NCHS received the death record.
         /// </summary>
+        /// <summary>The month NCHS received the death record.</summary>
+        /// <value>month</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.ReceiptMonth = 11 </para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Receipt Month: {ExampleDeathRecord.ReceiptMonth}");</para>
+        /// </example>
         [Property("ReceiptMonth", Property.Types.UInt32, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public uint? ReceiptMonth
         {
             get
@@ -9701,11 +9717,16 @@ namespace VRDR
             }
         }
 
-        /// <summary>
-        /// The day NCHS received the death record.
-        /// </summary>
+        /// <summary>The day NCHS received the death record.</summary>
+        /// <value>month</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.ReceiptDay = 13 </para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Receipt Day: {ExampleDeathRecord.ReceiptDay}");</para>
+        /// </example>
         [Property("ReceiptDay", Property.Types.UInt32, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public uint? ReceiptDay
         {
             get
@@ -9733,7 +9754,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Receipt Date: {ExampleDeathRecord.ReceiptDate}");</para>
         /// </example>
         [Property("Receipt Date", Property.Types.StringDateTime, "Coded Observations", "Receipt Date.", true, IGURL.CodingStatusValues, true, 25)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public string ReceiptDate
         {
             get
@@ -9762,8 +9783,16 @@ namespace VRDR
         /// <summary>
         /// Coder Status; TRX field with no IJE mapping
         /// </summary>
+        /// <summary>Coder Status; TRX field with no IJE mapping</summary>
+        /// <value>integer code</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.CoderStatus = 3;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Coder STatus {ExampleDeathRecord.CoderStatus}");</para>
+        /// </example>
         [Property("CoderStatus", Property.Types.UInt32, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, false)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public int? CoderStatus
         {
             get
@@ -9787,8 +9816,16 @@ namespace VRDR
         /// <summary>
         /// Shipment Number; TRX field with no IJE mapping
         /// </summary>
+        /// <summary>Coder Status; TRX field with no IJE mapping</summary>
+        /// <value>string</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.ShipmentNumber = "abc123"";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Shipment Number{ExampleDeathRecord.ShipmentNumber}");</para>
+        /// </example>
         [Property("ShipmentNumber", Property.Types.String, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, false)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public string ShipmentNumber
         {
             get
@@ -9811,8 +9848,16 @@ namespace VRDR
         /// <summary>
         /// Intentional Reject
         /// </summary>
+        /// <summary>Intentional Reject</summary>
+        /// <value>string</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.IntentionalReject = "Reject1";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Intentional Reject {ExampleDeathRecord.IntentionalReject}");</para>
+        /// </example>
         [Property("IntentionalReject", Property.Types.Dictionary, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public Dictionary<string, string> IntentionalReject
         {
             get
@@ -9850,7 +9895,7 @@ namespace VRDR
         /// </example>
         [Property("IntentionalRejectHelper", Property.Types.String, "Intentional Reject Codes", "IntentionalRejectCodes.", true, IGURL.CodingStatusValues, true, 4)]
         [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public string IntentionalRejectHelper
         {
             get
@@ -9867,11 +9912,19 @@ namespace VRDR
             }
         }
 
-        /// <summary>
-        /// Acme System Reject Codes
-        /// </summary>
+        /// <summary>Acme System Reject.</summary>
+        /// <value>
+        /// <para>"code" - the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.AcmeSystemReject = 3;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Acme System Reject Code: {ExampleDeathRecord.AcmeSystemReject}");</para>
+        /// </example>
+
         [Property("AcmeSystemReject", Property.Types.Dictionary, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public Dictionary<string, string> AcmeSystemReject
         {
             get
@@ -9897,19 +9950,19 @@ namespace VRDR
             }
         }
 
-        /// <summary>ACME System Reject Codes Helper.</summary>
-        /// <value>Acme System REject codes
+        /// <summary>Acme System Reject.</summary>
+        /// <value>
         /// <para>"code" - the code</para>
         /// </value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.AcmeSystemRejectCodeHelper = ValueSets.SystemRejectCodes.Not_Rejected;</para>
+        /// <para>ExampleDeathRecord.AcmeSystemReject = 3;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Acme System Reject Code: {ExampleDeathRecord.AcmeSystemRejectCodeHelper}");</para>
+        /// <para>Console.WriteLine($"Acme System Reject Code: {ExampleDeathRecord.AcmeSystemReject}");</para>
         /// </example>
         [Property("AcmeSystemRejectHelper", Property.Types.String, "Acme System Reject Codes", "AcmeSystemRejectCodes.", true, IGURL.CodingStatusValues, true, 4)]
         [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public string AcmeSystemRejectHelper
         {
             get
@@ -9926,11 +9979,19 @@ namespace VRDR
             }
         }
 
-        /// <summary>
-        /// Transax Conversion Flag
-        /// </summary>
+
+        /// <summary>Transax Conversion Flag</summary>
+        /// <value>
+        /// <para>"code" - the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleDeathRecord.TransaxConversion = 3;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Transax Conversion Code: {ExampleDeathRecord.TransaxConversion}");</para>
+        /// </example>
         [Property("TransaxConversion", Property.Types.Dictionary, "Coded Observations", "Coding Status", true, IGURL.CodingStatusValues, true)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public Dictionary<string, string> TransaxConversion
         {
             get
@@ -9968,7 +10029,7 @@ namespace VRDR
         /// </example>
         [Property("TransaxConversionFlag Helper", Property.Types.String, "Transax Conversion", "TransaxConversion Flag.", true, IGURL.CodingStatusValues, true, 4)]
         [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public string TransaxConversionHelper
         {
             get
@@ -10185,6 +10246,7 @@ namespace VRDR
                                 break;
 
                             default: // invalid position, should we go kaboom?
+                                // throw new System.ArgumentException("Found a Cause of Death Part1 Observation with a linenumber other than 1-4.");
                                 break;
                         }
                         break;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -4938,7 +4938,7 @@ namespace VRDR
         [PropertyParam("addressUnitnum", "address, unitnum")]
         [PropertyParam("addressZip", "address, zip")]
         [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(type.coding.code='bus')", "address")]
+        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(type.coding.code='funeralhome')", "address")]
         public Dictionary<string, string> FuneralHomeAddress
         {
             get
@@ -4974,7 +4974,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Funeral Home Name: {ExampleDeathRecord.FuneralHomeName}");</para>
         /// </example>
         [Property("Funeral Home Name", Property.Types.String, "Decedent Disposition", "Name of Funeral Home.", true, IGURL.FuneralHome, false, 94)]
-        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(type.coding.code='bus')", "name")]
+        [FHIRPath("Bundle.entry.resource.where($this is Organization).where(type.coding.code='funeralhome')", "name")]
         public string FuneralHomeName
         {
             get
@@ -5151,7 +5151,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Disposition Method: {ExampleDeathRecord.DecedentDispositionMethod['display']}");</para>
         /// </example>
-        [Property("Decedent Disposition Method", Property.Types.Dictionary, "Decedent Disposition", "Decedent's Disposition Method.", true, IGURL.DispositionLocation, true, 1)]
+        [Property("Decedent Disposition Method", Property.Types.Dictionary, "Decedent Disposition", "Decedent's Disposition Method.", true, IGURL.DecedentDispositionMethod, true, 1)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -5180,7 +5180,6 @@ namespace VRDR
                     DispositionMethod.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
                     //                    DispositionMethod.Performer.Add(new ResourceReference("urn:uuid:" + Mortician.Id));
                     DispositionMethod.Value = DictToCodeableConcept(value);
-                    // LinkObservationToLocation(DispositionMethod, DispositionLocation);
                     AddReferenceToComposition(DispositionMethod.Id, "DecedentDisposition");
                     Bundle.AddResourceEntry(DispositionMethod, "urn:uuid:" + DispositionMethod.Id);
                 }
@@ -5200,7 +5199,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Decedent Disposition Method: {ExampleDeathRecord.DecedentDispositionMethodHelper}");</para>
         /// </example>
         /// </value>
-        [Property("Decedent Disposition Method", Property.Types.String, "Decedent Disposition", "Decedent's Disposition Method.", true, IGURL.DispositionLocation, true, 1)]
+        [Property("Decedent Disposition Method", Property.Types.String, "Decedent Disposition", "Decedent's Disposition Method.", true, IGURL.DecedentDispositionMethod, true, 1)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80905-3')", "")]
         public string DecedentDispositionMethodHelper
@@ -5218,31 +5217,6 @@ namespace VRDR
                 SetCodeValue("DecedentDispositionMethod", value, VRDR.ValueSets.MethodOfDisposition.Codes);
             }
         }
-
-        // private void LinkObservationToLocation(Observation observation, Location location)
-        // {
-        //     if (observation == null || location == null)
-        //     {
-        //         return;
-        //     }
-
-        //     Extension extension = null;
-        //     foreach (Extension ext in observation.Extension)
-        //     {
-        //         if (ext.Url == "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Observation-Location")
-        //         {
-        //             extension = ext;
-        //             break;
-        //         }
-        //     }
-        //     if (extension == null)
-        //     {
-        //         extension = new Extension();
-        //         extension.Url = "http://hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Observation-Location";
-        //         observation.Extension.Add(extension);
-        //     }
-        //     extension.Value = new ResourceReference("urn:uuid:" + location.Id);
-        // }
 
         /////////////////////////////////////////////////////////////////////////////////
         //
@@ -5980,9 +5954,10 @@ namespace VRDR
         {
             get
             {
-                if (AutopsyPerformed != null && AutopsyPerformed.Component.Count() > 0 && AutopsyPerformed.Component.First().Value as CodeableConcept != null)
-                {
-                    return CodeableConceptToDict((CodeableConcept)AutopsyPerformed.Component.First().Value);
+                var performed = DeathDateObs.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
+                    && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69436-4");
+                if(performed != null){
+                    return CodeableConceptToDict((CodeableConcept)performed.Value);
                 }
                 return EmptyCodeDict();
             }
@@ -6296,7 +6271,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Type: {ExampleDeathRecord.DeathLocationType['display']}");</para>
         /// </example>
-        [Property("Death Location Type", Property.Types.Dictionary, "Death Investigation", "Type of Death Location.", true, IGURL.DeathLocation, false, 19)]
+        [Property("Death Location Type", Property.Types.Dictionary, "Death Investigation", "Type of Death Location.", true, IGURL.DeathDate, false, 19)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
@@ -6351,7 +6326,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Death Location Type: {ExampleDeathRecord.DeathLocationTypeHelper}");</para>
         /// </example>
-        [Property("Death Location Type Helper", Property.Types.String, "Death Investigation", "Type of Death Location.", true, IGURL.DeathLocation, false, 19)]
+        [Property("Death Location Type Helper", Property.Types.String, "Death Investigation", "Type of Death Location.", true, IGURL.DeathDate, false, 19)]
         [PropertyParam("code", "The code used to describe this concept.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "component")]
         public string DeathLocationTypeHelper
@@ -6581,12 +6556,7 @@ namespace VRDR
                     // If there already is a data absent reason do not overwrite it with the default
                     if (AgeAtDeathObs.DataAbsentReason == null)
                     {
-                        AgeAtDeathDataAbsentReason = new Dictionary<string, string>() {
-                            { "system", CodeSystems.Data_Absent_Reason_HL7_V3 },
-                            { "code", "unknown" },
-                            { "display", "Unknown" },
-                            { "text", null }
-                        };
+                        AgeAtDeathDataAbsentReason = CodeableConceptToDict(new CodeableConcept(CodeSystems.Data_Absent_Reason_HL7_V3,"unknown","Unknown",null));
                     }
                     AgeAtDeathObs.Value = (Quantity)null;  // this is either or with the data absent reason
                 }
@@ -6996,39 +6966,39 @@ namespace VRDR
             }
         }
 
-        /// <summary>Description of Injury Location.</summary>
-        /// <value>the injury location description.</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.InjuryLocationDescription = "Bedford Cemetery";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Injury Location Description: {ExampleDeathRecord.InjuryLocationDescription}");</para>
-        /// </example>
-        [Property("Injury Location Description", Property.Types.String, "Death Investigation", "Description of Injury Location.", true, IGURL.InjuryLocation, true, 36)]
-        [FHIRPath("Bundle.entry.resource.where($this is Location).where(type='injury')", "description")]
-        public string InjuryLocationDescription
-        {
-            get
-            {
-                if (InjuryLocationLoc != null)
-                {
-                    return InjuryLocationLoc.Description;
-                }
-                return null;
-            }
-            set
-            {
-                if (InjuryLocationLoc == null)
-                {
-                    CreateInjuryLocationLoc();
-                    // LinkObservationToLocation(InjuryIncidentObs, InjuryLocationLoc);
-                    AddReferenceToComposition(InjuryLocationLoc.Id, "DeathInvestigation");
-                    Bundle.AddResourceEntry(InjuryLocationLoc, "urn:uuid:" + InjuryLocationLoc.Id);
-                }
+        // /// <summary>Description of Injury Location.</summary>
+        // /// <value>the injury location description.</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.InjuryLocationDescription = "Bedford Cemetery";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Injury Location Description: {ExampleDeathRecord.InjuryLocationDescription}");</para>
+        // /// </example>
+        // [Property("Injury Location Description", Property.Types.String, "Death Investigation", "Description of Injury Location.", true, IGURL.InjuryLocation, true, 36)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Location).where(type='injury')", "description")]
+        // public string InjuryLocationDescription
+        // {
+        //     get
+        //     {
+        //         if (InjuryLocationLoc != null)
+        //         {
+        //             return InjuryLocationLoc.Description;
+        //         }
+        //         return null;
+        //     }
+        //     set
+        //     {
+        //         if (InjuryLocationLoc == null)
+        //         {
+        //             CreateInjuryLocationLoc();
+        //             // LinkObservationToLocation(InjuryIncidentObs, InjuryLocationLoc);
+        //             AddReferenceToComposition(InjuryLocationLoc.Id, "DeathInvestigation");
+        //             Bundle.AddResourceEntry(InjuryLocationLoc, "urn:uuid:" + InjuryLocationLoc.Id);
+        //         }
 
-                InjuryLocationLoc.Description = value;
-            }
-        }
+        //         InjuryLocationLoc.Description = value;
+        //     }
+        // }
 
         /// <summary>Decedent's Year of Injury.</summary>
         /// <value>the decedent's year of injury</value>
@@ -7631,7 +7601,7 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue1_2}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 1 Number 2", Property.Types.String, "Decedent Demographics", "1-Byte Field 2", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE1_2')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
         public string EmergingIssue1_2
         {
             get
@@ -7653,7 +7623,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue1_3}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 1 Number 3", Property.Types.String, "Decedent Demographics", "1-Byte Field 3", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE1_3')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue1_3
         {
             get
@@ -7675,7 +7646,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue1_4}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 1 Number 4", Property.Types.String, "Decedent Demographics", "1-Byte Field 4", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE1_4')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue1_4
         {
             get
@@ -7697,7 +7669,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue1_5}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 1 Number 5", Property.Types.String, "Decedent Demographics", "1-Byte Field 5", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE1_5')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue1_5
         {
             get
@@ -7719,7 +7692,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue1_6}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 1 Number 6", Property.Types.String, "Decedent Demographics", "1-Byte Field 6", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE1_6')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue1_6
         {
             get
@@ -7741,7 +7715,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue8_1}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 8 Number 1", Property.Types.String, "Decedent Demographics", "8-Byte Field 1", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE8_1')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue8_1
         {
             get
@@ -7763,7 +7738,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue8_2}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 8 Number 2", Property.Types.String, "Decedent Demographics", "8-Byte Field 2", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE8_2')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue8_2
         {
             get
@@ -7785,7 +7761,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue8_3}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 8 Number 3", Property.Types.String, "Decedent Demographics", "8-Byte Field 3", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE8_3')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue8_3
         {
             get
@@ -7809,7 +7786,8 @@ namespace VRDR
         /// <para>Console.WriteLine($"Emerging Issue Value: {ExampleDeathRecord.EmergingIssue20}");</para>
         /// </example>
         [Property("Emerging Issue Field Length 20", Property.Types.String, "Decedent Demographics", "20-Byte Field", true, IGURL.EmergingIssues, false, 50)]
-        [FHIRPath("Bundle.entry.resource.where($this is Parameters).where(parameter.name='PLACE20')", "value")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='emergingissues')", "")]
+
         public string EmergingIssue20
         {
             get

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -95,15 +95,19 @@ namespace VRDR
                     CodCondition.Code = new CodeableConcept(CodeSystems.LOINC, "69453-9", "Cause of death [US Standard Certificate of Death]", null);
                     CodCondition.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
                     CodCondition.Performer.Add (new ResourceReference("urn:uuid:" + Certifier.Id));
+                    Observation.ComponentComponent component = new Observation.ComponentComponent();
+                    component.Code = new CodeableConcept(CodeSystems.ComponentCode, "lineNumber", "line number", null);
+                    component.Value = new Integer (index + 1); // index is 0-3, linenumbers are 1-4
+                    CodCondition.Component.Add(component);
                     AddReferenceToComposition(CodCondition.Id, "DeathCertification");
                     Bundle.AddResourceEntry(CodCondition, "urn:uuid:" + CodCondition.Id);
-                    List.EntryComponent entry = new List.EntryComponent();
-                    entry.Item = new ResourceReference("urn:uuid:" + CodCondition.Id);
-                    if (CauseOfDeathConditionPathway.Entry.Count() != 4)
-                    {
-                        foreach (var i in Enumerable.Range(0, 4)) { CauseOfDeathConditionPathway.Entry.Add(null); }
-                    }
-                    CauseOfDeathConditionPathway.Entry[index] = entry;
+                    // List.EntryComponent entry = new List.EntryComponent();
+                    // entry.Item = new ResourceReference("urn:uuid:" + CodCondition.Id);
+                    // if (CauseOfDeathConditionPathway.Entry.Count() != 4)
+                    // {
+                    //     foreach (var i in Enumerable.Range(0, 4)) { CauseOfDeathConditionPathway.Entry.Add(null); }
+                    // }
+                    // CauseOfDeathConditionPathway.Entry[index] = entry;
                     return (CodCondition);
         }
 
@@ -120,8 +124,8 @@ namespace VRDR
         /// <summary>Cause Of Death Condition Line D (#4).</summary>
         private Observation CauseOfDeathConditionD;
 
-        /// <summary>Cause Of Death Condition Pathway.</summary>
-        private List CauseOfDeathConditionPathway;
+        // /// <summary>Cause Of Death Condition Pathway.</summary>
+        // private List CauseOfDeathConditionPathway;
 
         /// <summary>Decedent's Father.</summary>
         private RelatedPerson Father;
@@ -628,15 +632,15 @@ namespace VRDR
             Bundle.AddResourceEntry(Composition, "urn:uuid:" + Composition.Id);
 
             // Start with an empty Cause of Death Pathway
-            CauseOfDeathConditionPathway = new List();
-            CauseOfDeathConditionPathway.Id = Guid.NewGuid().ToString();
-            CauseOfDeathConditionPathway.Meta = new Meta();
-            string[] causeofdeathconditionpathway_profile = { ProfileURL.CauseOfDeathPathway };
-            CauseOfDeathConditionPathway.Meta.Profile = causeofdeathconditionpathway_profile;
-            CauseOfDeathConditionPathway.Status = List.ListStatus.Current;
-            CauseOfDeathConditionPathway.Mode = Hl7.Fhir.Model.ListMode.Snapshot;
-            CauseOfDeathConditionPathway.Source = new ResourceReference("urn:uuid:" + Certifier.Id);
-            CauseOfDeathConditionPathway.OrderedBy = new CodeableConcept("http://terminology.hl7.org/CodeSystem/list-order", "priority", "Sorted by Priority", null);
+            // CauseOfDeathConditionPathway = new List();
+            // CauseOfDeathConditionPathway.Id = Guid.NewGuid().ToString();
+            // CauseOfDeathConditionPathway.Meta = new Meta();
+            // string[] causeofdeathconditionpathway_profile = { ProfileURL.CauseOfDeathPathway };
+            // CauseOfDeathConditionPathway.Meta.Profile = causeofdeathconditionpathway_profile;
+            // CauseOfDeathConditionPathway.Status = List.ListStatus.Current;
+            // CauseOfDeathConditionPathway.Mode = Hl7.Fhir.Model.ListMode.Snapshot;
+            // CauseOfDeathConditionPathway.Source = new ResourceReference("urn:uuid:" + Certifier.Id);
+            // CauseOfDeathConditionPathway.OrderedBy = new CodeableConcept("http://terminology.hl7.org/CodeSystem/list-order", "priority", "Sorted by Priority", null);
 
             CreateEmptyCodingStatusValues();
 
@@ -647,7 +651,7 @@ namespace VRDR
             // AddReferenceToComposition(Pronouncer.Id, "OBE");
             AddReferenceToComposition(DeathCertification.Id, "DeathCertification");
             AddReferenceToComposition(FuneralHome.Id, "DecedentDisposition");
-            AddReferenceToComposition(CauseOfDeathConditionPathway.Id, "DeathCertification");
+            // AddReferenceToComposition(CauseOfDeathConditionPathway.Id, "DeathCertification");
             AddReferenceToComposition(DispositionLocation.Id, "DispositionLocation");
             AddReferenceToComposition(CodingStatusValues.Id, "CodingStatus");
             Bundle.AddResourceEntry(Decedent, "urn:uuid:" + Decedent.Id);
@@ -659,7 +663,7 @@ namespace VRDR
             Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
             Bundle.AddResourceEntry(FuneralHome, "urn:uuid:" + FuneralHome.Id);
             //Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
-            Bundle.AddResourceEntry(CauseOfDeathConditionPathway, "urn:uuid:" + CauseOfDeathConditionPathway.Id);
+            // Bundle.AddResourceEntry(CauseOfDeathConditionPathway, "urn:uuid:" + CauseOfDeathConditionPathway.Id);
             Bundle.AddResourceEntry(DispositionLocation, "urn:uuid:" + DispositionLocation.Id);
             Bundle.AddResourceEntry(CodingStatusValues, "urn:uuid:" + CodingStatusValues.Id);
 
@@ -840,7 +844,7 @@ namespace VRDR
             AddResourceToBundleIfPresent(CauseOfDeathConditionB, codccBundle);
             AddResourceToBundleIfPresent(CauseOfDeathConditionC, codccBundle);
             AddResourceToBundleIfPresent(CauseOfDeathConditionD, codccBundle);
-            AddResourceToBundleIfPresent(CauseOfDeathConditionPathway, codccBundle);
+            // AddResourceToBundleIfPresent(CauseOfDeathConditionPathway, codccBundle);
             AddResourceToBundleIfPresent(ConditionContributingToDeath, codccBundle);
             AddResourceToBundleIfPresent(MannerOfDeath, codccBundle);
             AddResourceToBundleIfPresent(AutopsyPerformed, codccBundle);
@@ -1786,7 +1790,7 @@ namespace VRDR
         /// <para>    Console.WriteLine($"Cause: {cause.Item1}, Onset: {cause.Item2}");</para>
         /// <para>}</para>
         /// </example>
-        [Property("Causes Of Death", Property.Types.TupleArr, "Death Certification", "Conditions that resulted in the cause of death.", true, IGURL.CauseOfDeathPathway, true, 50)]
+        [Property("Causes Of Death", Property.Types.TupleArr, "Death Certification", "Conditions that resulted in the cause of death.", true, IGURL.CauseOfDeathPart1, true, 50)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(onset.empty().not())", "")]
         public Tuple<string, string>[] CausesOfDeath
         {
@@ -10446,6 +10450,34 @@ namespace VRDR
                 case "69441-4":
                     ConditionContributingToDeath = (Observation)obs;
                     break;
+                case "69453-9":
+                        var lineNumber = 0;
+                        Observation.ComponentComponent lineNumComp = obs.Component.Where(c => c.Code.Coding[0].Code=="lineNumber").FirstOrDefault();
+                        if (lineNumComp != null && lineNumComp.Value != null)
+                        {
+                            lineNumber = Int32.Parse(lineNumComp.Value.ToString());
+                        }
+                    switch(lineNumber){
+                        case 1:
+                            CauseOfDeathConditionA = obs;
+                            break;
+
+                        case 2:
+                            CauseOfDeathConditionB = obs;
+                            break;
+
+                        case 3:
+                            CauseOfDeathConditionC = obs;
+                            break;
+
+                        case 4:
+                            CauseOfDeathConditionD = obs;
+                            break;
+
+                        default: // invalid position, should we go kaboom?
+                        break;
+                    }
+                    break;
                 case "80913-7":
                     DecedentEducationLevel = (Observation)obs;
                     break;
@@ -10523,47 +10555,47 @@ namespace VRDR
                 }
             }
 
-            // Grab Cause Of Death Condition Pathway
-            var causeOfDeathConditionPathway = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.List );
-            if (causeOfDeathConditionPathway != null)
-            {
-                CauseOfDeathConditionPathway = (List)causeOfDeathConditionPathway.Resource;
-            }
+            // // Grab Cause Of Death Condition Pathway
+            // var causeOfDeathConditionPathway = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.List );
+            // if (causeOfDeathConditionPathway != null)
+            // {
+            //     CauseOfDeathConditionPathway = (List)causeOfDeathConditionPathway.Resource;
+            // }
 
             // Grab Causes of Death using CauseOfDeathConditionPathway
-            List<Observation> causeConditions = new List<Observation>();
-            if (CauseOfDeathConditionPathway != null)
-            {
-                foreach (List.EntryComponent condition in CauseOfDeathConditionPathway.Entry)
-                {
-                    if (condition != null && condition.Item != null && condition.Item.Reference != null)
-                    {
-                        var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69453-9") &&
-                        (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
-                        if (codCond != null)
-                        {
-                            causeConditions.Add((Observation)codCond.Resource);
-                        }
-                    }
-                }
-                if (causeConditions.Count() > 0)
-                {
-                    CauseOfDeathConditionA = causeConditions[0];
-                }
-                if (causeConditions.Count() > 1)
-                {
-                    CauseOfDeathConditionB = causeConditions[1];
-                }
-                if (causeConditions.Count() > 2)
-                {
-                    CauseOfDeathConditionC = causeConditions[2];
-                }
-                if (causeConditions.Count() > 3)
-                {
-                    CauseOfDeathConditionD = causeConditions[3];
-                }
+            // List<Observation> causeConditions = new List<Observation>();
+            // if (CauseOfDeathConditionPathway != null)
+            // {
+            //     foreach (List.EntryComponent condition in CauseOfDeathConditionPathway.Entry)
+            //     {
+            //         if (condition != null && condition.Item != null && condition.Item.Reference != null)
+            //         {
+            //             var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69453-9") &&
+            //             (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
+            //             if (codCond != null)
+            //             {
+            //                 causeConditions.Add((Observation)codCond.Resource);
+            //             }
+            //         }
+            //     }
+            //     if (causeConditions.Count() > 0)
+            //     {
+            //         CauseOfDeathConditionA = causeConditions[0];
+            //     }
+            //     if (causeConditions.Count() > 1)
+            //     {
+            //         CauseOfDeathConditionB = causeConditions[1];
+            //     }
+            //     if (causeConditions.Count() > 2)
+            //     {
+            //         CauseOfDeathConditionC = causeConditions[2];
+            //     }
+            //     if (causeConditions.Count() > 3)
+            //     {
+            //         CauseOfDeathConditionD = causeConditions[3];
+            //     }
 
-            }
+            // }
             // Scan through all RelatedPerson to make sure they all have relationship codes!
             foreach (var rp in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.RelatedPerson ))
             {

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -4434,107 +4434,10 @@ namespace VRDR
                 if (!String.IsNullOrWhiteSpace(value))
                 {
                     BirthRecordIdentifier.Value = new FhirString(value);
-                    BirthRecordIdentifierDataAbsentBoolean = false;
                 }
                 else
                 {
                     BirthRecordIdentifier.Value = (FhirString)null;
-                    BirthRecordIdentifierDataAbsentBoolean = true;
-                }
-            }
-        }
-        /// <summary>Birth Record Identifier Data Absent Reason (Code).</summary>
-        /// <value>Data Absent Reason for the Birth Record Identifier. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; brs = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>brs.Add("code", "unknown");</para>
-        /// <para>code.Add("system", CodeSystems.Data_Absent_Reason_HL7_V3);</para>
-        /// <para>brs.Add("display", "unknown");</para>
-        /// <para>ExampleDeathRecord.BirthRecordIdentifierDataAbsentReason = brs;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Birth Record Data Absent Reason: {ExampleDeathRecord.BirthRecordIdentifierDataAbsentReason}");</para>
-        /// </example>
-        [Property("Birth Record Identifier Data Absent Reason (Code)", Property.Types.Dictionary, "Decedent Demographics", "Birth Record Identifier Data Absent Reason.", true, IGURL.BirthRecordIdentifier, false, 17)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='BR').dataAbsentReason", "")]
-        public Dictionary<string, string> BirthRecordIdentifierDataAbsentReason
-        {
-            get
-            {
-                if (BirthRecordIdentifier?.DataAbsentReason != null && BirthRecordIdentifier.DataAbsentReason as CodeableConcept != null)
-                {
-                    return CodeableConceptToDict(BirthRecordIdentifier.DataAbsentReason);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (BirthRecordIdentifier == null)
-                {
-                    CreateBirthRecordIdentifier();
-
-                }
-                // If an empty dict is provided then this will reset the `BirthRecordIdentifier.Value`
-                // Since `EmptyCodeableDict()` is returned via the getter, implementers trying to
-                // copy one death record to another would get their BirthRecordId cleared when copying this field.
-                if (!IsDictEmptyOrDefault(value))
-                {
-                    BirthRecordIdentifier.DataAbsentReason = DictToCodeableConcept(value);
-                    BirthRecordIdentifier.Value = (FhirString)null; // If reason is set the data must be null;
-                }
-            }
-        }
-
-        /// <summary>Birth Record Identifier Data Absent Boolean.</summary>
-        /// <value>True if the data absent reason field is present</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.BirthRecordIdentifierDataAbsentBoolean = true;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"BirthRecordIdentifierDataAbsentBoolean: {ExampleDeathRecord.BirthRecordIdentifierDataAbsentReason}");</para>
-        /// </example>
-        [Property("Birth Record Identifier Data Absent (Boolean)", Property.Types.Bool, "Decedent Demographics", "Birth Record Identifier Data Absent Reason.", true, IGURL.BirthRecordIdentifier, false, 17)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='30525-0').dataAbsentReason", "")]
-        public bool BirthRecordIdentifierDataAbsentBoolean
-        {
-            get
-            {
-                return (BirthRecordIdentifier == null || BirthRecordIdentifier.DataAbsentReason != null);
-            }
-            set
-            {
-                if (value == false)
-                {
-                    if (BirthRecordIdentifier != null)
-                    {  // if it has been created, reset the DataAbsentReason, otherwise, nothing to do.
-                        BirthRecordIdentifier.DataAbsentReason = (CodeableConcept)null;
-                    }
-                }
-                else
-                {
-                    if (BirthRecordIdentifier == null)
-                    {
-                        CreateBirthRecordIdentifier();
-
-                    }
-                    // If there already is a data absent reason do not overwrite it with the default
-                    if (BirthRecordIdentifier.DataAbsentReason == null)
-                    {
-                        BirthRecordIdentifierDataAbsentReason = new Dictionary<string, string>() {
-                            { "system", CodeSystems.Data_Absent_Reason_HL7_V3 },
-                            { "code", "unknown" },
-                            { "display", "unknown" },
-                            { "text", null }
-                        };
-                    }
-                    BirthRecordIdentifier.Value = (FhirString)null; // If reason is set the data must be null;
                 }
             }
         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -1890,9 +1890,9 @@ namespace VRDR
                 {
                     var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    if (intervalComp?.Value != null)
                     {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                        return intervalComp.Value.ToString();
                     }
                 }
                 return "";
@@ -1909,13 +1909,13 @@ namespace VRDR
                     if (intervalComp != null)
                     {
 
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                     }
                     else
                     {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
+                    component.Value = new FhirString(value);
                     CauseOfDeathConditionA.Component.Add(component);
                 }
             }
@@ -2017,9 +2017,9 @@ namespace VRDR
                 {
                     var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    if (intervalComp?.Value != null)
                     {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                        return intervalComp.Value.ToString();
                     }
                 }
                 return "";
@@ -2033,16 +2033,16 @@ namespace VRDR
                 // Find correct component; if doesn't exist add another
                 var intervalComp = CauseOfDeathConditionB.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
+                     if (intervalComp != null)
                     {
 
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                     }
                     else
                     {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
+                    component.Value = new FhirString(value);
                     CauseOfDeathConditionB.Component.Add(component);
                 }
             }
@@ -2145,9 +2145,9 @@ namespace VRDR
                 {
                     var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    if (intervalComp?.Value != null)
                     {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                        return intervalComp.Value.ToString();
                     }
                 }
                 return "";
@@ -2161,18 +2161,18 @@ namespace VRDR
                 // Find correct component; if doesn't exist add another
                 var intervalComp = CauseOfDeathConditionC.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp != null)
-                    {
+                        if (intervalComp != null)
+                        {
 
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
-                    }
-                    else
-                    {
-                    Observation.ComponentComponent component = new Observation.ComponentComponent();
-                    component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
-                    CauseOfDeathConditionC.Component.Add(component);
-                }
+                        ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
+                        }
+                        else
+                        {
+                        Observation.ComponentComponent component = new Observation.ComponentComponent();
+                        component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
+                        component.Value = new FhirString(value);
+                        CauseOfDeathConditionC.Component.Add(component);
+                        }
             }
         }
 
@@ -2271,9 +2271,9 @@ namespace VRDR
                 {
                     var intervalComp = CauseOfDeathConditionD.Component.FirstOrDefault( entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6" );
-                    if (intervalComp?.Value != null && intervalComp.Value as CodeableConcept != null)
+                    if (intervalComp?.Value != null)
                     {
-                        return (CodeableConceptToDict((CodeableConcept)intervalComp.Value))["text"];
+                        return intervalComp.Value.ToString();
                     }
                 }
                 return "";
@@ -2290,13 +2290,13 @@ namespace VRDR
                     if (intervalComp != null)
                     {
 
-                    ((Observation.ComponentComponent)intervalComp).Value = new CodeableConcept(null, null, null, value);
+                    ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                     }
                     else
                     {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new CodeableConcept(null, null, null, value);
+                    component.Value = new FhirString(value);
                     CauseOfDeathConditionD.Component.Add(component);
                 }
             }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -4561,48 +4561,6 @@ namespace VRDR
                 }
             }
         }
-        /// <summary>Decedent's Usual Occupation (Code).</summary>
-        /// <value>the decedent's usual occupation. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; uocc = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>uocc.Add("code", "1340");</para>
-        /// <para>uocc.Add("system", "urn:oid:2.16.840.1.114222.4.11.7186");</para>
-        /// <para>uocc.Add("display", "Biomedical engineers");</para>
-        /// <para>ExampleDeathRecord.UsualOccupationCode = uocc;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Usual Occupation: {ExampleDeathRecord.UsualOccupationCode['display']}");</para>
-        /// </example>
-        [Property("Usual Occupation (Code)", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Usual Occupation.", false, IGURL.DecedentUsualWork, false, 39)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
-        public Dictionary<string, string> UsualOccupationCode
-        {
-            get
-            {
-                if (UsualWork != null && UsualWork.Value != null && UsualWork.Value as CodeableConcept != null)
-                {
-                    return CodeableConceptToDict((CodeableConcept)UsualWork.Value);
-                }
-                return EmptyCodeDict();
-            }
-            set
-            {
-                if (UsualWork == null)
-                {
-                    CreateUsualWork();
-                }
-                UsualWork.Value = DictToCodeableConcept(value);
-
-            }
-        }
 
         /// <summary>Decedent's Usual Occupation.</summary>
         /// <value>the decedent's usual occupation.</value>
@@ -4618,126 +4576,11 @@ namespace VRDR
         {
             get
             {
-                var usualOccupationCode = UsualOccupationCode;
-                if (usualOccupationCode.ContainsKey("text"))
+                if (UsualWork != null && UsualWork.Value != null && UsualWork.Value as CodeableConcept != null)
                 {
-                    return UsualOccupationCode["text"];
+                    return CodeableConceptToDict((CodeableConcept)UsualWork.Value)["text"];
                 }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                var uocc = new Dictionary<string, string>();
-                uocc["text"] = value;
-                UsualOccupationCode = uocc;
-            }
-        }
-
-        /// <summary>Start Date of Usual Occupation.</summary>
-        /// <value>the date usual occupation started</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.UsualOccupationStart = "2018-02-19";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Start of Usual Occupation: {ExampleDeathRecord.UsualOccupationStart}");</para>
-        /// </example>
-        [Property("Usual Occupation Start Date", Property.Types.StringDateTime, "Decedent Demographics", "Decedent's Usual Occupation.", true, IGURL.DecedentUsualWork, true, 41)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
-        public string UsualOccupationStart
-        {
-            get
-            {
-                if (UsualWork?.Effective != null && UsualWork.Effective as Period != null && ((Period)UsualWork.Effective).Start != null)
-                {
-                    return Convert.ToString(((Period)UsualWork.Effective).Start);
-                }
-                return null;
-            }
-            set
-            {
-                if (UsualWork == null)
-                {
-                    CreateUsualWork();
-                    UsualWork.Effective = new Period(new FhirDateTime(value), null);
-                }
-                if (UsualWork.Effective as Period != null)
-                {
-                    ((Period)UsualWork.Effective).Start = value;
-                }
-            }
-        }
-
-        /// <summary>End Date of Usual Occupation.</summary>
-        /// <value>the date usual occupation ended</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.UsualOccupationEnd = "2018-02-19";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"End of Usual Occupation: {ExampleDeathRecord.UsualOccupationEnd}");</para>
-        /// </example>
-        [Property("Usual Occupation End Date", Property.Types.StringDateTime, "Decedent Demographics", "Decedent's Usual Occupation.", true, IGURL.DecedentUsualWork, true, 42)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
-        public string UsualOccupationEnd
-        {
-            get
-            {
-                if (UsualWork?.Effective != null && UsualWork.Effective as Period != null && ((Period)UsualWork.Effective).End != null)
-                {
-                    return Convert.ToString(((Period)UsualWork.Effective).End);
-                }
-                return null;
-            }
-            set
-            {
-                if (UsualWork == null)
-                {
-                    CreateUsualWork();
-                    UsualWork.Effective = new Period(null, new FhirDateTime(value));
-                }
-                if (UsualWork.Effective as Period != null)
-                {
-                    ((Period)UsualWork.Effective).End = value;
-                }
-            }
-        }
-        /// <summary>Decedent's Usual Industry (Code).</summary>
-        /// <value>the decedent's usual industry. A Dictionary representing a code, containing the following key/value pairs:
-        /// <para>"code" - the code</para>
-        /// <para>"system" - the code system this code belongs to</para>
-        /// <para>"display" - a human readable meaning of the code</para>
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>Dictionary&lt;string, string&gt; uind = new Dictionary&lt;string, string&gt;();</para>
-        /// <para>uind.Add("code", "7280");</para>
-        /// <para>uind.Add("system", "urn:oid:2.16.840.1.114222.4.11.7187");</para>
-        /// <para>uind.Add("display", "Accounting, tax preparation, bookkeeping, and payroll services");</para>
-        /// <para>ExampleDeathRecord.UsualIndustryCode = uind;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Usual Industry: {ExampleDeathRecord.UsualIndustryCode['display']}");</para>
-        /// </example>
-        [Property("Usual Industry (Code)", Property.Types.Dictionary, "Decedent Demographics", "Decedent's Usual Industry.", false, IGURL.DecedentUsualWork, false, 43)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [PropertyParam("text", "Additional descriptive text.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='21843-8')", "")]
-        public Dictionary<string, string> UsualIndustryCode
-        {
-            get
-            {
-                if (UsualWork != null)
-                {
-                    Observation.ComponentComponent component = UsualWork.Component.FirstOrDefault(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6");
-                    if (component != null && component.Value != null && component.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)component.Value);
-                    }
-                }
-                return EmptyCodeableDict();
+                return "";
             }
             set
             {
@@ -4745,13 +4588,7 @@ namespace VRDR
                 {
                     CreateUsualWork();
                 }
-
-                UsualWork.Component.RemoveAll(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6");
-                Observation.ComponentComponent component = new Observation.ComponentComponent();
-                component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
-
-                component.Value = DictToCodeableConcept(value);
-                UsualWork.Component.Add(component);
+                UsualWork.Value = new CodeableConcept(null, null, null, value);
 
             }
         }
@@ -4770,22 +4607,32 @@ namespace VRDR
         {
             get
             {
-                var usualIndustryCode = UsualIndustryCode;
-                if (usualIndustryCode.ContainsKey("text"))
+                if (UsualWork != null)
                 {
-                    return UsualIndustryCode["text"];
+                    Observation.ComponentComponent component = UsualWork.Component.FirstOrDefault( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6" );
+                    if (component != null && component.Value != null && component.Value as CodeableConcept != null)
+                    {
+                        return CodeableConceptToDict((CodeableConcept)component.Value)["text"];
+                    }
                 }
-                else
-                {
-                    return null;
-                }
+                return "";
             }
             set
             {
-                var uicc = new Dictionary<string, string>();
-                uicc["text"] = value;
-                UsualIndustryCode = uicc;
+                if (UsualWork == null)
+                {
+                    CreateUsualWork();
+                }
+
+                UsualWork.Component.RemoveAll( cmp => cmp.Code!= null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6" );
+                Observation.ComponentComponent component = new Observation.ComponentComponent();
+                component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
+
+                component.Value = new CodeableConcept(null, null, null, value);
+                UsualWork.Component.Add(component);
+
             }
+
         }
 
         /// <summary>Decedent's Military Service.</summary>

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -284,6 +284,8 @@ namespace VRDR
             FuneralHome.Meta.Profile = funeralhome_profile;
             FuneralHome.Type.Add(new CodeableConcept(CodeSystems.OrganizationType, "funeralhome", "Funeral Home", null));
             FuneralHome.Active = true;
+            AddReferenceToComposition(FuneralHome.Id, "DecedentDisposition");
+            Bundle.AddResourceEntry(FuneralHome, "urn:uuid:" + FuneralHome.Id);
         }
         // /// <summary>The Funeral Home Director.</summary>
         // private PractitionerRole FuneralHomeDirector;

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -373,7 +373,7 @@ namespace VRDR
             }
             return partialDateTime;
         }
-
+        /// <summary>Create Death Date Observation.</summary>
         private void CreateDeathDateObs()
         {
             DeathDateObs = new Observation();
@@ -392,7 +392,7 @@ namespace VRDR
             AddReferenceToComposition(DeathDateObs.Id, "DeathInvestigation");
             Bundle.AddResourceEntry(DeathDateObs, "urn:uuid:" + DeathDateObs.Id);
         }
-
+        /// <summary>Create Surgery Date Observation.</summary>
         private void CreateSurgeryDateObs()
         {
             SurgeryDateObs = new Observation();
@@ -2503,53 +2503,53 @@ namespace VRDR
             }
         }
 
-        /// <summary>Decedent's Gender.</summary>
-        /// <value>the decedent's gender</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.Gender = "female";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Gender: {ExampleDeathRecord.Gender}");</para>
-        /// </example>
-        [Property("Gender", Property.Types.String, "Decedent Demographics", "Decedent's Gender.", true, IGURL.Decedent, true, 11)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "gender")]
-        public string Gender
-        {
-            get
-            {
-                return GetFirstString("Bundle.entry.resource.where($this is Patient).gender");
-            }
-            set
-            {
-                switch (value)
-                {
-                    case "male":
-                    case "Male":
-                    case "m":
-                    case "M":
-                        Decedent.Gender = AdministrativeGender.Male;
-                        break;
-                    case "female":
-                    case "Female":
-                    case "f":
-                    case "F":
-                        Decedent.Gender = AdministrativeGender.Female;
-                        break;
-                    case "other":
-                    case "Other":
-                    case "o":
-                    case "O":
-                        Decedent.Gender = AdministrativeGender.Other;
-                        break;
-                    case "unknown":
-                    case "Unknown":
-                    case "u":
-                    case "U":
-                        Decedent.Gender = AdministrativeGender.Unknown;
-                        break;
-                }
-            }
-        }
+        // /// <summary>Decedent's Gender.</summary>
+        // /// <value>the decedent's gender</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.Gender = "female";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Gender: {ExampleDeathRecord.Gender}");</para>
+        // /// </example>
+        // [Property("Gender", Property.Types.String, "Decedent Demographics", "Decedent's Gender.", true, IGURL.Decedent, true, 11)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Patient)", "gender")]
+        // public string Gender
+        // {
+        //     get
+        //     {
+        //         return GetFirstString("Bundle.entry.resource.where($this is Patient).gender");
+        //     }
+        //     set
+        //     {
+        //         switch (value)
+        //         {
+        //             case "male":
+        //             case "Male":
+        //             case "m":
+        //             case "M":
+        //                 Decedent.Gender = AdministrativeGender.Male;
+        //                 break;
+        //             case "female":
+        //             case "Female":
+        //             case "f":
+        //             case "F":
+        //                 Decedent.Gender = AdministrativeGender.Female;
+        //                 break;
+        //             case "other":
+        //             case "Other":
+        //             case "o":
+        //             case "O":
+        //                 Decedent.Gender = AdministrativeGender.Other;
+        //                 break;
+        //             case "unknown":
+        //             case "Unknown":
+        //             case "u":
+        //             case "U":
+        //                 Decedent.Gender = AdministrativeGender.Unknown;
+        //                 break;
+        //         }
+        //     }
+        // }
 
         /// <summary>Decedent's Sex at Death.</summary>
         /// <value>the decedent's sex at time of death</value>
@@ -2609,37 +2609,40 @@ namespace VRDR
             }
         }
 
-        // Should this be removed for IG v1.3 updates?
-        /// <summary>Decedent's Birth Sex.</summary>
-        /// <value>the decedent's birth sex</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleDeathRecord.BirthSex = "F";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Birth Sex: {ExampleDeathRecord.BirthSex}");</para>
-        /// </example>
-        [Property("Birth Sex", Property.Types.String, "Decedent Demographics", "Decedent's Birth Sex.", true, IGURL.Decedent, true, 12)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "")]
-        public string BirthSex
-        {
-            get
-            {
-                Extension birthsex = Decedent.Extension.Find(ext => ext.Url == OtherExtensionURL.BirthSex);
-                if (birthsex != null && birthsex.Value != null && birthsex.Value.GetType() == typeof(Code))
-                {
-                    return ((Code)birthsex.Value).Value;
-                }
-                return null;
-            }
-            set
-            {
-                Decedent.Extension.RemoveAll(ext => ext.Url == OtherExtensionURL.BirthSex);
-                Extension birthsex = new Extension();
-                birthsex.Url = OtherExtensionURL.BirthSex;
-                birthsex.Value = new Code(value);
-                Decedent.Extension.Add(birthsex);
-            }
-        }
+        // // Should this be removed for IG v1.3 updates?
+        // /// <summary>Decedent's Birth Sex.</summary>
+        // /// <value>the decedent's birth sex</value>
+        // /// <example>
+        // /// <para>// Setter:</para>
+        // /// <para>ExampleDeathRecord.BirthSex = "F";</para>
+        // /// <para>// Getter:</para>
+        // /// <para>Console.WriteLine($"Birth Sex: {ExampleDeathRecord.BirthSex}");</para>
+        // /// </example>
+        // [Property("Birth Sex", Property.Types.String, "Decedent Demographics", "Decedent's Birth Sex.", true, IGURL.Decedent, true, 12)]
+        // [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "")]
+        // public string BirthSex
+        // {
+        //     get
+        //     {
+        //         Extension birthsex = Decedent.Extension.Find(ext => ext.Url == OtherExtensionURL.BirthSex);
+        //         if (birthsex != null && birthsex.Value != null && birthsex.Value.GetType() == typeof(Code))
+        //         {
+        //             return ((Code)birthsex.Value).Value;
+        //         }
+        //         return null;
+        //     }
+        //     set
+        //     {
+        //         Decedent.Extension.RemoveAll(ext => ext.Url == OtherExtensionURL.BirthSex);
+        //         Extension birthsex = new Extension();
+        //         birthsex.Url = OtherExtensionURL.BirthSex;
+        //         birthsex.Value = new Code(value);
+        //         Decedent.Extension.Add(birthsex);
+        //     }
+        // }
+
+
+
 
         private void AddBirthDateToDecedent()
         {
@@ -2911,57 +2914,6 @@ namespace VRDR
             set
             {
                 SetCodeValue("ResidenceWithinCityLimits", value, VRDR.ValueSets.YesNoUnknown.Codes);
-            }
-        }
-
-        // Todo remove in V1.3 IG updates
-        /// <summary>Decedent's residence is/is not within city limits. This is a convenience method, to access the coded value use ResidenceWithinCityLimits.</summary>
-        /// <value>Decedent's residence is/is not within city limits. A null value means "not applicable".</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>SetterDeathRecord.ResidenceWithinCityLimitsBoolean = true;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Residence within city limits: {ExampleDeathRecord.ResidenceWithinCityLimitsBoolean}");</para>
-        /// </example>
-        [Property("Residence Within City Limits Boolean", Property.Types.Bool, "Decedent Demographics", "Decedent's residence is/is not within city limits.", true, IGURL.Decedent, true, 21)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "address")]
-        public bool? ResidenceWithinCityLimitsBoolean
-        {
-            get
-            {
-                var code = this.ResidenceWithinCityLimits;
-                switch (code["code"])
-                {
-                    case "Y": // Yes
-                        return true;
-                    case "N": // No
-                        return false;
-                    default: // Not applicable
-                        return null;
-                }
-            }
-            set
-            {
-                var code = EmptyCodeDict();
-                switch (value)
-                {
-                    case true:
-                        code["code"] = "Y";
-                        code["display"] = "Yes";
-                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
-                        break;
-                    case false:
-                        code["code"] = "N";
-                        code["display"] = "No";
-                        code["system"] = CodeSystems.PH_YesNo_HL7_2x;
-                        break;
-                    default:
-                        code["code"] = "NA";
-                        code["display"] = "not applicable";
-                        code["system"] = CodeSystems.PH_NullFlavor_HL7_V3;
-                        break;
-                }
-                this.ResidenceWithinCityLimits = code;
             }
         }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -116,13 +116,6 @@ namespace VRDR
                     CodCondition.Component.Add(component);
                     AddReferenceToComposition(CodCondition.Id, "DeathCertification");
                     Bundle.AddResourceEntry(CodCondition, "urn:uuid:" + CodCondition.Id);
-                    // List.EntryComponent entry = new List.EntryComponent();
-                    // entry.Item = new ResourceReference("urn:uuid:" + CodCondition.Id);
-                    // if (CauseOfDeathConditionPathway.Entry.Count() != 4)
-                    // {
-                    //     foreach (var i in Enumerable.Range(0, 4)) { CauseOfDeathConditionPathway.Entry.Add(null); }
-                    // }
-                    // CauseOfDeathConditionPathway.Entry[index] = entry;
                     return (CodCondition);
         }
 
@@ -138,9 +131,6 @@ namespace VRDR
 
         /// <summary>Cause Of Death Condition Line D (#4).</summary>
         private Observation CauseOfDeathConditionD;
-
-        // /// <summary>Cause Of Death Condition Pathway.</summary>
-        // private List CauseOfDeathConditionPathway;
 
         /// <summary>Decedent's Father.</summary>
         private RelatedPerson Father;
@@ -614,12 +604,6 @@ namespace VRDR
             // Start with an empty certification. - need reference in Composition
             CreateDeathCertification();
 
-            // Start with an empty funeral home. - why?
-            // CreateFuneralHome();
-
-            // Location of Disposition -why?
-            //CreateDispositionLocation();
-
             // Add Composition to bundle. As the record is filled out, new entries will be added to this element.
             Composition = new Composition();
             Composition.Id = Guid.NewGuid().ToString();
@@ -641,40 +625,19 @@ namespace VRDR
             Composition.Event.Add(eventComponent);
             Bundle.AddResourceEntry(Composition, "urn:uuid:" + Composition.Id);
 
-             // Start with an empty race and ethinicity observation - why?
-            // CreateInputRaceEthnicityObs();
-
-            // Start with an empty coding status values.
-            // CreateCodingStatusValues();
 
             // Add references back to the Decedent, Certifier, Certification, etc.
             AddReferenceToComposition(Decedent.Id, "DecedentDemographics");
             Bundle.AddResourceEntry(Decedent, "urn:uuid:" + Decedent.Id);
-
             AddReferenceToComposition(Certifier.Id, "DeathCertification");
             Bundle.AddResourceEntry(Certifier, "urn:uuid:" + Certifier.Id);
-            // AddReferenceToComposition(Pronouncer.Id, "OBE");
             AddReferenceToComposition(DeathCertification.Id, "DeathCertification");
             Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
-            // AddReferenceToComposition(FuneralHome.Id, "DecedentDisposition");
-            // Bundle.AddResourceEntry(FuneralHome, "urn:uuid:" + FuneralHome.Id);
-            // AddReferenceToComposition(CauseOfDeathConditionPathway.Id, "DeathCertification");
-            // AddReferenceToComposition(DispositionLocation.Id, "DispositionLocation");
-            // Bundle.AddResourceEntry(DispositionLocation, "urn:uuid:" + DispositionLocation.Id);
 
-            // TODO: Some of these, particularly the ones that only appear in certain bundles, probably shouldn't be added by default
-            // AddReferenceToComposition(InputRaceAndEthnicityObs.Id, "DecedentDemographics");
-            // Bundle.AddResourceEntry(InputRaceAndEthnicityObs, "urn:uuid:" + InputRaceAndEthnicityObs.Id);
-
+            // AddReferenceToComposition(Pronouncer.Id, "OBE");
             // Bundle.AddResourceEntry(Pronouncer, "urn:uuid:" + Pronouncer.Id);
             //Bundle.AddResourceEntry(Mortician, "urn:uuid:" + Mortician.Id);
-
-
             //Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
-            // Bundle.AddResourceEntry(CauseOfDeathConditionPathway, "urn:uuid:" + CauseOfDeathConditionPathway.Id);
-
-            AddReferenceToComposition(DeathCertification.Id, "DeathCertification");
-            Bundle.AddResourceEntry(DeathCertification, "urn:uuid:" + DeathCertification.Id);
 
             // Create a Navigator for this new death record.
             Navigator = Bundle.ToTypedElement();
@@ -853,7 +816,6 @@ namespace VRDR
             AddResourceToBundleIfPresent(CauseOfDeathConditionB, codccBundle);
             AddResourceToBundleIfPresent(CauseOfDeathConditionC, codccBundle);
             AddResourceToBundleIfPresent(CauseOfDeathConditionD, codccBundle);
-            // AddResourceToBundleIfPresent(CauseOfDeathConditionPathway, codccBundle);
             AddResourceToBundleIfPresent(ConditionContributingToDeath, codccBundle);
             AddResourceToBundleIfPresent(MannerOfDeath, codccBundle);
             AddResourceToBundleIfPresent(AutopsyPerformed, codccBundle);
@@ -10550,47 +10512,6 @@ namespace VRDR
                 }
             }
 
-            // // Grab Cause Of Death Condition Pathway
-            // var causeOfDeathConditionPathway = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.List );
-            // if (causeOfDeathConditionPathway != null)
-            // {
-            //     CauseOfDeathConditionPathway = (List)causeOfDeathConditionPathway.Resource;
-            // }
-
-            // Grab Causes of Death using CauseOfDeathConditionPathway
-            // List<Observation> causeConditions = new List<Observation>();
-            // if (CauseOfDeathConditionPathway != null)
-            // {
-            //     foreach (List.EntryComponent condition in CauseOfDeathConditionPathway.Entry)
-            //     {
-            //         if (condition != null && condition.Item != null && condition.Item.Reference != null)
-            //         {
-            //             var codCond = Bundle.Entry.FirstOrDefault( entry => entry.Resource.ResourceType == ResourceType.Observation && (((Observation)entry.Resource).Code.Coding.First().Code == "69453-9") &&
-            //             (entry.FullUrl == condition.Item.Reference || (entry.Resource.Id != null && entry.Resource.Id == condition.Item.Reference)) );
-            //             if (codCond != null)
-            //             {
-            //                 causeConditions.Add((Observation)codCond.Resource);
-            //             }
-            //         }
-            //     }
-            //     if (causeConditions.Count() > 0)
-            //     {
-            //         CauseOfDeathConditionA = causeConditions[0];
-            //     }
-            //     if (causeConditions.Count() > 1)
-            //     {
-            //         CauseOfDeathConditionB = causeConditions[1];
-            //     }
-            //     if (causeConditions.Count() > 2)
-            //     {
-            //         CauseOfDeathConditionC = causeConditions[2];
-            //     }
-            //     if (causeConditions.Count() > 3)
-            //     {
-            //         CauseOfDeathConditionD = causeConditions[3];
-            //     }
-
-            // }
             // Scan through all RelatedPerson to make sure they all have relationship codes!
             foreach (var rp in Bundle.Entry.Where( entry => entry.Resource.ResourceType == ResourceType.RelatedPerson ))
             {


### PR DESCRIPTION
…OfDeath

- Code and examples for COD1X (Part1) Interval was not aligned with IG.
- Swapped in new examples, and fixed codes to look for INTERVALx is a valueString, rather than the text field from a CodeableConcept.
- Cleanup some stray IGURL, Codesystem, and ProfileURL constants.
- Fix some FHIRPaths.
- Stripped the deathrecord constructor down to the bare minimum.  It needs Collection, and everything the collection refers to directly (not as entries) to exist, but not all of the random observations.
- Corrected DeathCertificate (Composition) sections for several elements.
- Delete a bunch of methods that aren't used (e.g., UsualOccupationCode).