### PR TITLE
Return correct empty dictionary for DeathRecord dictionary properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,9 @@ dotnet run --project VRDR.CLI connectathon 1 100 MA
 # Generate a verbose JSON description of the record (in the format used to drive Canary)
 dotnet run --project VRDR.CLI description VRDR.CLI/1.json
 
+# Dump content of a death record in key/value IJE format
+dotnet run --project VRDR.CLI 2ijecontent VRDR.CLI/1.json
+
 # Convert a record to IJE and back to identify any conversion issues
 dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI/1.json
 
@@ -412,6 +415,9 @@ dotnet run --project VRDR.CLI compare VRDR.CLI/1.MOR VRDR.CLI/1.json
 
 # Extract a FHIR record from a FHIR message
 dotnet run --project VRDR.CLI extract VRDR.CLI/1submit.json
+
+# Dump content of a submission message in key/value IJE format
+dotnet run --project VRDR.CLI extract2ijecontent VRDR.CLI/1submit.json
 
 # Create a submission FHIR message wrapping a FHIR record
 dotnet run --project VRDR.CLI submit VRDR.CLI/1.json

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -427,7 +427,7 @@ namespace VRDR.CLI
             else if (args.Length == 2 && args[0] == "2ijecontent")
             { // dumps content of a death record in key/value IJE format
                 DeathRecord d = new DeathRecord(File.ReadAllText(args[1]));
-                IJEMortality ije1 = new IJEMortality(d);
+                IJEMortality ije1 = new IJEMortality(d, false);
                 // Loop over every property (these are the fields); Order by priority
                 List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Priority).ToList();
                 foreach (PropertyInfo property in properties)
@@ -700,7 +700,7 @@ namespace VRDR.CLI
                 {
                     case DeathRecordSubmissionMessage submission:
                         var d = submission.DeathRecord;
-                        IJEMortality ije1 = new IJEMortality(d);
+                        IJEMortality ije1 = new IJEMortality(d, false);
                         // Loop over every property (these are the fields); Order by priority
                         List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Priority).ToList();
                         foreach (PropertyInfo property in properties)

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -297,7 +297,7 @@ namespace VRDR.Tests
         {
             Assert.Equal(ValueSets.PlaceOfDeath.Death_In_Home, DeathRecord1_JSON.DeathLocationTypeHelper);
             Assert.Equal(ValueSets.PlaceOfDeath.Death_In_Hospital, DeathCertificateDocument1_JSON.DeathLocationTypeHelper);
-            Assert.Null(CauseOfDeathCodedContentBundle1_JSON.DeathLocationTypeHelper);
+            Assert.Equal("", CauseOfDeathCodedContentBundle1_JSON.DeathLocationType["code"]);
             Assert.Equal(ValueSets.PlaceOfDeath.Death_In_Home, DeathRecord1_XML.DeathLocationTypeHelper);
         }
         [Fact]
@@ -3222,7 +3222,7 @@ namespace VRDR.Tests
             Assert.Equal("000182", codedcontentbundle.Identifier);
             Assert.Equal("000000000042", codedcontentbundle.StateLocalIdentifier1);
             Assert.Equal("100000000001", codedcontentbundle.StateLocalIdentifier2);
-            Assert.Null(codedcontentbundle.DeathLocationType); // should be missing
+            Assert.Equal("", codedcontentbundle.DeathLocationType["code"]); // should be empty
             Assert.Null(codedcontentbundle.BirthDay); // should be missing
             // TODO: Fill out tests
         }
@@ -3237,7 +3237,7 @@ namespace VRDR.Tests
             Assert.Equal("000182", codedcontentbundle.Identifier);
             Assert.Equal("000000000042", codedcontentbundle.StateLocalIdentifier1);
             Assert.Equal("100000000001", codedcontentbundle.StateLocalIdentifier2);
-            Assert.Null(codedcontentbundle.DeathLocationType); // should be missing
+            Assert.Equal("", codedcontentbundle.DeathLocationType["code"]); // should be empty
             Assert.Null(codedcontentbundle.BirthDay); // should be missing
             // TODO: Fill out tests
         }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -1322,14 +1322,14 @@ namespace VRDR
             {
                 if (DeathCertification == null)
                 {
-                    return EmptyCodeDict();
+                    return EmptyCodeableDict();
                 }
                 Hl7.Fhir.Model.Procedure.PerformerComponent performer = DeathCertification.Performer.FirstOrDefault();
                 if (performer != null && performer.Function != null)
                 {
                     return CodeableConceptToDict(performer.Function);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -1422,7 +1422,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)MannerOfDeath.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -2617,7 +2617,7 @@ namespace VRDR
                         return CodeableConceptToDict((CodeableConcept)sex.Value);
                     }
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -3598,7 +3598,7 @@ namespace VRDR
                         return CodeableConceptToDict(contact.Relationship.FirstOrDefault());
                     }
                 }
-                return null;
+                return EmptyCodeableDict();
             }
             set
             {
@@ -3638,7 +3638,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)Decedent.MaritalStatus);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -3691,7 +3691,7 @@ namespace VRDR
                         return CodeableConceptToDict((CodeableConcept)addressExt.Value);
                     }
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -4317,7 +4317,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)DecedentEducationLevel.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -4696,7 +4696,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)MilitaryServiceObs.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -4981,7 +4981,7 @@ namespace VRDR
                 }
                 else
                 {
-                    return null;
+                    return EmptyAddrDict();
                 }
             }
             set
@@ -5202,7 +5202,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)DispositionMethod.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -5292,7 +5292,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)AutopsyPerformed.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -6001,7 +6001,7 @@ namespace VRDR
             {
                 if (AutopsyPerformed == null || AutopsyPerformed.Component == null)
                 {
-                    return EmptyCodeDict();
+                    return EmptyCodeableDict();
                 }
                 var performed = AutopsyPerformed.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null
                     && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69436-4");
@@ -6009,7 +6009,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)performed.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -6348,11 +6348,10 @@ namespace VRDR
                         return (CodeableConceptToDict((CodeableConcept)placeComp.Value));
                     }
                 }
-                return null;
+                return EmptyCodeableDict();
             }
             set
             {
-
                 if (DeathDateObs == null)
                 {
                     CreateDeathDateObs(); // Create it
@@ -6553,7 +6552,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)PregnancyObs.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -6708,7 +6707,7 @@ namespace VRDR
                     CodeableConcept cc = (CodeableConcept)ExaminerContactedObs.Value;
                     return CodeableConceptToDict(cc);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -7255,7 +7254,7 @@ namespace VRDR
                         return CodeableConceptToDict((CodeableConcept)placeComp.Value);
                     }
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -7456,7 +7455,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)TobaccoUseObs.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -7807,7 +7806,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)ActivityAtTimeOfDeathObs.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -7939,7 +7938,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)PlaceOfInjuryObs.Value);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -9837,7 +9836,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict(intentionalReject);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -9911,7 +9910,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict(acmeSystemReject);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {
@@ -9985,7 +9984,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict(transaxConversion);
                 }
-                return EmptyCodeDict();
+                return EmptyCodeableDict();
             }
             set
             {


### PR DESCRIPTION
This pull request

1. Updates DeathRecord to return the appropriate empty dictionary for all properties that are dictionaries
2. Updates the tests to align with this change
3. Incidentally makes CLI functions for extracting IJE content more flexible
4. Incidentally documents CLI functions where documentation was missing