### PR TITLE
Make parse bundle function public

### DIFF
--- a/VRDR.Client/VRDRClient.csproj
+++ b/VRDR.Client/VRDRClient.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageId>VRDR.Client</PackageId>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="VRDR.Messaging" Version="3.2.1"/>
+    <ProjectReference Include="..\VRDR.Messaging\VRDRMessaging.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -465,7 +465,7 @@ namespace VRDR
         /// <param name="source">the XML or JSON serialization of a FHIR Bundle</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <returns>The deserialized bundle object</returns>
-        private static Bundle ParseGenericBundle(string source, bool permissive = false)
+        public static Bundle ParseGenericBundle(string source, bool permissive = false)
         {
             if (!String.IsNullOrEmpty(source) && source.TrimStart().StartsWith("<"))
             {


### PR DESCRIPTION
This change supports batch uploading in the Reference API. Bundles can be of type "message" or "batch". The API uses this function to parse the generic bundle, checks the type, and then handles the bundle appropriately. 