### PR TITLE
Multiple bug fixes

### DIFF
--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -903,6 +903,11 @@ namespace VRDR.CLI
                 if (args.Length == 2)
                 {
                     DeathRecord d = new DeathRecord(File.ReadAllText(args[1]));
+                    if (d.DeathRecordIdentifier == null)
+                    {
+                        Console.WriteLine("Error: command json2mre requires a Coded Demographic Bundle; did you pass in a message?");
+                        return(1);
+                    }
                     IJEMortality ije = new IJEMortality(d, false);
                     ije.DOD_YR = d.DeathRecordIdentifier.Substring(0, 4);
                     ije.DSTATE = d.DeathRecordIdentifier.Substring(4, 2);
@@ -920,6 +925,11 @@ namespace VRDR.CLI
                 if (args.Length == 2)
                 {
                     DeathRecord d = new DeathRecord(File.ReadAllText(args[1]));
+                    if (d.DeathRecordIdentifier == null)
+                    {
+                        Console.WriteLine("Error: command json2trx requires a Coded Cause Of Death Bundle; did you pass in a message?");
+                        return(1);
+                    }
                     IJEMortality ije = new IJEMortality(d, false);
                     ije.DOD_YR = d.DeathRecordIdentifier.Substring(0, 4);
                     ije.DSTATE = d.DeathRecordIdentifier.Substring(4, 2);

--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -281,7 +281,7 @@ namespace VRDR
         protected void SetSingleStringValue(string key, string value)
         {
             Record.Remove(key);
-            if (value != null)
+            if (!String.IsNullOrWhiteSpace(value))
             {
                 Record.Add(key, new FhirString(value));
             }

--- a/VRDR.Messaging/StatusMessage.cs
+++ b/VRDR.Messaging/StatusMessage.cs
@@ -3,23 +3,23 @@ using Hl7.Fhir.Model;
 
 namespace VRDR
 {
-    /// <summary>Class <c>DeathRecordVoidMessage</c> indicates that a previously submitted DeathRecordSubmissionMessage should be voided.</summary>
+    /// <summary>Class <c>StatusMessage</c> provides a status update to a jurisdiction about a previously submitted message.</summary>
     public class StatusMessage : BaseMessage
     {
         /// <summary>
-        /// The Event URI for DeathRecordVoidMessage
+        /// The Event URI for StatusMessage
         /// </summary>
         public const string MESSAGE_TYPE = "http://nchs.cdc.gov/vrdr_status";
 
-        /// <summary>Default constructor that creates a new, empty DeathRecordVoidMessage.</summary>
+        /// <summary>Default constructor that creates a new, empty StatusMessage.</summary>
         public StatusMessage() : base(MESSAGE_TYPE)
         {
         }
 
         /// <summary>
-        /// Construct a DeathRecordVoidMessage from a FHIR Bundle.
+        /// Construct a StatusMessage from a FHIR Bundle.
         /// </summary>
-        /// <param name="messageBundle">a FHIR Bundle that will be used to initialize the DeathRecordVoidMessage</param>
+        /// <param name="messageBundle">a FHIR Bundle that will be used to initialize the StatusMessage</param>
         /// <returns></returns>
         internal StatusMessage(Bundle messageBundle) : base(messageBundle)
         {

--- a/VRDR.Tests/Messaging_Should.cs
+++ b/VRDR.Tests/Messaging_Should.cs
@@ -940,6 +940,19 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void CreateAliasForRecordWithEmptyMiddleNameString()
+        {
+            // This is a regression test for a bug where an empty middle name field led to an empty string in the alias
+            DeathRecord record = new DeathRecord();
+            record.Identifier = "321";
+            record.DeathLocationJurisdiction = "MA";
+            record.DeathYear = 2022;
+            record.GivenNames = new string[] { "Rocket", "" };
+            DeathRecordAliasMessage message = new DeathRecordAliasMessage(record);
+            Assert.Null(message.AliasDecedentMiddleName);
+        }
+
+        [Fact]
         public void SelectMessageType()
         {
             var msg = BaseMessage.Parse(FixtureStream("fixtures/json/AcknowledgementMessage.json"), false);


### PR DESCRIPTION
This pull request

1. Updates comments in the StatusMessage code to correct copy paste errors
2. Catches a potential null reference exception in the CLI in a case where a user passes a message instead of a record (should we consider updating the CLI to accept a record or message in all cases where a record can be specified?)
3. Fixes a bug that allowed alias message fields (and really any message fields) to contain blank strings, which are not allowed in FHIR