### PR TITLE
NVSS-368: Don't restrict pregnancy to second position.

### DIFF
--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3175,13 +3175,13 @@ namespace VRDR.Tests
             Assert.Equal(2, racGet.Count());
             Assert.Equal(1, racGet.ElementAt(0).Position);
             Assert.Equal("T27.3", racGet.ElementAt(0).Code);
-            Assert.False(racGet.ElementAt(0).Pregnancy); // Pregnancy flag is only allowed in position 2
+            Assert.True(racGet.ElementAt(0).Pregnancy); // Pregnancy flag is not enforced as only allowed in position 2
             Assert.Equal(2, racGet.ElementAt(1).Position);
             Assert.Equal("T27.5", racGet.ElementAt(1).Code);
             Assert.True(racGet.ElementAt(1).Pregnancy);
 
             IJEMortality ije = new IJEMortality(SetterDeathRecord, false); // Don't validate since we don't care about most fields
-            string fmtRac = "T273 T2751".PadRight(100, ' ');
+            string fmtRac = "T2731T2751".PadRight(100, ' ');
             Assert.Equal(fmtRac, ije.RAC);
         }
 

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -9605,7 +9605,7 @@ namespace VRDR
 
                     // Record axis codes have an unusual and obscure handling of a Pregnancy flag, for more information see
                     // http://build.fhir.org/ig/HL7/vrdr/branches/master/StructureDefinition-vrdr-record-axis-cause-of-death.html#usage
-                    if (rac.Pregnancy && rac.Position == 2)
+                    if (rac.Pregnancy)
                     {
                         Observation.ComponentComponent pregComp = new Observation.ComponentComponent();
                         pregComp.Value = new FhirBoolean(true);


### PR DESCRIPTION
Allows more flexibility with WouldBeUnderlyingCauseOfDeathWithoutPregnancy flags.

This will include the (potentially invalid) flags in the IJE, which may not be desirable. If we don't want to pass along potentially problematic content into IJE, then some filtering logic should be added to the IJE conversion to ignore or reject it. For now, updated the test case to expect an extra 1.