### PR TITLE
Remove second addition of injury location object to output bundle

### DIFF
--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -6814,8 +6814,6 @@ namespace VRDR
                 {
                     CreateInjuryLocationLoc();
                     //LinkObservationToLocation(InjuryIncidentObs, InjuryLocationLoc);
-                    AddReferenceToComposition(InjuryLocationLoc.Id, "DeathInvestigation");
-                    Bundle.AddResourceEntry(InjuryLocationLoc, "urn:uuid:" + InjuryLocationLoc.Id);
                 }
 
                 InjuryLocationLoc.Address = DictToAddress(value);


### PR DESCRIPTION
Adding the injury location object to the death record bundle already occurs in the CreateInjuryLocationLoc method. Removing the code to add that object to the bundle in the InjuryLocationAddress setter will only add the injury location object to the output bundle once, which is what is expected.