### PR TITLE
Add parser to handle just a bundle and just a BaseMessage

### DIFF
--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -465,7 +465,7 @@ namespace VRDR
         /// <param name="source">the XML or JSON serialization of a FHIR Bundle</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <returns>The deserialized bundle object</returns>
-        public static Bundle ParseGenericBundle(string source, bool permissive = false)
+        private static Bundle ParseGenericBundle(string source, bool permissive = false)
         {
             if (!String.IsNullOrEmpty(source) && source.TrimStart().StartsWith("<"))
             {
@@ -590,11 +590,6 @@ namespace VRDR
                 throw new System.ArgumentException(e.Message);
             }
 
-            if (bundle.Type.ToString() != "Message")
-            {
-                throw new System.ArgumentException($"The given input does not appear to be a valid XML FHIR message.{bundle.Type.ToString()} !");
-            }
-
             return bundle;
         }
 
@@ -625,11 +620,6 @@ namespace VRDR
             catch (Exception e)
             {
                 throw new System.ArgumentException(e.Message);
-            }
-
-            if (bundle.Type.ToString() != "Message")
-            {
-                throw new System.ArgumentException($"The given input does not appear to be a valid JSON FHIR message.{bundle.Type.ToString()} !");
             }
 
             return bundle;

--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -441,21 +441,44 @@ namespace VRDR
         /// <returns>The deserialized message object</returns>
         public static BaseMessage Parse(string source, bool permissive = false)
         {
-            Bundle bundle = null;
+            Bundle bundle = ParseGenericBundle(source, permissive);
+
+            return Parse(bundle);
+        }
+
+        /// <summary>
+        /// Parse an XML or JSON serialization of a FHIR Bundle and construct a generic BaseMessage.
+        /// </summary>
+        /// <param name="source">the XML or JSON serialization of a FHIR Bundle</param>
+        /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
+        /// <returns>The deserialized base message object</returns>
+        public static BaseMessage ParseGenericMessage(string source, bool permissive = false)
+        {
+            Bundle bundle = ParseGenericBundle(source, permissive);
+            BaseMessage message = new BaseMessage(bundle, true, false);
+            return message;
+        }
+
+        /// <summary>
+        /// Parse an XML or JSON serialization of a FHIR Bundle. 
+        /// </summary>
+        /// <param name="source">the XML or JSON serialization of a FHIR Bundle</param>
+        /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
+        /// <returns>The deserialized bundle object</returns>
+        public static Bundle ParseGenericBundle(string source, bool permissive = false)
+        {
             if (!String.IsNullOrEmpty(source) && source.TrimStart().StartsWith("<"))
             {
-                bundle = ParseXML(source, permissive);
+                return ParseXML(source, permissive);
             }
             else if (!String.IsNullOrEmpty(source) && source.TrimStart().StartsWith("{"))
             {
-                bundle = ParseJSON(source, permissive);
+                return ParseJSON(source, permissive);
             }
             else
             {
                 throw new System.ArgumentException("The given input does not appear to be a valid XML or JSON FHIR message.");
             }
-
-            return Parse(bundle);
         }
 
         /// <summary>
@@ -567,6 +590,11 @@ namespace VRDR
                 throw new System.ArgumentException(e.Message);
             }
 
+            if (bundle.Type.ToString() != "Message")
+            {
+                throw new System.ArgumentException($"The given input does not appear to be a valid XML FHIR message.{bundle.Type.ToString()} !");
+            }
+
             return bundle;
         }
 
@@ -597,6 +625,11 @@ namespace VRDR
             catch (Exception e)
             {
                 throw new System.ArgumentException(e.Message);
+            }
+
+            if (bundle.Type.ToString() != "Message")
+            {
+                throw new System.ArgumentException($"The given input does not appear to be a valid JSON FHIR message.{bundle.Type.ToString()} !");
             }
 
             return bundle;

--- a/VRDR.Tests/DeathRecord.Tests.csproj
+++ b/VRDR.Tests/DeathRecord.Tests.csproj
@@ -56,6 +56,7 @@
     <None Update="fixtures/json/MissingMessageType.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/MissingObservationCode.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/MissingRelatedPersonRelationshipCode.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/old-trx-pre-IGv13.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord2.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordVoidMessage.json" CopyToOutputDirectory="PreserveNewest" />

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -861,6 +861,23 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void ParseOldTRXVersionAsGenericMsg()
+        {
+            // verifies the Generic Message Parser allows for messages based on the old IG 1.2
+            string trxMsg = FixtureStream("fixtures/json/old-trx-pre-IGv13.json").ReadToEnd();
+            BaseMessage msg = BaseMessage.ParseGenericMessage(trxMsg, true);
+            Assert.Equal("http://nchs.cdc.gov/vrdr_coding", msg.MessageType);
+        }
+
+        [Fact]
+        public void ParseOldTRXVersionAsCodedMsgType()
+        {
+            // verifies the Type Specific Message Parser errors on messages based on the old IG 1.2
+            MessageParseException ex = Assert.Throws<MessageParseException>(() => BaseMessage.Parse(FixtureStream("fixtures/json/old-trx-pre-IGv13.json")));
+            Assert.Equal("Unsupported message type: http://nchs.cdc.gov/vrdr_coding", ex.Message);
+        }
+
+        [Fact]
         public void CreateExtractionErrorForMessage()
         {
             DeathRecordSubmissionMessage submission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));

--- a/VRDR.Tests/fixtures/json/old-trx-pre-IGv13.json
+++ b/VRDR.Tests/fixtures/json/old-trx-pre-IGv13.json
@@ -1,0 +1,116 @@
+{
+    "resourceType": "Bundle",
+    "id": "6d7d1d05-2c20-49ef-ab0e-a62ffb7e7d98",
+    "type": "message",
+    "timestamp": "2022-01-13T15:00:11.152535-05:00",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:8b18869d-865d-4cb4-9392-3d1f07752b8b",
+            "resource": {
+                "resourceType": "MessageHeader",
+                "id": "8b18869d-865d-4cb4-9392-3d1f07752b8b",
+                "eventUri": "http://nchs.cdc.gov/vrdr_coding",
+                "destination": [
+                    {
+                        "endpoint": "https://utah.gov/VRDR/fhir/message/endpoint"
+                    }
+                ],
+                "source": {
+                    "endpoint": "http://nchs.cdc.gov/vrdr_submission"
+                },
+                "focus": [
+                    {
+                        "reference": "urn:uuid:681424f9-8675-4032-a6fd-9ccf6fcda95b"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:681424f9-8675-4032-a6fd-9ccf6fcda95b",
+            "resource": {
+                "resourceType": "Parameters",
+                "id": "681424f9-8675-4032-a6fd-9ccf6fcda95b",
+                "parameter": [
+                    {
+                        "name": "cert_no",
+                        "valueUnsignedInt": 1
+                    },
+                    {
+                        "name": "death_year",
+                        "valueUnsignedInt": 2021
+                    },
+                    {
+                        "name": "jurisdiction_id",
+                        "valueString": "UT"
+                    },
+                    {
+                        "name": "manner",
+                        "valueString": "Natural"
+                    },
+                    {
+                        "name": "injpl",
+                        "valueString": "SportsAndAthleticsArea"
+                    },
+                    {
+                        "name": "rec_mo",
+                        "valueUnsignedInt": 1
+                    },
+                    {
+                        "name": "rec_dy",
+                        "valueUnsignedInt": 12
+                    },
+                    {
+                        "name": "cs",
+                        "valueCoding": {
+                            "system": "https://ftp.cdc.gov/pub/Health_Statistics/NCHS/Software/MICAR/Data_Entry_Software/ACME_TRANSAX/Documentation/auser.pdf",
+                            "code": "1"
+                        }
+                    },
+                    {
+                        "name": "ship",
+                        "valueString": "028"
+                    },
+                    {
+                        "name": "sys_rej",
+                        "valueString": "NotRejected"
+                    },
+                    {
+                        "name": "underlying_cause_of_death",
+                        "valueCoding": {
+                            "system": "http://hl7.org/fhir/ValueSet/icd-10",
+                            "code": "I469"
+                        }
+                    },
+                    {
+                        "name": "record_cause_of_death",
+                        "part": [
+                            {
+                                "name": "coding",
+                                "valueCoding": {
+                                    "system": "http://hl7.org/fhir/ValueSet/icd-10",
+                                    "code": "I469"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "entity_axis_code",
+                        "part": [
+                            {
+                                "name": "lineNumber",
+                                "valueId": "1"
+                            },
+                            {
+                                "name": "coding",
+                                "valueCoding": {
+                                    "system": "http://hl7.org/fhir/ValueSet/icd-10",
+                                    "code": "I469"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Our BaseMessage Parse function returns a specific type of Message, ex CauseOfDeathCodingMessage. We ran into an issue where a TRX message created by Veronique's code was aligned with the new version of the library but the API had not been updated and threw an error when it couldn't parse the message. This change allows us to keep the parsing on the API server as generic as possible by only parsing the json to a BaseMessage. We need to still parse it as a BaseMessage so we can access the message id when we add the message to the response bundle.

This will allow more messages to get returned in the responses from the API. It will be the client's responsibility to verify the specific message type.