### PR TITLE
fix bug submitted by Reece(ID) via zulip 

### DIFF
--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -7280,11 +7280,7 @@ namespace VRDR
                 CodeableConcept concept = InjuryIncidentObs?.Value as CodeableConcept;
                 if(concept != null)
                 {
-                    Dictionary<string, string> dict = CodeableConceptToDict(concept);
-                    if (dict.ContainsKey("text"))
-                    {
-                            return (dict["text"]);
-                    }
+                    return concept.Text;
                 }
                 return null;
             }

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -7277,9 +7277,9 @@ namespace VRDR
         {
             get
             {
-                if (InjuryIncidentObs?.Value != null && InjuryIncidentObs.Value as CodeableConcept != null)
+                CodeableConcept concept = InjuryIncidentObs?.Value as CodeableConcept;
                 {
-                    Dictionary<string, string> dict = CodeableConceptToDict((CodeableConcept)InjuryIncidentObs.Value);
+                    Dictionary<string, string> dict = CodeableConceptToDict(concept);
                     if (dict.ContainsKey("text"))
                     {
                             return (dict["text"]);

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -7278,6 +7278,7 @@ namespace VRDR
             get
             {
                 CodeableConcept concept = InjuryIncidentObs?.Value as CodeableConcept;
+                if(concept != null)
                 {
                     Dictionary<string, string> dict = CodeableConceptToDict(concept);
                     if (dict.ContainsKey("text"))

--- a/VRDR/DeathRecord.cs
+++ b/VRDR/DeathRecord.cs
@@ -7277,9 +7277,13 @@ namespace VRDR
         {
             get
             {
-                if (InjuryIncidentObs?.Value != null)
+                if (InjuryIncidentObs?.Value != null && InjuryIncidentObs.Value as CodeableConcept != null)
                 {
-                    return Convert.ToString(InjuryIncidentObs.Value);
+                    Dictionary<string, string> dict = CodeableConceptToDict((CodeableConcept)InjuryIncidentObs.Value);
+                    if (dict.ContainsKey("text"))
+                    {
+                            return (dict["text"]);
+                    }
                 }
                 return null;
             }
@@ -7292,7 +7296,7 @@ namespace VRDR
                 {
                     CreateInjuryIncidentObs();
                 }
-                InjuryIncidentObs.Value = new FhirString(value);
+                InjuryIncidentObs.Value = new CodeableConcept(null, null, null, value);
             }
         }
 


### PR DESCRIPTION
Fix bug with injury incident value that was encoded as valueString instead of value.text [see](https://chat.fhir.org/#narrow/stream/179301-Death-on-FHIR/topic/Injury.20Incident.20in.20CoD.20Coding.20Bundle)