### PR TITLE
Alias message support and Connectathon record generation updates

### DIFF
--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -23,7 +23,7 @@ namespace VRDR.CLI
 @"* VRDR Command Line Interface - commands
   - help:  prints this help message  (no arguments)
   - fakerecord: prints a fake XML death record (no arguments)
-  - connectathon: prints one of the 3 connectathon records (1 argument: the number (1,2, or 3) of the connectathon record)
+  - connectathon: prints one of the 3 connectathon records (3 arguments: the number (1,2, or 3) of the connectathon record, the certificate number, and the jurisdiction)
   - description: prints a verbose JSON description of the record (in the format used to drive Canary) (1 argument: the path to the death record)
   - 2ije: Read in the FHIR XML or JSON death record and print out as IJE (1 argument: path to death record in JSON or XML format)
   - 2ijecontent: Read in the FHIR XML or JSON death record and dump content  in key/value IJE format (1 argument: path to death record in JSON or XML format)
@@ -31,12 +31,11 @@ namespace VRDR.CLI
   - checkJson: Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs (1 argument: FHIR JSon file)
   - checkXml: Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs (1 argument: FHIR XML file)
   - compare: Compare an IJE record with a FHIR record by each IJE field (2 arguments:  IJE record, FHIR Record)
-  - connectathon: prints one of the 3 connectathon records (1 argument: the number (1,2, or 3) of the connectathon record)
   - description: prints a verbose JSON description of the record (in the format used to drive Canary) (1 argument: the path to the death record)
   - extract2ijecontent: Dump content of a submission message in key/value IJE format (1 argument: submission message)
   - extract: Extract a FHIR record from a FHIR message (1 argument: FHIR message)
   - fakerecord: prints a fake XML death record (no arguments)
-  - generatedrecords: Generate records for bulk testing based on the 3 connectathon testing records. (4 arguments: initial certificate number, number of records to generate (each with cert_no one greater than its predecessor), output directory (must exist), Submitting jurisdiction)
+  - generaterecords: Generate records for bulk testing based on the 3 connectathon testing records. (4+ arguments: initial certificate number, number of records to generate (each with cert_no one greater than its predecessor), submitting jurisdiction, output directory (must exist), optional year)
   - ije2json: Read in the IJE death record and print out as JSON (1 argument: path to death record in IJE format)
   - ije2xml: Read in the IJE death record and print out as XML (1 argument: path to death record in IJE format)
   - ije: Read in and parse an IJE death record and print out the values for every (supported) field (1 argument: path to death record in IJE format)
@@ -47,6 +46,7 @@ namespace VRDR.CLI
   - roundtrip-ije: Convert a record to IJE and back and check field by field to identify any conversion issues (1 argument: FHIR Death Record)
   - showcodes: Extract and show the codes in a coding response message (1 argument: coding response message)
   - submit: Create a submission FHIR message wrapping a FHIR death record (1 argument: FHIR death record)
+  - alias: Create an alias FHIR message for a FHIR death record (1 argument: FHIR death record)
   - toMortalityRoster: Create and print a mortality roster bundle from a death record (1 argument: FHIR death record)
   - trx2fhir: Creates a Cause of Death Coding Bundle from a TRX Message (1 argument: TRX file)
   - void: Creates a Void message for a Death Record (1 argument: FHIR death record)
@@ -768,6 +768,14 @@ namespace VRDR.CLI
                 Console.WriteLine(message.ToJSON(true));
                 return 0;
             }
+            else if (args.Length == 2 && args[0] == "alias")
+            {
+                DeathRecord record = new DeathRecord(File.ReadAllText(args[1]));
+                DeathRecordAliasMessage message = new DeathRecordAliasMessage(record);
+                message.MessageSource = "http://mitre.org/vrdr";
+                Console.WriteLine(message.ToJSON(true));
+                return 0;
+            }
             else if (args.Length == 2 && args[0] == "toMortalityRoster")
             {
                 DeathRecord record = new DeathRecord(File.ReadAllText(args[1]));
@@ -858,37 +866,57 @@ namespace VRDR.CLI
                 }
                 return 0;
             }
-            else if (args.Length == 5 && args[0] == "generaterecords")
+            else if (args.Length >= 5 && args[0] == "generaterecords")
             {
-                Console.WriteLine("generaterecords");
                 int start_certificate_number = Int16.Parse(args[1]);
                 int count = Int16.Parse(args[2]);
-                string output_directory = args[3];
-                string state = args[4];
-                if (start_certificate_number <= 0) {
+                string state = args[3];
+                string output_directory = args[4];
+                int year = DateTime.Today.Year;
+                if (args.Length > 5)
+                {
+                    year = Int16.Parse(args[5]);
+                }
+                if (start_certificate_number <= 0)
+                {
                     Console.WriteLine("Must supply a starting certificate number greater than 0");
                     return(1);
-                }else if (String.IsNullOrWhiteSpace(args[3]) || !Directory.Exists(args[3])){
-                    Console.WriteLine("Must supply a valid output directory");
-                    return(1);
-                }else if (count <= 0 ){
+                }
+                else if (count <= 0 )
+                {
                     Console.WriteLine("Must supply a count greater than 0");
                     return(1);
                 }
-                for (int i = 0; i < count; i += 1) {
-                   int certificate_number = start_certificate_number + i;
-                   string cert6 = certificate_number.ToString("D6");
-                   int record_selector = (i % 3) + 1;
-                   String file_name =  $"{output_directory}/{DateTime.Today.Year}{cert6}{state}.json";
-                   Console.WriteLine(file_name);
-                   StreamWriter sw = new StreamWriter(file_name);
-                   // FromId(int id, int? certificateNumber = null, string state = null)
-                   DeathRecord d = Connectathon.FromId(record_selector, certificate_number, state);
-                   sw.WriteLine(d.ToJson());
-                   sw.Flush();
+                else if (!Regex.IsMatch(state, "^[A-Z][A-Z]$"))
+                {
+                    Console.WriteLine("Must supply a valid two character jurisdiction code");
+                    return(1);
                 }
-            } else {
-                Console.WriteLine($"**** No such command {args[0]}");
+                else if (String.IsNullOrWhiteSpace(output_directory) || !Directory.Exists(output_directory))
+                {
+                    Console.WriteLine("Must supply a valid output directory");
+                    return(1);
+                }
+                else if (year < 1900 || year > 3000)
+                {
+                    Console.WriteLine("Must supply a valid year if supplying a year");
+                }
+                for (int i = 0; i < count; i += 1)
+                {
+                    int certificate_number = start_certificate_number + i;
+                    string cert6 = certificate_number.ToString("D6");
+                    int record_selector = (i % 3) + 1;
+                    DeathRecord record = Connectathon.FromId(record_selector, certificate_number, state, year);
+                    String file_name =  $"{output_directory}/{year}{state}{cert6}.json";
+                    Console.WriteLine($"Writing record to {file_name}");
+                    StreamWriter sw = new StreamWriter(file_name);
+                    sw.WriteLine(record.ToJson());
+                    sw.Flush();
+                }
+            }
+            else
+            {
+                Console.WriteLine($"**** No such command {args[0]} with the number of arguments supplied");
             }
             return 0;
         }

--- a/VRDR.Messaging/DeathRecordAliasMessage.cs
+++ b/VRDR.Messaging/DeathRecordAliasMessage.cs
@@ -3,7 +3,7 @@ using Hl7.Fhir.Model;
 
 namespace VRDR
 {
-    /// <summary>Class <c>DeathRecordAliasMessage</c> indicates that a previously submitted DeathRecordSubmissionMessage should be voided.</summary>
+    /// <summary>Class <c>DeathRecordAliasMessage</c> indicates that a previously submitted DeathRecordSubmissionMessage has alias information.</summary>
     public class DeathRecordAliasMessage : BaseMessage
     {
         /// <summary>
@@ -25,11 +25,35 @@ namespace VRDR
         {
         }
 
-        /// <summary>Constructor that takes a VRDR.DeathRecord and creates a message to void that record.</summary>
+        /// <summary>Constructor that takes a VRDR.DeathRecord and creates a message to submit an alias for that record.</summary>
         /// <param name="record">the VRDR.DeathRecord to create a DeathRecordAliasMessage for.</param>
         public DeathRecordAliasMessage(DeathRecord record) : this()
         {
             ExtractBusinessIdentifiers(record);
+            if (record.GivenNames.Length > 0)
+            {
+                AliasDecedentFirstName = record.GivenNames[0];
+            }
+            if (record.FamilyName != null)
+            {
+                AliasDecedentLastName = record.FamilyName;
+            }
+            if (record.GivenNames.Length > 1)
+            {
+                AliasDecedentMiddleName = record.GivenNames[1];
+            }
+            if (record.Suffix != null)
+            {
+                AliasDecedentNameSuffix = record.Suffix;
+            }
+            if (record.FatherFamilyName != null)
+            {
+                AliasFatherSurname = record.FatherFamilyName;
+            }
+            if (record.SSN != null)
+            {
+                AliasSocialSecurityNumber = record.SSN;
+            }
         }
 
         /// <summary>Alias for the decedent's first name</summary>

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -9,7 +9,7 @@ namespace VRDR
     public class Connectathon
     {
         /// <summary>Generate a DeathRecord from one of 5 pre-set records, providing an optional certificate number and state</summary>
-        public static DeathRecord FromId(int id, int? certificateNumber = null, string state = null)
+        public static DeathRecord FromId(int id, int? certificateNumber = null, string state = null, int? year = null)
         {
             DeathRecord record = null;
             switch (id)
@@ -25,14 +25,19 @@ namespace VRDR
                     break;
             }
 
+            if (record != null && certificateNumber != null)
+            {
+                record.Identifier = certificateNumber.ToString();
+            }
+
             if (record != null && state != null)
             {
                 record.DeathLocationJurisdiction = state;
             }
 
-            if (record != null && certificateNumber != null)
+            if (record != null && year != null)
             {
-                record.Identifier = certificateNumber.ToString();
+                record.DeathYear = (uint)year;
             }
 
             return record;

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -118,7 +118,7 @@
         <member name="T:VRDR.Connectathon">
             <summary>Class <c>Connectathon</c> provides static methods for generating records used in Connectathon testing, used in Canary and in the CLI tool</summary>
         </member>
-        <member name="M:VRDR.Connectathon.FromId(System.Int32,System.Nullable{System.Int32},System.String)">
+        <member name="M:VRDR.Connectathon.FromId(System.Int32,System.Nullable{System.Int32},System.String,System.Nullable{System.Int32})">
             <summary>Generate a DeathRecord from one of 5 pre-set records, providing an optional certificate number and state</summary>
         </member>
         <member name="M:VRDR.Connectathon.TwilaHilty">


### PR DESCRIPTION
This pull request includes two small unrelated updates

1. Improves support for Alias messages, including
    1. Alias message generation from a record pulls in the appropriate data from that record
    2. The CLI can generate an alias message from a record
    3. Code cleanup (fixed some copy pasta comments)
2. Improves support for generating Connectathon records, including
    1. Allowing an optional year to be specified when generating many connectathon records
    2. Getting the order of fields right in the file name
    3. Code cleanup