### PR TITLE
fix spouse alive issue reported by Ruvos

### DIFF
--- a/VRDR/CodeSystems.cs
+++ b/VRDR/CodeSystems.cs
@@ -3,25 +3,21 @@ namespace VRDR
     /// <summary>Single definitions for CodeSystem OIDs and URLs used throughout. </summary>
     public static class CodeSystems
     {
+        // CodeSystems Defined Externally
         /// <summary>SNOMEDCT.</summary>
         public static string SCT = "http://snomed.info/sct";
 
         /// <summary>LOINC.</summary>
         public static string LOINC = "http://loinc.org";
 
+        /// <summary> ICD10 </summary>
+        public static string ICD10 = "http://hl7.org/fhir/sid/icd-10";
+
         /// <summary>Social Security Numbers.</summary>
         public static string US_SSN = "http://hl7.org/fhir/sid/us-ssn";
 
         /// <summary>Observation Category. </summary>
         public static string ObservationCategory = "http://terminology.hl7.org/CodeSystem/observation-category";
-
-        /// <summary>PHINVADS Race and Ethnicity.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_RaceAndEthnicity_CDC = "urn:oid:2.16.840.1.113883.6.238";
-
-        /// <summary>PHINVADS Null Flavor.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_NullFlavor_HL7_V3 = "http://terminology.hl7.org/CodeSystem/v3-NullFlavor"; // "urn:oid:2.16.840.1.113883.5.1008";
 
         /// <summary>HL7 V3 Null Flavor.</summary>
         public static string NullFlavor_HL7_V3 = "http://terminology.hl7.org/CodeSystem/v3-NullFlavor";
@@ -32,49 +28,13 @@ namespace VRDR
         /// <summary>HL7 Yes No.</summary>
         public static string YesNo_0136HL7_V2 = "http://terminology.hl7.org/CodeSystem/v2-0136";
 
-        /// <summary>PHINVADS Local Coding System.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_PHINVS_CDC = "urn:oid:2.16.840.1.114222.4.5.274";
 
-        /// <summary>PHINVADS Yes/No.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_YesNo_HL7_2x = "urn:oid:2.16.840.1.113883.12.136";
-
-        /// <summary>PHINVADS County FIPS 6-4</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_County_FIPS_6_4 = "2.16.840.1.113883.6.93";
-
-        /// <summary>PHINVADS Country GEC</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_Country_GEC = "2.16.840.1.113883.13.250";
-
-        /// <summary>PHINVADS Place of Occurrence.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_PlaceOfOccurrence_ICD_10_WHO = "urn:oid:2.16.840.1.114222.4.5.320";
-
-        /// <summary>PHINVADS SNOMED.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_SNOMED_CT = "urn:oid:2.16.840.1.113883.6.96";
-
-        /// <summary>PHINVADS Marital Satus.</summary>
+        /// <summary>PHINVADS Marital Status.</summary>
         public static string PH_MaritalStatus_HL7_2x = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
-
-        /// <summary>PHINVADS USGS GNIS.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_USGS_GNIS = "urn:oid:2.16.840.1.113883.6.245";
-
-        /// <summary>PHINVADS FIPS 5 2.</summary>
-        // TODO: FLAGGED FOR DELETION
-        public static string PH_State_FIPS_5_2 = "urn:oid:2.16.840.1.113883.6.92";
 
         /// <summary>HL7 Location Physical Type.</summary>
         public static string HL7_location_physical_type = "http://terminology.hl7.org/CodeSystem/location-physical-type";
 
-        /// <summary> CDC Census Occupation Code  </summary>
-        public static string PH_Occupation_CDC_Census2010 = "urn:oid:2.16.840.1.114222.4.5.314";
-
-        /// <summary> CDC Census Industry Code  </summary>
-        public static string PH_Industry_CDC_Census2010 = "urn:oid:2.16.840.1.114222.4.5.315";
 
         /// <summary> US NPI HL7  </summary>
         public static string US_NPI_HL7 = "http://hl7.org/fhir/sid/us-npi";
@@ -82,23 +42,15 @@ namespace VRDR
         /// <summary>HL7 Identifier Type.</summary>
         public static string HL7_identifier_type = "http://terminology.hl7.org/CodeSystem/v2-0203";
 
-        /// <summary>HL7 Organization Type.</summary>
-        public static string HL7_organization_type =  "http://terminology.hl7.org/CodeSystem/organization-type";
+        // <summary>HL7 Organization Type.</summary>
+        // public static string HL7_organization_type =  "http://terminology.hl7.org/CodeSystem/organization-type";
 
-        /// <summary>PHINVADS HL7 RoleCode.</summary>
-        public static string PH_RoleCode_HL7_V3 = "urn:oid:2.16.840.1.113883.5.111";
 
         /// <summary>HL7 RoleCode.</summary>
         public static string RoleCode_HL7_V3 = "http://terminology.hl7.org/CodeSystem/v3-RoleCode";
 
-        /// <summary> ISO 3166-2  </summary>
-        public static string ISO_3166_2 = "urn:iso:std:iso:3166:-2";
-
         /// <summary> Administrative Gender </summary>
         public static string AdministrativeGender = "http://hl7.org/fhir/administrative-gender";
-
-        /// <summary> Bypass Edit Flag </summary>
-        public static string BypassEditFlag = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs";
 
         /// <summary> Education Level </summary>
         public static string EducationLevel = "http://terminology.hl7.org/CodeSystem/v3-EducationLevel";
@@ -106,18 +58,23 @@ namespace VRDR
         /// <summary> Degree Licence and Certificate </summary>
         public static string DegreeLicenceAndCertificate = "http://terminology.hl7.org/CodeSystem/v2-0360";
 
-        /// <summary> Pregnancy Status </summary>
-        public static string PregnancyStatus = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs";
-
-        /// <summary> Missing Value Reason </summary>
-        public static string MissingValueReason = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-missing-value-reason-cs";
-
         /// <summary> Units of Measure </summary>
         public static string UnitsOfMeasure = "http://unitsofmeasure.org";
 
         /// <summary> HL7 Yes No </summary>
         public static string YesNo = "http://terminology.hl7.org/CodeSystem/v2-0136";
 
+        /// <summary> Bypass Edit Flag </summary>
+        public static string BypassEditFlag = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs";
+
+        /// <summary> Pregnancy Status </summary>
+        public static string PregnancyStatus = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs";
+
+        /// <summary> Missing Value Reason </summary>
+        public static string MissingValueReason = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-missing-value-reason-cs";
+
+
+        // CodeSystems Defined within the VRDR IG
         /// <summary> Filing Format </summary>
         public static string FilingFormat = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs";
 
@@ -158,12 +115,10 @@ namespace VRDR
 
         /// <summary> Component Codes </summary>
         public static string ComponentCode = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs";
-        //
 
         /// <summary> Component </summary>
         public static string Component = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs";
-        /// <summary> ICD10 </summary>
-        public static string ICD10 = "http://hl7.org/fhir/sid/icd-10";
+
     }
 
 }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -4249,7 +4249,7 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SpouseAlive", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                SetCodeValue("SpouseAlive", value, VRDR.ValueSets.SpouseAlive.Codes);
             }
         }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -3023,7 +3023,7 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity1", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                SetCodeValue("Ethnicity1", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
             }
         }
 
@@ -3102,7 +3102,7 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity2", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                SetCodeValue("Ethnicity2", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
             }
         }
 
@@ -3181,7 +3181,7 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity3", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                SetCodeValue("Ethnicity3", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
             }
         }
 
@@ -3260,7 +3260,7 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity4", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                SetCodeValue("Ethnicity4", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
             }
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -3184,11 +3184,11 @@ namespace VRDR
         {
             get
             {
-                return Get_MappingFHIRToIJE(Mappings.YesNoUnknownNotApplicable.FHIRToIJE, "SpouseAlive", "SPOUSELV");
+                return Get_MappingFHIRToIJE(Mappings.SpouseAlive.FHIRToIJE, "SpouseAlive", "SPOUSELV");
             }
             set
             {
-                Set_MappingIJEToFHIR(Mappings.YesNoUnknownNotApplicable.IJEToFHIR, "SPOUSELV", "SpouseAlive", value);
+                Set_MappingIJEToFHIR(Mappings.SpouseAlive.IJEToFHIR, "SPOUSELV", "SpouseAlive", value);
             }
         }
 

--- a/VRDR/Mappings.cs
+++ b/VRDR/Mappings.cs
@@ -3014,6 +3014,26 @@ namespace VRDR
                 { "updated_notforNCHS", "2" },
             };
         }
+        /// <summary>Mappings for SpouseAlive</summary>
+        public static class SpouseAlive
+        {
+            /// <summary>IJE -> FHIR Mapping for SpouseAlive</summary>
+            public readonly static Dictionary<string, string> IJEToFHIR = new Dictionary<string, string>
+            {
+                { "1", "Y" },
+                { "2", "N" },
+                { "8", "NA" },
+                { "9", "UNK" },
+            };
+            /// <summary>FHIR -> IJE Mapping for SpouseAlive</summary>
+            public readonly static Dictionary<string, string> FHIRToIJE = new Dictionary<string, string>
+            {
+                { "Y", "1" },
+                { "N", "2" },
+                { "NA", "8" },
+                { "UNK", "9" },
+            };
+        }
         /// <summary>Mappings for SystemReject</summary>
         public static class SystemReject
         {

--- a/VRDR/Mappings.cs
+++ b/VRDR/Mappings.cs
@@ -216,6 +216,24 @@ namespace VRDR
                 { "mixed", "2" },
             };
         }
+        /// <summary>Mappings for HispanicNoUnknown</summary>
+        public static class HispanicNoUnknown
+        {
+            /// <summary>IJE -> FHIR Mapping for HispanicNoUnknown</summary>
+            public readonly static Dictionary<string, string> IJEToFHIR = new Dictionary<string, string>
+            {
+                { "H", "Y" },
+                { "N", "N" },
+                { "U", "UNK" },
+            };
+            /// <summary>FHIR -> IJE Mapping for HispanicNoUnknown</summary>
+            public readonly static Dictionary<string, string> FHIRToIJE = new Dictionary<string, string>
+            {
+                { "Y", "H" },
+                { "N", "N" },
+                { "UNK", "U" },
+            };
+        }
         /// <summary>Mappings for HispanicOrigin</summary>
         public static class HispanicOrigin
         {

--- a/VRDR/ValueSets.cs
+++ b/VRDR/ValueSets.cs
@@ -16,7 +16,7 @@ namespace VRDR
                 { "4", "While resting, sleeping, eating, or engaging in other vital activities", VRDR.CodeSystems.ActivityAtTimeOfDeath },
                 { "8", "While engaged in other specified activities.", VRDR.CodeSystems.ActivityAtTimeOfDeath },
                 { "9", "During unspecified activity", VRDR.CodeSystems.ActivityAtTimeOfDeath },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> While_Engaged_In_Sports_Activity </summary>
             public static string  While_Engaged_In_Sports_Activity = "0";
@@ -48,7 +48,7 @@ namespace VRDR
                 { "LA14091-5", "Industrial or construction area", VRDR.CodeSystems.LOINC },
                 { "LA14092-3", "Farm", VRDR.CodeSystems.LOINC },
                 { "LA14093-1", "Unspecified", VRDR.CodeSystems.LOINC },
-                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "OTH", "Other", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Home </summary>
             public static string  Home = "LA14084-0";
@@ -93,7 +93,7 @@ namespace VRDR
                 { "455381000124109", "Medical Examiner/Coroner-On the basis of examination, and/or investigation, in my opinion, death occurred at the time, date, and place, and due to the cause(s) and manner stated.", VRDR.CodeSystems.SCT },
                 { "434641000124105", "Pronouncing & Certifying physician-To the best of my knowledge, death occurred at the time, date, and place, and due to the cause(s) and manner stated.", VRDR.CodeSystems.SCT },
                 { "434651000124107", "Certifying physician-To the best of my knowledge, death occurred due to the cause(s) and manner stated.", VRDR.CodeSystems.SCT },
-                { "OTH", "Other (Specify)", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "OTH", "Other (Specify)", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Medical_Examiner_Coroner </summary>
             public static string  Medical_Examiner_Coroner = "455381000124109";
@@ -111,8 +111,8 @@ namespace VRDR
                 { "373066001", "Yes", VRDR.CodeSystems.SCT },
                 { "373067005", "No", VRDR.CodeSystems.SCT },
                 { "2931005", "Probably", VRDR.CodeSystems.SCT },
-                { "UNK", "Unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "NI", "no information", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "Unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "NI", "no information", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Yes </summary>
             public static string  Yes = "373066001";
@@ -203,7 +203,7 @@ namespace VRDR
                 { "AA", "Associate's or technical degree complete", VRDR.CodeSystems.DegreeLicenceAndCertificate },
                 { "BA", "Bachelor's degree", VRDR.CodeSystems.DegreeLicenceAndCertificate },
                 { "MA", "Master's degree", VRDR.CodeSystems.DegreeLicenceAndCertificate },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Elementary_School </summary>
             public static string  Elementary_School = "ELEM";
@@ -272,7 +272,7 @@ namespace VRDR
                 { "M", "Married", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
                 { "S", "Never Married", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
                 { "W", "Widowed", VRDR.CodeSystems.PH_MaritalStatus_HL7_2x },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Divorced </summary>
             public static string  Divorced = "D";
@@ -296,8 +296,8 @@ namespace VRDR
                 { "449951000124101", "Donation", VRDR.CodeSystems.SCT },
                 { "449961000124104", "Cremation", VRDR.CodeSystems.SCT },
                 { "449971000124106", "Burial", VRDR.CodeSystems.SCT },
-                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "UNK", "Unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "OTH", "Other", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "UNK", "Unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Entombment </summary>
             public static string  Entombment = "449931000124108";
@@ -324,8 +324,8 @@ namespace VRDR
                 { "16983000", "Death in hospital", VRDR.CodeSystems.SCT },
                 { "450391000124102", "Death in hospital-based emergency department or outpatient department", VRDR.CodeSystems.SCT },
                 { "450381000124100", "Death in nursing home or long term care facility", VRDR.CodeSystems.SCT },
-                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "UNK", "UNK", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "OTH", "Other", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "UNK", "UNK", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Dead_On_Arrival_At_Hospital </summary>
             public static string  Dead_On_Arrival_At_Hospital = "63238001";
@@ -353,7 +353,7 @@ namespace VRDR
                 { "3", "Not pregnant, but pregnant within 42 days of death", VRDR.CodeSystems.PregnancyStatus },
                 { "4", "Not pregnant, but pregnant 43 days to 1 year before death", VRDR.CodeSystems.PregnancyStatus },
                 { "9", "Unknown if pregnant within the past year", VRDR.CodeSystems.PregnancyStatus },
-                { "NA", "Not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "NA", "Not applicable", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Not_Pregnant_Within_Past_Year </summary>
             public static string  Not_Pregnant_Within_Past_Year = "1";
@@ -405,9 +405,9 @@ namespace VRDR
                 { "236320001", "Vehicle driver", VRDR.CodeSystems.SCT },
                 { "257500003", "Passenger", VRDR.CodeSystems.SCT },
                 { "257518000", "Pedestrian", VRDR.CodeSystems.SCT },
-                { "OTH", "Other", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "OTH", "Other", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "NA", "not applicable", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Vehicle_Driver </summary>
             public static string  Vehicle_Driver = "236320001";
@@ -431,7 +431,7 @@ namespace VRDR
                 { "h", "Hours", VRDR.CodeSystems.UnitsOfMeasure },
                 { "mo", "Months", VRDR.CodeSystems.UnitsOfMeasure },
                 { "a", "Years", VRDR.CodeSystems.UnitsOfMeasure },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Minutes </summary>
             public static string  Minutes = "min";
@@ -452,8 +452,8 @@ namespace VRDR
             public static string[,] Codes = {
                 { "Y", "Yes", VRDR.CodeSystems.YesNo },
                 { "N", "No", VRDR.CodeSystems.YesNo },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "NA", "not applicable", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Yes </summary>
             public static string  Yes = "Y";
@@ -470,7 +470,7 @@ namespace VRDR
             public static string[,] Codes = {
                 { "N", "No", VRDR.CodeSystems.YesNo },
                 { "Y", "Yes", VRDR.CodeSystems.YesNo },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> No </summary>
             public static string  No = "N";
@@ -4361,8 +4361,8 @@ namespace VRDR
             public static string[,] Codes = {
                 { "Y", "Yes", VRDR.CodeSystems.YesNo },
                 { "N", "No", VRDR.CodeSystems.YesNo },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
-                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 },
+                { "NA", "not applicable", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> Yes </summary>
             public static string  Yes = "Y";
@@ -4379,7 +4379,7 @@ namespace VRDR
             public static string[,] Codes = {
                 { "N", "No", VRDR.CodeSystems.YesNo },
                 { "Y", "Yes", VRDR.CodeSystems.YesNo },
-                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+                { "UNK", "unknown", VRDR.CodeSystems.NullFlavor_HL7_V3 }
             };
             /// <summary> No </summary>
             public static string  No = "N";

--- a/VRDR/ValueSets.cs
+++ b/VRDR/ValueSets.cs
@@ -4379,5 +4379,23 @@ namespace VRDR
             /// <summary> Reject9 </summary>
             public static string  Reject9 = "9";
         };
+        /// <summary> SpouseAlive </summary>
+        public static class SpouseAlive {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "Y", "Yes", VRDR.CodeSystems.YesNo },
+                { "N", "No", VRDR.CodeSystems.YesNo },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 },
+                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> Yes </summary>
+            public static string  Yes = "Y";
+            /// <summary> No </summary>
+            public static string  No = "N";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
+            /// <summary> Not_Applicable </summary>
+            public static string  Not_Applicable = "NA";
+        };
    }
 }

--- a/VRDR/ValueSets.cs
+++ b/VRDR/ValueSets.cs
@@ -314,15 +314,6 @@ namespace VRDR
             /// <summary> Unknown </summary>
             public static string  Unknown = "UNK";
         };
-        /// <summary> NotApplicable </summary>
-        public static class NotApplicable {
-            /// <summary> Codes </summary>
-            public static string[,] Codes = {
-                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
-            };
-            /// <summary> Not_Applicable </summary>
-            public static string  Not_Applicable = "NA";
-        };
         /// <summary> PlaceOfDeath </summary>
         public static class PlaceOfDeath {
             /// <summary> Codes </summary>
@@ -454,21 +445,6 @@ namespace VRDR
             public static string  Years = "a";
             /// <summary> Unknown </summary>
             public static string  Unknown = "UNK";
-        };
-        /// <summary> YesNoNotApplicable </summary>
-        public static class YesNoNotApplicable {
-            /// <summary> Codes </summary>
-            public static string[,] Codes = {
-                { "N", "No", VRDR.CodeSystems.YesNo },
-                { "Y", "Yes", VRDR.CodeSystems.YesNo },
-                { "NA", "not applicable", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
-            };
-            /// <summary> No </summary>
-            public static string  No = "N";
-            /// <summary> Yes </summary>
-            public static string  Yes = "Y";
-            /// <summary> Not_Applicable </summary>
-            public static string  Not_Applicable = "NA";
         };
         /// <summary> YesNoUnknownNotApplicable </summary>
         public static class YesNoUnknownNotApplicable {
@@ -4396,6 +4372,21 @@ namespace VRDR
             public static string  Unknown = "UNK";
             /// <summary> Not_Applicable </summary>
             public static string  Not_Applicable = "NA";
+        };
+        /// <summary> HispanicNoUnknown </summary>
+        public static class HispanicNoUnknown {
+            /// <summary> Codes </summary>
+            public static string[,] Codes = {
+                { "N", "No", VRDR.CodeSystems.YesNo },
+                { "Y", "Yes", VRDR.CodeSystems.YesNo },
+                { "UNK", "unknown", VRDR.CodeSystems.PH_NullFlavor_HL7_V3 }
+            };
+            /// <summary> No </summary>
+            public static string  No = "N";
+            /// <summary> Yes </summary>
+            public static string  Yes = "Y";
+            /// <summary> Unknown </summary>
+            public static string  Unknown = "UNK";
         };
    }
 }

--- a/tools/generate_value_set_lookups_from_VRDR_IG.rb
+++ b/tools/generate_value_set_lookups_from_VRDR_IG.rb
@@ -54,7 +54,7 @@ require 'json'
 require 'pry'
 codesystems = {
     "http://snomed.info/sct" => "VRDR.CodeSystems.SCT",
-    "http://terminology.hl7.org/CodeSystem/v3-NullFlavor" => "VRDR.CodeSystems.PH_NullFlavor_HL7_V3",
+    "http://terminology.hl7.org/CodeSystem/v3-NullFlavor" => "VRDR.CodeSystems.NullFlavor_HL7_V3",
     "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus" => "VRDR.CodeSystems.PH_MaritalStatus_HL7_2x",
     "http://hl7.org/fhir/administrative-gender" => "VRDR.CodeSystems.AdministrativeGender",
     "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs" => "VRDR.CodeSystems.BypassEditFlag",

--- a/tools/generate_value_set_lookups_from_VRDR_IG.rb
+++ b/tools/generate_value_set_lookups_from_VRDR_IG.rb
@@ -91,14 +91,12 @@ valuesets = {
     "ValueSet-vrdr-manner-of-death-vs.json" => "MannerOfDeath",
     "ValueSet-vrdr-marital-status-vs.json" => "MaritalStatus",
     "ValueSet-vrdr-method-of-disposition-vs.json" => "MethodOfDisposition",
-    "ValueSet-vrdr-not-applicable-vs.json" => "NotApplicable",
     "ValueSet-vrdr-place-of-death-vs.json" => "PlaceOfDeath",
     "ValueSet-vrdr-pregnancy-status-vs.json" => "PregnancyStatus",
     "ValueSet-vrdr-race-missing-value-reason-vs.json" => "RaceMissingValueReason",
     "ValueSet-vrdr-replace-status-vs.json" => "ReplaceStatus",
     "ValueSet-vrdr-transportation-incident-role-vs.json" => "TransportationIncidentRole",
     "ValueSet-vrdr-units-of-age-vs.json" => "UnitsOfAge",
-    "ValueSet-vrdr-yes-no-not-applicable-vs.json" => "YesNoNotApplicable",
     "ValueSet-vrdr-yes-no-unknown-not-applicable-vs.json" => "YesNoUnknownNotApplicable",
     "ValueSet-vrdr-yes-no-unknown-vs.json" => "YesNoUnknown",
     "ValueSet-vrdr-race-code-vs.json" => "RaceCode",
@@ -108,6 +106,7 @@ valuesets = {
     "ValueSet-vrdr-system-reject-vs.json" => "AcmeSystemReject",
     "ValueSet-vrdr-intentional-reject-vs.json" => "IntentionalReject",
     "ValueSet-vrdr-spouse-alive-vs.json" => "SpouseAlive",
+    "ValueSet-vrdr-hispanic-no-unknown-vs.json" => "HispanicNoUnknown",
 }
 
 outfilename = ARGV[1] + "/ValueSets.cs"

--- a/tools/generate_value_set_lookups_from_VRDR_IG.rb
+++ b/tools/generate_value_set_lookups_from_VRDR_IG.rb
@@ -107,9 +107,11 @@ valuesets = {
     "ValueSet-vrdr-transax-conversion-vs.json" => "TransaxConversion",
     "ValueSet-vrdr-system-reject-vs.json" => "AcmeSystemReject",
     "ValueSet-vrdr-intentional-reject-vs.json" => "IntentionalReject",
+    "ValueSet-vrdr-spouse-alive-vs.json" => "SpouseAlive",
 }
 
 outfilename = ARGV[1] + "/ValueSets.cs"
+puts "Output in #{outfilename}"
 file = file=File.open(outfilename,"w")
 systems_without_constants = []
 


### PR DESCRIPTION
https://chat.fhir.org/#narrow/stream/179301-Death-on-FHIR/topic/IJE.20to.20FHIR.20Conversion.3A.20.20SPOUSELV

A similar issue was found with the HispanicNoUnknown (H/N/U) encoding in IJE, and has been addressed.
Some Valuesets that were not used (Yes,No,Not-Applicable) have been nuked from the IG, and from the library.