### PR TITLE
Fix handling of record bundles in messages

### DIFF
--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -119,6 +119,22 @@ namespace VRDR
         }
 
         /// <summary>
+        /// Update the record bundle in this message based on the MessageBundleRecord property (for whichever subclass we're instantiated as).
+        /// Important if we're managing a death record that might have changed.
+        /// </summary>
+        protected void UpdateMessageBundleRecord()
+        {
+            MessageBundle.Entry.RemoveAll( entry => entry.Resource.ResourceType == ResourceType.Bundle );
+            Header.Focus.Clear();
+            Bundle newBundle = MessageBundleRecord;
+            if (newBundle != null)
+            {
+                MessageBundle.AddResourceEntry(newBundle, "urn:uuid:" + newBundle.Id);
+                Header.Focus.Add(new ResourceReference("urn:uuid:" + newBundle.Id));
+            }
+        }
+
+        /// <summary>
         /// Allow explicit casting of a message into a bundle
         /// </summary>
         /// <param name="message">the death record to extract the bundle from</param>
@@ -129,6 +145,7 @@ namespace VRDR
         /// <returns>a string representation of this DeathRecordSubmissionMessage in XML format</returns>
         public string ToXML(bool prettyPrint = false)
         {
+            UpdateMessageBundleRecord(); // Update the record in the message bundle in case the DeathRecord (if present) has changed
             return MessageBundle.ToXml(new FhirXmlSerializationSettings { Pretty = prettyPrint, AppendNewLine = prettyPrint, TrimWhitespaces = prettyPrint });
         }
 
@@ -145,6 +162,7 @@ namespace VRDR
         /// <returns>a string representation of this DeathRecordSubmissionMessage in JSON format</returns>
         public string ToJSON(bool prettyPrint = false)
         {
+            UpdateMessageBundleRecord(); // Update the record in the message bundle in case the DeathRecord (if present) has changed
             return MessageBundle.ToJson(new FhirJsonSerializationSettings { Pretty = prettyPrint, AppendNewLine = prettyPrint });
         }
 
@@ -161,6 +179,17 @@ namespace VRDR
         // Message Properties
         //
         /////////////////////////////////////////////////////////////////////////////////
+
+        /// <summary>The record bundle that should go into the message bundle for this message</summary>
+        /// <value>the MessageBundleRecord</value>
+        protected virtual Bundle MessageBundleRecord
+        {
+            get
+            {
+                // The base message class and some subclasses do not have a record
+                return null;
+            }
+        }
 
         /// <summary>Message timestamp</summary>
         /// <value>the message timestamp.</value>

--- a/VRDR.Messaging/CauseOfDeathCodingMessage.cs
+++ b/VRDR.Messaging/CauseOfDeathCodingMessage.cs
@@ -57,14 +57,17 @@ namespace VRDR
             set
             {
                 deathRecord = value;
-                MessageBundle.Entry.RemoveAll( entry => entry.Resource.ResourceType == ResourceType.Bundle );
-                Header.Focus.Clear();
-                if (deathRecord != null)
-                {
-                    Bundle bundle = deathRecord.GetCauseOfDeathCodedContentBundle();
-                    MessageBundle.AddResourceEntry(bundle, "urn:uuid:" + bundle.Id);
-                    Header.Focus.Add(new ResourceReference("urn:uuid:" + bundle.Id));
-                }
+                UpdateMessageBundleRecord();
+            }
+        }
+
+        /// <summary>The record bundle that should go into the message bundle for this message</summary>
+        /// <value>the MessageBundleRecord</value>
+        protected override Bundle MessageBundleRecord
+        {
+            get
+            {
+                return deathRecord?.GetCauseOfDeathCodedContentBundle();
             }
         }
     }

--- a/VRDR.Messaging/CauseOfDeathCodingMessage.cs
+++ b/VRDR.Messaging/CauseOfDeathCodingMessage.cs
@@ -61,8 +61,9 @@ namespace VRDR
                 Header.Focus.Clear();
                 if (deathRecord != null)
                 {
-                    MessageBundle.AddResourceEntry(deathRecord.GetCauseOfDeathCodedContentBundle(), "urn:uuid:" + deathRecord.GetCauseOfDeathCodedContentBundle().Id);
-                    Header.Focus.Add(new ResourceReference("urn:uuid:" + deathRecord.GetCauseOfDeathCodedContentBundle().Id));
+                    Bundle bundle = deathRecord.GetCauseOfDeathCodedContentBundle();
+                    MessageBundle.AddResourceEntry(bundle, "urn:uuid:" + bundle.Id);
+                    Header.Focus.Add(new ResourceReference("urn:uuid:" + bundle.Id));
                 }
             }
         }

--- a/VRDR.Messaging/DeathRecordSubmissionMessage.cs
+++ b/VRDR.Messaging/DeathRecordSubmissionMessage.cs
@@ -59,8 +59,9 @@ namespace VRDR
                 Header.Focus.Clear();
                 if (deathRecord != null)
                 {
-                    MessageBundle.AddResourceEntry(deathRecord.GetBundle(), "urn:uuid:" + deathRecord.GetBundle().Id);
-                    Header.Focus.Add(new ResourceReference("urn:uuid:" + deathRecord.GetBundle().Id));
+                    Bundle bundle = deathRecord.GetBundle();
+                    MessageBundle.AddResourceEntry(bundle, "urn:uuid:" + bundle.Id);
+                    Header.Focus.Add(new ResourceReference("urn:uuid:" + bundle.Id));
                 }
             }
         }

--- a/VRDR.Messaging/DeathRecordSubmissionMessage.cs
+++ b/VRDR.Messaging/DeathRecordSubmissionMessage.cs
@@ -55,14 +55,17 @@ namespace VRDR
             set
             {
                 deathRecord = value;
-                MessageBundle.Entry.RemoveAll( entry => entry.Resource.ResourceType == ResourceType.Bundle );
-                Header.Focus.Clear();
-                if (deathRecord != null)
-                {
-                    Bundle bundle = deathRecord.GetBundle();
-                    MessageBundle.AddResourceEntry(bundle, "urn:uuid:" + bundle.Id);
-                    Header.Focus.Add(new ResourceReference("urn:uuid:" + bundle.Id));
-                }
+                UpdateMessageBundleRecord();
+            }
+        }
+
+        /// <summary>The record bundle that should go into the message bundle for this message</summary>
+        /// <value>the MessageBundleRecord</value>
+        protected override Bundle MessageBundleRecord
+        {
+            get
+            {
+                return deathRecord?.GetBundle();
             }
         }
     }

--- a/VRDR.Messaging/DemographicsCodingMessage.cs
+++ b/VRDR.Messaging/DemographicsCodingMessage.cs
@@ -57,14 +57,17 @@ namespace VRDR
             set
             {
                 deathRecord = value;
-                MessageBundle.Entry.RemoveAll( entry => entry.Resource.ResourceType == ResourceType.Bundle );
-                Header.Focus.Clear();
-                if (deathRecord != null)
-                {
-                    Bundle bundle = deathRecord.GetDemographicCodedContentBundle();
-                    MessageBundle.AddResourceEntry(bundle, "urn:uuid:" + bundle.Id);
-                    Header.Focus.Add(new ResourceReference("urn:uuid:" + bundle.Id));
-                }
+                UpdateMessageBundleRecord();
+            }
+        }
+
+        /// <summary>The record bundle that should go into the message bundle for this message</summary>
+        /// <value>the MessageBundleRecord</value>
+        protected override Bundle MessageBundleRecord
+        {
+            get
+            {
+                return deathRecord?.GetDemographicCodedContentBundle();
             }
         }
     }

--- a/VRDR.Messaging/DemographicsCodingMessage.cs
+++ b/VRDR.Messaging/DemographicsCodingMessage.cs
@@ -61,8 +61,9 @@ namespace VRDR
                 Header.Focus.Clear();
                 if (deathRecord != null)
                 {
-                    MessageBundle.AddResourceEntry(deathRecord.GetDemographicCodedContentBundle(), "urn:uuid:" + deathRecord.GetDemographicCodedContentBundle().Id);
-                    Header.Focus.Add(new ResourceReference("urn:uuid:" + deathRecord.GetDemographicCodedContentBundle().Id));
+                    Bundle bundle = deathRecord.GetDemographicCodedContentBundle();
+                    MessageBundle.AddResourceEntry(bundle, "urn:uuid:" + bundle.Id);
+                    Header.Focus.Add(new ResourceReference("urn:uuid:" + bundle.Id));
                 }
             }
         }

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -322,6 +322,27 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void CreateCauseOfDeathCodingResponseFromSubmissionBundle()
+        {
+            CauseOfDeathCodingMessage message = new CauseOfDeathCodingMessage((DeathRecord)JSONRecords[0]);
+            // Add cause of death coding
+            message.DeathRecord.AutomatedUnderlyingCOD = "A04.7";
+            // Add record axis codes
+            IList<(int, string, bool)> causeOfDeathRecordAxis = new List<(int, string, bool)>();
+            causeOfDeathRecordAxis.Add((1, "A41.9", false));
+            message.DeathRecord.RecordAxisCauseOfDeath = causeOfDeathRecordAxis;
+            // Add entity axis codes
+            IList<(int, int, string, bool)> causeOfDeathEntityAxis = new List<(int, int, string, bool)>();
+            causeOfDeathEntityAxis.Add((1, 1, "J18.9", false));
+            message.DeathRecord.EntityAxisCauseOfDeath = causeOfDeathEntityAxis;
+            // Make sure the codes are actually in there
+            string json = message.ToJson();
+            Assert.True(json.IndexOf("A04.7") > -1);
+            Assert.True(json.IndexOf("A41.9") > -1);
+            Assert.True(json.IndexOf("J18.9") > -1);
+        }
+
+        [Fact]
         public void CreateCauseOfDeathCodingUpdateFromJSON()
         {
             CauseOfDeathCodingUpdateMessage message = BaseMessage.Parse<CauseOfDeathCodingUpdateMessage>(FixtureStream("fixtures/json/CauseOfDeathCodingUpdateMessage.json"));


### PR DESCRIPTION
This pull request:

1. Makes sure that when a message is converted to JSON any changes to the DeathRecord (if present) are incorporated in the message bundle
2. Cleans up bundle handling across the subclasses that handle records
3. Adds a test to confirm that the record is updated