### PR TITLE
support NCHS 5 character ICD-like codes (without period) on all coded…

### DIFF
--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3205,7 +3205,7 @@ namespace VRDR.Tests
             Assert.True(racGet.ElementAt(1).Pregnancy);
 
             IJEMortality ije = new IJEMortality(SetterDeathRecord, false); // Don't validate since we don't care about most fields
-            string fmtRac = "T273 1T275 1".PadRight(100, ' ');
+            string fmtRac = "T2731T2751".PadRight(100, ' ');
             Assert.Equal(fmtRac, ije.RAC);
         }
 

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3143,16 +3143,21 @@ namespace VRDR.Tests
         [Fact]
         public void Set_EntityAxisCodes()
         {
-            SetterDeathRecord.EntityAxisCauseOfDeath = new[] { (LineNumber: 2, Position: 1, Code: "T27.3", ECode: true) };
+            SetterDeathRecord.EntityAxisCauseOfDeath = new[] { (LineNumber: 2, Position: 1, Code: "T27.3", ECode: true),
+                                                               (LineNumber: 2, Position: 3, Code: "K27.10", ECode: false) };
             var eacGet = SetterDeathRecord.EntityAxisCauseOfDeath;
-            Assert.Single(eacGet);
+            Assert.Equal(2,eacGet.Count());
             Assert.Equal(2, eacGet.ElementAt(0).LineNumber);
             Assert.Equal(1, eacGet.ElementAt(0).Position);
             Assert.Equal("T27.3", eacGet.ElementAt(0).Code);
             Assert.True(eacGet.ElementAt(0).ECode);
+            Assert.Equal(2, eacGet.ElementAt(1).LineNumber);
+            Assert.Equal(3, eacGet.ElementAt(1).Position);
+            Assert.Equal("K27.10", eacGet.ElementAt(1).Code);
+            Assert.False(eacGet.ElementAt(1).ECode);
 
             IJEMortality ije = new IJEMortality(SetterDeathRecord, false); // Don't validate since we don't care about most fields
-            string fmtEac = "21T273 &".PadRight(160, ' ');
+            string fmtEac = "21T273 &23K2710".PadRight(160, ' ');
             Assert.Equal(fmtEac, ije.EAC);
         }
 

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3291,8 +3291,8 @@ namespace VRDR.Tests
             ije.FILENO = "578660";
             ije.MAN_UC = "I219";
             ije.EAC = "21I219  31I251  61E119  62F179  63I10   64E780  ";
-            ije.RAC = "I219  E119  E780  F179  I10   I251  ";
-            Assert.Equal("I219  E119  E780  F179  I10   I251  ".PadRight(100), ije.RAC);
+            ije.RAC = "I219 E119 E780 F179 I10  I251 ";
+            Assert.Equal("I219 E119 E780 F179 I10  I251 ".PadRight(100), ije.RAC);
             ije.AUXNO = "579927";
             ije.MFILED = "0";
             ije.MANNER = "N";
@@ -3316,7 +3316,7 @@ namespace VRDR.Tests
             Assert.Equal("578660", ije2.FILENO);
             Assert.Equal("I219", ije2.MAN_UC);
             Assert.Equal("21I219  31I251  61E119  62F179  63I10   64E780".PadRight(160), ije2.EAC);
-            Assert.Equal("I219  E119  E780  F179  I10   I251  ".PadRight(100), ije2.RAC);
+            Assert.Equal("I219 E119 E780 F179 I10  I251  ".PadRight(100), ije2.RAC);
             Assert.Equal("579927".PadLeft(12, '0'), ije2.AUXNO);
             Assert.Equal("0", ije2.MFILED);
             Assert.Equal("N", ije2.MANNER);

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3205,7 +3205,7 @@ namespace VRDR.Tests
             Assert.True(racGet.ElementAt(1).Pregnancy);
 
             IJEMortality ije = new IJEMortality(SetterDeathRecord, false); // Don't validate since we don't care about most fields
-            string fmtRac = "T2731T2751".PadRight(100, ' ');
+            string fmtRac = "T273 1T275 1".PadRight(100, ' ');
             Assert.Equal(fmtRac, ije.RAC);
         }
 
@@ -3290,8 +3290,9 @@ namespace VRDR.Tests
             ije.DSTATE = "MA";
             ije.FILENO = "578660";
             ije.MAN_UC = "I219";
-            ije.EAC = "21I219  31I251  61E119  62F179  63I10   64E780";
-            ije.RAC = "I219 E119 E780 F179 I10  I251";
+            ije.EAC = "21I219  31I251  61E119  62F179  63I10   64E780  ";
+            ije.RAC = "I219  E119  E780  F179  I10   I251  ";
+            Assert.Equal("I219  E119  E780  F179  I10   I251  ".PadRight(100), ije.RAC);
             ije.AUXNO = "579927";
             ije.MFILED = "0";
             ije.MANNER = "N";
@@ -3315,7 +3316,7 @@ namespace VRDR.Tests
             Assert.Equal("578660", ije2.FILENO);
             Assert.Equal("I219", ije2.MAN_UC);
             Assert.Equal("21I219  31I251  61E119  62F179  63I10   64E780".PadRight(160), ije2.EAC);
-            Assert.Equal("I219 E119 E780 F179 I10  I251".PadRight(100), ije2.RAC);
+            Assert.Equal("I219  E119  E780  F179  I10   I251  ".PadRight(100), ije2.RAC);
             Assert.Equal("579927".PadLeft(12, '0'), ije2.AUXNO);
             Assert.Equal("0", ije2.MFILED);
             Assert.Equal("N", ije2.MANNER);

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -1709,7 +1709,7 @@ namespace VRDR
                         CodeableConcept valueCC = (CodeableConcept)ob.Value;
                         if (valueCC != null && valueCC.Coding != null && valueCC.Coding.Count() > 0)
                         {
-                            icd10code = valueCC.Coding[0].Code;
+                            icd10code = valueCC.Coding[0].Code.Trim();
                         }
                         Observation.ComponentComponent ecodeComp = ob.Component.Where(c => c.Code.Coding[0].Code == "eCodeIndicator").FirstOrDefault();
                         if (ecodeComp != null && ecodeComp.Value != null)

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -777,26 +777,28 @@ namespace VRDR
         /// <summary>NCHS ICD10 to actual ICD10 </summary>
         private string NCHSICD10toActualICD10(string nchsicd10code)
         {
-            Regex ICD10rgx = new Regex(@"^[A-Z]\d{2}(\.\d){0,1}$");  // ICD10 codes only have one character after the decimal
-            Regex NCHSICD10rgx = new Regex(@"^[A-Z]\d{2,4}$");       // NCHS tacks on an extra character to some ICD10 codes, e.g., K7210 (K27.10)
-            string code;
-            nchsicd10code = nchsicd10code.Trim();
-            if (ICD10rgx.IsMatch(nchsicd10code))
+            // ICD-10 diagnosis codes always begin with a letter (except U) followed by a digit.
+            // The third character is usually a digit, but could be an A or B [1].
+            // After the first three characters, there may be a decimal point, and up to three more alphanumeric characters.
+            // These alphanumeric characters are never U. Sometimes the decimal is left out.
+            // Regex ICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB].?[0-9A-TV-Z]{0,4}$");
+            // NCHS ICD10 codes are the same as above for the first three characters.
+            // The decimal point is always dropped.
+            // Some codes have a fourth character that reflects an actual ICD10 code.
+            // NCHS tacks on an extra character to some ICD10 codes, e.g., K7210 (K27.10)
+            // Regex NCHSICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB][0-9A-TV-Z]{0,2}$");
+            string code = "";
+
+            if (!String.IsNullOrEmpty(nchsicd10code))
             {
-                code = nchsicd10code;
+                 code = nchsicd10code.Trim();
             }
-            else
+
+            if (code.Length >= 4)    // codes of length 4 or 5 need to have a decimal inserted
             {
-                code = "";
-                if (NCHSICD10rgx.IsMatch(nchsicd10code))
-                {
-                    code = nchsicd10code;
-                    if (nchsicd10code.Length >= 4)    // codes of length 4 or 5 need to have a decimal inserted
-                    {
-                        code = nchsicd10code.Insert(3, ".");
-                    }
-                }
+                code = nchsicd10code.Insert(3, ".");
             }
+
             return (code);
         }
         /// <summary>Actual ICD10 to NCHS ICD10 </summary>

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -791,7 +791,7 @@ namespace VRDR
 
             if (!String.IsNullOrEmpty(nchsicd10code))
             {
-                 code = nchsicd10code.Trim();
+                code = nchsicd10code.Trim();
             }
 
             if (code.Length >= 4)    // codes of length 4 or 5 need to have a decimal inserted

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -2693,7 +2693,7 @@ namespace VRDR
                 foreach ((int Position, string Code, bool Pregnancy) entry in record.RecordAxisCauseOfDeath)
                 {
                     // Position doesn't appear in the IJE/TRX format it's just implicit
-                    string icdCode = Truncate(ActualICD10toNCHSICD10(entry.Code), 5).PadRight(5, ' ');
+                    string icdCode = Truncate(ActualICD10toNCHSICD10(entry.Code), 4).PadRight(4, ' ');
                     string preg = entry.Pregnancy ? "1" : " ";
                     racStr += icdCode + preg;
                 }
@@ -2704,14 +2704,14 @@ namespace VRDR
             {
                 List<(int Position, string Code, bool Pregnancy)> rac = new List<(int Position, string Code, bool Pregnancy)>();
                 string paddedValue = value.PadRight(100); // Accept input that's missing white space padding to the right
-                IEnumerable<string> codes = Enumerable.Range(0, paddedValue.Length / 6).Select(i => paddedValue.Substring(i * 6, 6));
+                IEnumerable<string> codes = Enumerable.Range(0, paddedValue.Length / 5).Select(i => paddedValue.Substring(i * 5, 5));
                 int position = 1;
                 foreach (string code in codes)
                 {
                     if (!String.IsNullOrWhiteSpace(code))
                     {
-                        string icdCode = NCHSICD10toActualICD10(code.Substring(0, 5));
-                        string preg = code.Substring(5, 1);
+                        string icdCode = NCHSICD10toActualICD10(code.Substring(0, 4));
+                        string preg = code.Substring(4, 1);
                         Tuple<string, string, string> entry = Tuple.Create(Convert.ToString(position), icdCode, preg);
                         rac.Add((Position: position, Code: icdCode, Pregnancy: preg == "1"));
                     }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -2704,14 +2704,14 @@ namespace VRDR
             {
                 List<(int Position, string Code, bool Pregnancy)> rac = new List<(int Position, string Code, bool Pregnancy)>();
                 string paddedValue = value.PadRight(100); // Accept input that's missing white space padding to the right
-                IEnumerable<string> codes = Enumerable.Range(0, paddedValue.Length / 5).Select(i => paddedValue.Substring(i * 5, 5));
+                IEnumerable<string> codes = Enumerable.Range(0, paddedValue.Length / 6).Select(i => paddedValue.Substring(i * 6, 6));
                 int position = 1;
                 foreach (string code in codes)
                 {
                     if (!String.IsNullOrWhiteSpace(code))
                     {
-                        string icdCode = NCHSICD10toActualICD10(code.Substring(0, 4));
-                        string preg = code.Substring(4, 1);
+                        string icdCode = NCHSICD10toActualICD10(code.Substring(0, 5));
+                        string preg = code.Substring(5, 1);
                         Tuple<string, string, string> entry = Tuple.Create(Convert.ToString(position), icdCode, preg);
                         rac.Add((Position: position, Code: icdCode, Pregnancy: preg == "1"));
                     }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -777,8 +777,8 @@ namespace VRDR
         /// <summary>NCHS ICD10 to actual ICD10 </summary>
         private string NCHSICD10toActualICD10(string nchsicd10code)
         {
-            Regex ICD10rgx = new Regex(@"^[A-Z]\d{2}(\.\d){0,1}$");
-            Regex NCHSICD10rgx = new Regex(@"^[A-Z]\d{2,3}$");
+            Regex ICD10rgx = new Regex(@"^[A-Z]\d{2}(\.\d){0,1}$");  // ICD10 codes only have one character after the decimal
+            Regex NCHSICD10rgx = new Regex(@"^[A-Z]\d{2,4}$");       // NCHS tacks on an extra character to some ICD10 codes, e.g., K7210 (K27.10)
             string code;
             nchsicd10code = nchsicd10code.Trim();
             if (ICD10rgx.IsMatch(nchsicd10code))
@@ -788,11 +788,10 @@ namespace VRDR
             else
             {
                 code = "";
-                //if(value.Length == 4 && value[value.Length-1] != '.'){
                 if (NCHSICD10rgx.IsMatch(nchsicd10code))
                 {
                     code = nchsicd10code;
-                    if (nchsicd10code.Length == 4)
+                    if (nchsicd10code.Length >= 4)    // codes of length 4 or 5 need to have a decimal inserted
                     {
                         code = nchsicd10code.Insert(3, ".");
                     }
@@ -2636,10 +2635,9 @@ namespace VRDR
                 {
                     string lineNumber = Truncate(entry.LineNumber.ToString(), 1).PadRight(1, ' ');
                     string position = Truncate(entry.Position.ToString(), 1).PadRight(1, ' ');
-                    string icdCode = Truncate(ActualICD10toNCHSICD10(entry.Code), 4).PadRight(4, ' '); ;
-                    string reserved = " ";
+                    string icdCode = Truncate(ActualICD10toNCHSICD10(entry.Code), 5).PadRight(5, ' '); ;
                     string eCode = entry.ECode ? "&" : " ";
-                    eacStr += lineNumber + position + icdCode + reserved + eCode;
+                    eacStr += lineNumber + position + icdCode + eCode;
                 }
                 string fmtEac = Truncate(eacStr, 160).PadRight(160, ' ');
                 return fmtEac;
@@ -2655,7 +2653,7 @@ namespace VRDR
                     {
                         if (int.TryParse(code.Substring(0, 1), out int lineNumber) && int.TryParse(code.Substring(1, 1), out int position))
                         {
-                            string icdCode = NCHSICD10toActualICD10(code.Substring(2, 4));
+                            string icdCode = NCHSICD10toActualICD10(code.Substring(2, 5));
                             string eCode = code.Substring(7, 1);
                             eac.Add((LineNumber: lineNumber, Position: position, Code: icdCode, ECode: eCode == "&"));
                         }
@@ -2695,7 +2693,7 @@ namespace VRDR
                 foreach ((int Position, string Code, bool Pregnancy) entry in record.RecordAxisCauseOfDeath)
                 {
                     // Position doesn't appear in the IJE/TRX format it's just implicit
-                    string icdCode = Truncate(ActualICD10toNCHSICD10(entry.Code), 4).PadRight(4, ' ');
+                    string icdCode = Truncate(ActualICD10toNCHSICD10(entry.Code), 5).PadRight(5, ' ');
                     string preg = entry.Pregnancy ? "1" : " ";
                     racStr += icdCode + preg;
                 }


### PR DESCRIPTION
… fields

All ICD10 fields except RAC are 5 characters (with 5th documented as 'reserved').
RAC uses 5th position for pregnancy indicator.
All fields except RAC are now 5-character capable.

Simplified the conversion between NCHS and official ICD10 formats.   The regular expressions are interesting as documentation, but irrelevant for the actual conversion which involves adding or deleting a decimal point.
