### PR TITLE
Fixed an issue due to blank race value fields.

### DIFF
--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -2534,6 +2534,12 @@ namespace VRDR
                         // convert boolean race codes to strings
                         if (booleanRaceCodes.Contains(raceCode))
                         {
+                            if (component.Value == null) {
+                              // If there is no value given, set the race to blank.
+                              var race = Tuple.Create(raceCode, "");
+                              races.Add(race);
+                              continue;
+                            }
 
                             // Todo Find conversion from FhirBoolean to bool
                             string raceBool = ((FhirBoolean)component.Value).ToString();


### PR DESCRIPTION
Fixed an issue where, if the valueBoolean for a race component in an input FHIR JSON was missing, vrdr would crash. To resolve this, when there's a missing valueBoolean for race, it will set that value to blank.