### PR TITLE
Add null check to support API Server upgrade 

### DIFF
--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -7574,7 +7574,7 @@ namespace VRDR
             }
             // Remove existing component (if it exists) and add an appropriate component.
             Observation.ComponentComponent issue = EmergingIssues.Component.FirstOrDefault(c => c.Code.Coding[0].Code == identifier);
-            if (issue != null)
+            if (issue != null && issue.Value != null)
             {
                 return issue.Value.ToString();
             }


### PR DESCRIPTION
Similar to some other issues we've seen, there was a null pointer exception when the API server tried use the library to convert the message submission to IJE. This is a small fix to support the api update