### PR TITLE
Null checks and release v4.0.0-preview11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v4.0.0-preview11 - 2022-09-19
+
+* Fixed null object reference issue when retrieving message ID
+
 ### v4.0.0-preview10 - 2022-09-19
 
 * Fixed date handling to correctly distinguish between unknown and unset

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>4.0.0-preview10</Version>
+        <Version>4.0.0-preview11</Version>
         <ProjectUrl>https://github.com/nightingaleproject/vrdr-dotnet</ProjectUrl>
         <RepositoryUrl>https://github.com/nightingaleproject/vrdr-dotnet</RepositoryUrl>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ This repository includes .NET (C#) code for
 <td style="text-align: center;"><a href="http://build.fhir.org/ig/HL7/vrdr/">STU2 v1.3</a></td>
 <td style="text-align: center;"><a href="http://build.fhir.org/ig/nightingaleproject/vital_records_fhir_messaging_ig/branches/main/index.html">v0.9</a></td>
 <td style="text-align: center;">R4</td>
-<td style="text-align: center;">V4.0.0-preview10</td>
-<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR/4.0.0-preview10">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0-preview10"> github</a></td>
-<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR.Messaging/4.0.0-preview10">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0-preview10"> github</a></td>
+<td style="text-align: center;">V4.0.0-preview11</td>
+<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR/4.0.0-preview11">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0-preview11"> github</a></td>
+<td style="text-align: center;"><a href="https://www.nuget.org/packages/VRDR.Messaging/4.0.0-preview11">nuget</a> <a href="https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/4.0.0-preview11"> github</a></td>
 </tr>
 </tbody>
 </table>
@@ -78,7 +78,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR" Version="4.0.0-preview10" />
+  <PackageReference Include="VRDR" Version="4.0.0-preview11" />
   ...
 </ItemGroup>
 ```
@@ -275,7 +275,7 @@ This package is published on NuGet, so including it is as easy as:
 ```xml
 <ItemGroup>
   ...
-  <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview10" />
+  <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview11" />
   ...
 </ItemGroup>
 ```

--- a/VRDR.Messaging/AcknowledgementMessage.cs
+++ b/VRDR.Messaging/AcknowledgementMessage.cs
@@ -56,7 +56,7 @@ namespace VRDR
         {
             get
             {
-                return Header.Response.Identifier;
+                return Header?.Response?.Identifier;
             }
             set
             {

--- a/VRDR.Messaging/AcknowledgementMessage.cs
+++ b/VRDR.Messaging/AcknowledgementMessage.cs
@@ -60,6 +60,11 @@ namespace VRDR
             }
             set
             {
+                if (Header.Response == null)
+                {
+                    Header.Response = new MessageHeader.ResponseComponent();
+                    Header.Response.Code = MessageHeader.ResponseType.Ok;
+                }
                 Header.Response.Identifier = value;
             }
         }

--- a/VRDR.Messaging/CauseOfDeathCodingMessage.cs
+++ b/VRDR.Messaging/CauseOfDeathCodingMessage.cs
@@ -110,8 +110,8 @@ namespace VRDR
                 if (Header.Response == null)
                 {
                     Header.Response = new MessageHeader.ResponseComponent();
+                    Header.Response.Code = MessageHeader.ResponseType.Ok;
                 }
-                Header.Response.Code = MessageHeader.ResponseType.Ok;
                 Header.Response.Identifier = value;
             }
         }

--- a/VRDR.Messaging/CauseOfDeathCodingMessage.cs
+++ b/VRDR.Messaging/CauseOfDeathCodingMessage.cs
@@ -99,7 +99,7 @@ namespace VRDR
 
         /// <summary>The id of the death record submission/update message that was coded to produce the content of this message</summary>
         /// <value>the message id.</value>
-        public string SubmittedMessageId
+        public string CodedMessageId
         {
             get
             {

--- a/VRDR.Messaging/CauseOfDeathCodingMessage.cs
+++ b/VRDR.Messaging/CauseOfDeathCodingMessage.cs
@@ -103,7 +103,7 @@ namespace VRDR
         {
             get
             {
-                return Header.Response.Identifier;
+                return Header?.Response?.Identifier;
             }
             set
             {

--- a/VRDR.Messaging/DemographicsCodingMessage.cs
+++ b/VRDR.Messaging/DemographicsCodingMessage.cs
@@ -97,7 +97,7 @@ namespace VRDR
         }
         /// <summary>The id of the death record submission/update message that was coded to produce the content of this message</summary>
         /// <value>the message id.</value>
-        public string SubmittedMessageId
+        public string CodedMessageId
         {
             get
             {

--- a/VRDR.Messaging/DemographicsCodingMessage.cs
+++ b/VRDR.Messaging/DemographicsCodingMessage.cs
@@ -101,7 +101,7 @@ namespace VRDR
         {
             get
             {
-                return Header.Response.Identifier;
+                return Header?.Response?.Identifier;
             }
             set
             {

--- a/VRDR.Messaging/DemographicsCodingMessage.cs
+++ b/VRDR.Messaging/DemographicsCodingMessage.cs
@@ -108,8 +108,8 @@ namespace VRDR
                 if (Header.Response == null)
                 {
                     Header.Response = new MessageHeader.ResponseComponent();
+                    Header.Response.Code = MessageHeader.ResponseType.Ok;
                 }
-                Header.Response.Code = MessageHeader.ResponseType.Ok;
                 Header.Response.Identifier = value;
             }
         }

--- a/VRDR.Messaging/ErrorMessage.cs
+++ b/VRDR.Messaging/ErrorMessage.cs
@@ -70,6 +70,11 @@ namespace VRDR
             }
             set
             {
+                if (Header.Response == null)
+                {
+                    Header.Response = new MessageHeader.ResponseComponent();
+                    Header.Response.Code = MessageHeader.ResponseType.FatalError;
+                }
                 Header.Response.Identifier = value;
             }
         }

--- a/VRDR.Messaging/ErrorMessage.cs
+++ b/VRDR.Messaging/ErrorMessage.cs
@@ -66,7 +66,7 @@ namespace VRDR
         {
             get
             {
-                return Header.Response.Identifier;
+                return Header?.Response?.Identifier;
             }
             set
             {

--- a/VRDR.Messaging/StatusMessage.cs
+++ b/VRDR.Messaging/StatusMessage.cs
@@ -61,6 +61,11 @@ namespace VRDR
             }
             set
             {
+                if (Header.Response == null)
+                {
+                    Header.Response = new MessageHeader.ResponseComponent();
+                    Header.Response.Code = MessageHeader.ResponseType.Ok;
+                }
                 Header.Response.Identifier = value;
             }
         }

--- a/VRDR.Messaging/StatusMessage.cs
+++ b/VRDR.Messaging/StatusMessage.cs
@@ -57,7 +57,7 @@ namespace VRDR
         {
             get
             {
-                return Header.Response.Identifier;
+                return Header?.Response?.Identifier;
             }
             set
             {

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -243,7 +243,7 @@ namespace VRDR.Tests
             DeathRecordSubmissionMessage submission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
             CauseOfDeathCodingMessage coding = new CauseOfDeathCodingMessage(submission);
             Assert.Equal("http://nchs.cdc.gov/vrdr_causeofdeath_coding", coding.MessageType);
-            Assert.Equal(submission.MessageId, coding.SubmittedMessageId);
+            Assert.Equal(submission.MessageId, coding.CodedMessageId);
             Assert.Equal(submission.MessageSource, coding.MessageDestination);
             Assert.Equal(submission.MessageDestination, coding.MessageSource);
             Assert.Equal(submission.StateAuxiliaryId, coding.StateAuxiliaryId);
@@ -253,7 +253,7 @@ namespace VRDR.Tests
             submission = null;
             coding = new CauseOfDeathCodingMessage(submission);
             Assert.Equal("http://nchs.cdc.gov/vrdr_causeofdeath_coding", coding.MessageType);
-            Assert.Null(coding.SubmittedMessageId);
+            Assert.Null(coding.CodedMessageId);
             Assert.Null(coding.MessageDestination);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", coding.MessageSource);
             Assert.Null(coding.CertNo);
@@ -263,7 +263,7 @@ namespace VRDR.Tests
             submission = new DeathRecordSubmissionMessage();
             coding = new CauseOfDeathCodingMessage(submission);
             Assert.Equal("http://nchs.cdc.gov/vrdr_causeofdeath_coding", coding.MessageType);
-            Assert.Equal(submission.MessageId, coding.SubmittedMessageId);
+            Assert.Equal(submission.MessageId, coding.CodedMessageId);
             Assert.Equal(submission.MessageSource, coding.MessageDestination);
             Assert.Equal(submission.MessageDestination, coding.MessageSource);
             Assert.Equal(submission.StateAuxiliaryId, coding.StateAuxiliaryId);
@@ -277,7 +277,7 @@ namespace VRDR.Tests
             DeathRecordSubmissionMessage submission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
             DemographicsCodingMessage coding = new DemographicsCodingMessage(submission);
             Assert.Equal("http://nchs.cdc.gov/vrdr_demographics_coding", coding.MessageType);
-            Assert.Equal(submission.MessageId, coding.SubmittedMessageId);
+            Assert.Equal(submission.MessageId, coding.CodedMessageId);
             Assert.Equal(submission.MessageSource, coding.MessageDestination);
             Assert.Equal(submission.MessageDestination, coding.MessageSource);
             Assert.Equal(submission.StateAuxiliaryId, coding.StateAuxiliaryId);
@@ -287,7 +287,7 @@ namespace VRDR.Tests
             submission = null;
             coding = new DemographicsCodingMessage(submission);
             Assert.Equal("http://nchs.cdc.gov/vrdr_demographics_coding", coding.MessageType);
-            Assert.Null(coding.SubmittedMessageId);
+            Assert.Null(coding.CodedMessageId);
             Assert.Null(coding.MessageDestination);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", coding.MessageSource);
             Assert.Null(coding.CertNo);
@@ -297,7 +297,7 @@ namespace VRDR.Tests
             submission = new DeathRecordSubmissionMessage();
             coding = new DemographicsCodingMessage(submission);
             Assert.Equal("http://nchs.cdc.gov/vrdr_demographics_coding", coding.MessageType);
-            Assert.Equal(submission.MessageId, coding.SubmittedMessageId);
+            Assert.Equal(submission.MessageId, coding.CodedMessageId);
             Assert.Equal(submission.MessageSource, coding.MessageDestination);
             Assert.Equal(submission.MessageDestination, coding.MessageSource);
             Assert.Equal(submission.StateAuxiliaryId, coding.StateAuxiliaryId);
@@ -484,7 +484,7 @@ namespace VRDR.Tests
             CauseOfDeathCodingMessage message = new CauseOfDeathCodingMessage(ije.ToDeathRecord());
             message.MessageSource = "http://nchs.cdc.gov/vrdr_submission";
             message.MessageDestination = "https://example.org/jurisdiction/endpoint";
-            message.SubmittedMessageId = "378888";
+            message.CodedMessageId = "378888";
             Assert.Equal(CauseOfDeathCodingMessage.MESSAGE_TYPE, message.MessageType);
             Assert.Equal("http://nchs.cdc.gov/vrdr_submission", message.MessageSource);
             Assert.Equal("https://example.org/jurisdiction/endpoint", message.MessageDestination);
@@ -492,7 +492,7 @@ namespace VRDR.Tests
             Assert.Equal((uint)2022, message.DeathYear);
             Assert.Equal("500", message.StateAuxiliaryId);
             Assert.Equal("2022YC000123", message.NCHSIdentifier);
-            Assert.Equal("378888", message.SubmittedMessageId);
+            Assert.Equal("378888", message.CodedMessageId);
             Assert.Equal("T27.3", message.DeathRecord.AutomatedUnderlyingCOD);
             var recordAxisCodes = message.DeathRecord.RecordAxisCauseOfDeath;
             Assert.Equal(2, recordAxisCodes.Count());


### PR DESCRIPTION
This pull request

* Re-adds the missing "SubmittedMessageId-->CodedMessageID" commit
* Fixes a null object issue when pulling out a Message Identifier
* Bumps our version to v4.0.0-preview11
* Updates our CHANGELOG with release information
* Updates our README with new version information