### PR TITLE
Improve handling of dates and times that are explicitly unknown vs just unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ Console.WriteLine($"Date/Time of Death: {deathRecord.DateOfDeath}");
 Console.WriteLine($"Cause of Death Part I, Line a: {deathRecord.COD1A}");
 Console.WriteLine($"Cause of Death Part I Interval, Line a: {deathRecord.INTERVAL1A}");
 ```
+#### Specifying that a date or time is explicitly unknown
+
+When specifying a date or time it is important to be able to differentiate between "we explicitly
+don't know the date, and we're telling you that we don't know it" and just not setting a date
+property at all. For this reason the date and time properties on the DeathRecord class support the
+special value of -1 (for properties that expect an integer) or "-1" (for properties that expect a
+string) in order to specify that the data is explicitly unknown. This is equivalent to using a value
+of "9999" in IJE.
+
+Example:
+
+```
+DeathRecord deathRecord = new DeathRecord();
+deathRecord.DeathYear = 2022;
+deathRecord.DeathMonth = 2;
+deathRecord.DeathDay = -1;
+deathRecord.DeathTime = "-1";
+```
 
 #### Helper Methods for Value Sets
 

--- a/VRDR.Messaging/BaseMessage.cs
+++ b/VRDR.Messaging/BaseMessage.cs
@@ -112,7 +112,7 @@ namespace VRDR
             }
             if (from?.DeathYear != null)
             {
-                this.DeathYear = from.DeathYear;
+                this.DeathYear = (uint)from.DeathYear;
             }
             this.JurisdictionId = from?.DeathLocationJurisdiction;
         }

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -101,7 +101,7 @@ namespace VRDR.Tests
             DeathRecord first = DeathRecord2_JSON;
             IJEMortality firstije = new IJEMortality(first);
             Assert.Null(first.DateOfDeath);   // Record has an unknown death day, the DeathDate should be null
-            Assert.Null(first.DeathDay);
+            Assert.Equal(-1, first.DeathDay); // Since it's explicitly unknown the DeathDay should be -1
             Assert.Equal("French", firstije.RACE22);
         }
         [Fact]
@@ -1264,8 +1264,8 @@ namespace VRDR.Tests
             Assert.Equal("99", ije1.DOB_MO);
             Assert.Equal("24", ije1.DOB_DY);
             DeathRecord dr1 = ije1.ToDeathRecord();
-            Assert.Null(dr1.BirthYear);
-            Assert.Null(dr1.BirthMonth);
+            Assert.Equal(-1, dr1.BirthYear);
+            Assert.Equal(-1, dr1.BirthMonth);
             Assert.Equal(24, (int)dr1.BirthDay);
             Assert.Null(dr1.DateOfBirth);
         }
@@ -2918,7 +2918,7 @@ namespace VRDR.Tests
             DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
             Assert.Equal(2021, (int)dr.DeathYear);
             Assert.Equal(2, (int)dr.DeathMonth);
-            Assert.Null(dr.DeathDay);
+            Assert.Equal(-1, dr.DeathDay);
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -1238,14 +1238,19 @@ namespace VRDR.Tests
             Assert.Equal(1950, (int)SetterDeathRecord.BirthYear);
             Assert.Null(SetterDeathRecord.BirthMonth);
             Assert.Null(SetterDeathRecord.BirthDay);
+            SetterDeathRecord.BirthMonth = -1;
+            SetterDeathRecord.BirthDay = -1;
+            Assert.Equal(1950, (int)SetterDeathRecord.BirthYear);
+            Assert.Equal(-1, SetterDeathRecord.BirthMonth);
+            Assert.Equal(-1, SetterDeathRecord.BirthDay);
         }
 
         [Fact]
         public void Get_BirthDate_Partial_Date()
         {
             DeathRecord dr = new DeathRecord(File.ReadAllText(FixturePath("fixtures/json/BirthAndDeathDateDataAbsent.json")));
-            Assert.Null(dr.BirthYear);
-            Assert.Null(dr.BirthMonth);
+            Assert.Equal(-1, dr.BirthYear);
+            Assert.Equal(-1, dr.BirthMonth);
             Assert.Equal(24, (int)dr.BirthDay);
         }
 
@@ -2868,12 +2873,12 @@ namespace VRDR.Tests
         {
             Assert.Null(DeathCertificateDocument2_JSON.DateOfDeath);
             Assert.Null(DeathCertificateDocument2_JSON.DeathDay);
-            Assert.Equal((uint)2020, (DeathCertificateDocument2_JSON.DeathYear));
+            Assert.Equal(2020, (DeathCertificateDocument2_JSON.DeathYear));
             Assert.Equal("2020-11-12T00:00:00", DeathCertificateDocument1_JSON.DateOfDeath);
-            Assert.Equal((uint)2020, (DeathCertificateDocument1_JSON.DeathYear));
+            Assert.Equal(2020, (DeathCertificateDocument1_JSON.DeathYear));
             Assert.Null(DeathCertificateDocument1_JSON.DeathTime);
             Assert.Equal("2019-02-19T16:48:06", DeathRecord1_XML.DateOfDeath);
-            Assert.Equal((uint)2019, (DeathRecord1_JSON.DeathYear));
+            Assert.Equal(2019, (DeathRecord1_JSON.DeathYear));
         }
 
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2901,15 +2901,45 @@ namespace VRDR.Tests
             //Tuple<string, string>[] datePart = { Tuple.Create("date-year", "2021"), Tuple.Create("date-month", "5"), Tuple.Create("day-absent-reason", "asked-unknown")};
             SetterDeathRecord.DeathYear = 2021;
             SetterDeathRecord.DeathMonth = 5;
-            SetterDeathRecord.DeathDay = null;
+            SetterDeathRecord.DeathDay = -1;
             SetterDeathRecord.DeathTime = "10:00:00";
             IJEMortality ije1 = new IJEMortality(SetterDeathRecord, false);
+            Assert.Equal("2021", ije1.DOD_YR);
+            Assert.Equal("05", ije1.DOD_MO);
+            Assert.Equal("99", ije1.DOD_DY);
             Assert.Equal("1000", ije1.TOD);
             DeathRecord dr2 = ije1.ToDeathRecord();
-            Assert.Equal(2021, (int)dr2.DeathYear);
-            Assert.Equal(5, (int)dr2.DeathMonth);
-            Assert.Null(dr2.DeathDay);
+            Assert.Equal(2021, dr2.DeathYear);
+            Assert.Equal(5, dr2.DeathMonth);
+            Assert.Equal(-1, dr2.DeathDay);
             Assert.Equal("10:00:00", dr2.DeathTime);
+        }
+
+        [Fact]
+        public void Set_DateOfDeath_Unknown_Partial_Date()
+        {
+            // Test ability to set dates and times diferentiating between explicitly unknown and unspecified
+            DeathRecord d = new DeathRecord();
+            Assert.Null(d.DeathYear);
+            Assert.Null(d.DeathMonth);
+            Assert.Null(d.DeathDay);
+            Assert.Null(d.DeathTime);
+            d.DeathYear = 2022;
+            Assert.Equal(2022, d.DeathYear);
+            Assert.Null(d.DeathMonth);
+            Assert.Null(d.DeathDay);
+            Assert.Null(d.DeathTime);
+            d.DeathMonth = -1;
+            d.DeathTime = "-1";
+            Assert.Equal(2022, d.DeathYear);
+            Assert.Equal(-1, d.DeathMonth);
+            Assert.Null(d.DeathDay);
+            Assert.Equal("-1", d.DeathTime);
+            IJEMortality ije = new IJEMortality(d, false);
+            Assert.Equal("2022", ije.DOD_YR);
+            Assert.Equal("99", ije.DOD_MO);
+            Assert.Equal("  ", ije.DOD_DY);
+            Assert.Equal("9999", ije.TOD);
         }
 
         [Fact]

--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -181,9 +181,9 @@ namespace VRDR.Tests
             Assert.Equal("06", ije1.DOB_MO);
             Assert.Equal("02", ije1.DOB_DY);
             DeathRecord dr1 = ije1.ToDeathRecord();
-            Assert.Null(dr1.BirthYear);
-            Assert.Equal(6, (int)dr1.BirthMonth);
-            Assert.Equal(2, (int)dr1.BirthDay);
+            Assert.Equal(-1, dr1.BirthYear);
+            Assert.Equal(6, dr1.BirthMonth);
+            Assert.Equal(2, dr1.BirthDay);
             Assert.Null(dr1.DateOfBirth);
         }
 
@@ -195,9 +195,9 @@ namespace VRDR.Tests
             Assert.Equal("99", ije1.DOB_MO);
             Assert.Equal("99", ije1.DOB_DY);
             DeathRecord dr1 = ije1.ToDeathRecord();
-            Assert.Null(dr1.BirthYear);
-            Assert.Null(dr1.BirthMonth);
-            Assert.Null(dr1.BirthDay);
+            Assert.Equal(-1, dr1.BirthYear);
+            Assert.Equal(-1, dr1.BirthMonth);
+            Assert.Equal(-1, dr1.BirthDay);
             Assert.Null(dr1.DateOfBirth);
         }
 

--- a/VRDR/Connectathon.cs
+++ b/VRDR/Connectathon.cs
@@ -37,7 +37,7 @@ namespace VRDR
 
             if (record != null && year != null)
             {
-                record.DeathYear = (uint)year;
+                record.DeathYear = year;
             }
 
             return record;

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -3482,10 +3482,12 @@
             <summary>Set a value on the DeathRecord whose type is some part of a DateTime.</summary>
         </member>
         <member name="M:VRDR.IJEMortality.NumericAllowingUnknown_Get(System.String,System.String)">
-            <summary>Get a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
+            <summary>Get a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and -1 on the
+            FHIR side to represent'unknown' and blank on the IJE side and null on the FHIR side to represent unspecified</summary>
         </member>
         <member name="M:VRDR.IJEMortality.NumericAllowingUnknown_Set(System.String,System.String,System.String)">
-            <summary>Set a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
+            <summary>Set a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and -1 on the
+            FHIR side to represent'unknown' and blank on the IJE side and null on the FHIR side to represent unspecified</summary>
         </member>
         <member name="M:VRDR.IJEMortality.TimeAllowingUnknown_Get(System.String,System.String)">
             <summary>Get a value on the DeathRecord that is a time with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -1084,7 +1084,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.ReceiptYear">
             <summary>The year NCHS received the death record.</summary>
-            <value>year</value>
+            <value>year, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.ReceiptYear = 2022 </para>
@@ -1097,7 +1097,7 @@
             The month NCHS received the death record.
             </summary>
             <summary>The month NCHS received the death record.</summary>
-            <value>month</value>
+            <value>month, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.ReceiptMonth = 11 </para>
@@ -1107,7 +1107,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.ReceiptDay">
             <summary>The day NCHS received the death record.</summary>
-            <value>month</value>
+            <value>day, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.ReceiptDay = 13 </para>
@@ -1681,7 +1681,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.BirthYear">
             <summary>Decedent's Year of Birth.</summary>
-            <value>the decedent's year of birth</value>
+            <value>the decedent's year of birth, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.BirthYear = 1928;</para>
@@ -1691,7 +1691,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.BirthMonth">
             <summary>Decedent's Month of Birth.</summary>
-            <value>the decedent's month of birth</value>
+            <value>the decedent's month of birth, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.BirthMonth = 11;</para>
@@ -1701,7 +1701,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.BirthDay">
             <summary>Decedent's Day of Birth.</summary>
-            <value>the decedent's dau of birth</value>
+            <value>the decedent's day of birth, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.BirthDay = 11;</para>
@@ -2466,7 +2466,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.DeathYear">
             <summary>Decedent's Year of Death.</summary>
-            <value>the decedent's year of death</value>
+            <value>the decedent's year of death, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.DeathYear = 2018;</para>
@@ -2476,7 +2476,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.DeathMonth">
             <summary>Decedent's Month of Death.</summary>
-            <value>the decedent's month of death</value>
+            <value>the decedent's month of death, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.DeathMonth = 6;</para>
@@ -2486,7 +2486,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.DeathDay">
             <summary>Decedent's Day of Death.</summary>
-            <value>the decedent's day of death</value>
+            <value>the decedent's day of death, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.DeathDay = 16;</para>
@@ -2544,7 +2544,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.SurgeryYear">
             <summary>Decedent's Year of Surgery.</summary>
-            <value>the decedent's year of surgery</value>
+            <value>the decedent's year of surgery, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.SurgeryYear = 2018;</para>
@@ -2554,7 +2554,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.SurgeryMonth">
             <summary>Decedent's Month of Surgery.</summary>
-            <value>the decedent's month of surgery</value>
+            <value>the decedent's month of surgery, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.SurgeryMonth = 6;</para>
@@ -2564,7 +2564,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.SurgeryDay">
             <summary>Decedent's Day of Surgery.</summary>
-            <value>the decedent's day of surgery</value>
+            <value>the decedent's day of surgery, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.SurgeryDay = 16;</para>
@@ -3005,7 +3005,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.InjuryYear">
             <summary>Decedent's Year of Injury.</summary>
-            <value>the decedent's year of injury</value>
+            <value>the decedent's year of injury, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.InjuryYear = 2018;</para>
@@ -3015,7 +3015,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.InjuryMonth">
             <summary>Decedent's Month of Injury.</summary>
-            <value>the decedent's month of injury</value>
+            <value>the decedent's month of injury, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.InjuryMonth = 7;</para>
@@ -3025,7 +3025,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.InjuryDay">
             <summary>Decedent's Day of Injury.</summary>
-            <value>the decedent's day of injury</value>
+            <value>the decedent's day of injury, or -1 if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.InjuryDay = 22;</para>
@@ -3159,20 +3159,20 @@
             <para>Console.WriteLine($"Tobacco Use: {ExampleDeathRecord.TobaccoUseHelper}");</para>
             </example>
         </member>
-        <member name="M:VRDR.DeathRecord.InjuryIncidentTimeSet">
-            <summary>Has an InjuryIncident Time Been Set</summary>
-        </member>
-        <member name="M:VRDR.DeathRecord.SurgeryDateSet">
-            <summary>Has a Surgery Date Been Set</summary>
-        </member>
         <member name="M:VRDR.DeathRecord.GetPartialDate(Hl7.Fhir.Model.Extension,System.String)">
-            <summary>Getter helper for anything that uses PartialDateTime, allowing a particular date field (year, month, or day) to be read from the extension</summary>
+            <summary>Getter helper for anything that uses PartialDateTime, allowing a particular date field (year, month, or day) to be read
+            from the extension. Returns either a numeric date part, or -1 meaning explicitly unknown, or null meaning not specified.</summary>
         </member>
         <member name="M:VRDR.DeathRecord.NewBlankPartialDateTimeExtension(System.Boolean)">
-            <summary>NewBlankPartialDateTimeExtension, Build a blank PartialDateTime extension (which means all the data absent reasons are present to note that the data is not in fact present)</summary>
+            <summary>NewBlankPartialDateTimeExtension, Build a blank PartialDateTime extension (which means all the placeholder data absent
+            reasons are present to note that the data is not in fact present). This method takes an optional flag to determine if this extension
+            should include the time field, which is not always needed</summary>
         </member>
-        <member name="M:VRDR.DeathRecord.SetPartialDate(Hl7.Fhir.Model.Extension,System.String,System.Nullable{System.UInt32})">
-            <summary>Setter helper for anything that uses PartialDateTime, allowing a particular date field (year, month, or day) to be set in the extension</summary>
+        <member name="M:VRDR.DeathRecord.SetPartialDate(Hl7.Fhir.Model.Extension,System.String,System.Nullable{System.Int32})">
+            <summary>Setter helper for anything that uses PartialDateTime, allowing a particular date field (year, month, or day) to be
+            set in the extension. Arguments are the extension to poplulate, the part of the URL to populate, and the value to specify.
+            The value can be a positive number for an actual value, a -1 meaning that the value is explicitly unknown, or null meaning
+            the data has not been specified.</summary>
         </member>
         <member name="M:VRDR.DeathRecord.GetPartialTime(Hl7.Fhir.Model.Extension)">
             <summary>Getter helper for anything that uses PartialDateTime, allowing the time to be read from the extension</summary>
@@ -3325,7 +3325,7 @@
         <member name="F:VRDR.Property.Types.TupleCOD">
             <summary>Parameter is an array of Tuples, specifically for CausesOfDeath.</summary>
         </member>
-        <member name="F:VRDR.Property.Types.UInt32">
+        <member name="F:VRDR.Property.Types.Int32">
             <summary>Parameter is an unsigned integer.</summary>
         </member>
         <member name="F:VRDR.Property.Types.Tuple4Arr">
@@ -3481,13 +3481,13 @@
         <member name="M:VRDR.IJEMortality.DateTime_Set(System.String,System.String,System.String,System.String,System.Boolean,System.Boolean)">
             <summary>Set a value on the DeathRecord whose type is some part of a DateTime.</summary>
         </member>
-        <member name="M:VRDR.IJEMortality.NumericAllowingUnknown_Get(System.String,System.String,System.Boolean)">
+        <member name="M:VRDR.IJEMortality.NumericAllowingUnknown_Get(System.String,System.String)">
             <summary>Get a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
         </member>
         <member name="M:VRDR.IJEMortality.NumericAllowingUnknown_Set(System.String,System.String,System.String)">
             <summary>Set a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
         </member>
-        <member name="M:VRDR.IJEMortality.TimeAllowingUnknown_Get(System.String,System.String,System.Boolean)">
+        <member name="M:VRDR.IJEMortality.TimeAllowingUnknown_Get(System.String,System.String)">
             <summary>Get a value on the DeathRecord that is a time with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
         </member>
         <member name="M:VRDR.IJEMortality.TimeAllowingUnknown_Set(System.String,System.String,System.String)">

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -2496,7 +2496,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.DeathTime">
             <summary>Decedent's Time of Death.</summary>
-            <value>the decedent's time of death</value>
+            <value>the decedent's time of death, or "-1" if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.DeathTime = "07:15";</para>
@@ -3035,7 +3035,7 @@
         </member>
         <member name="P:VRDR.DeathRecord.InjuryTime">
             <summary>Decedent's Time of Injury.</summary>
-            <value>the decedent's time of injury</value>
+            <value>the decedent's time of injury, or "-1" if explicitly unknown, or null if never specified</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleDeathRecord.InjuryTime = "07:15";</para>

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -1870,16 +1870,16 @@ namespace VRDR
 
 
         /// <summary>The year NCHS received the death record.</summary>
-        /// <value>year</value>
+        /// <value>year, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.ReceiptYear = 2022 </para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Receipt Year: {ExampleDeathRecord.ReceiptYear}");</para>
         /// </example>
-        [Property("ReceiptYear", Property.Types.UInt32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, true)]
+        [Property("ReceiptYear", Property.Types.Int32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, true)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
-        public uint? ReceiptYear
+        public int? ReceiptYear
         {
             get
             {
@@ -1901,16 +1901,16 @@ namespace VRDR
         /// The month NCHS received the death record.
         /// </summary>
         /// <summary>The month NCHS received the death record.</summary>
-        /// <value>month</value>
+        /// <value>month, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.ReceiptMonth = 11 </para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Receipt Month: {ExampleDeathRecord.ReceiptMonth}");</para>
         /// </example>
-        [Property("ReceiptMonth", Property.Types.UInt32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, true)]
+        [Property("ReceiptMonth", Property.Types.Int32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, true)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
-        public uint? ReceiptMonth
+        public int? ReceiptMonth
         {
             get
             {
@@ -1929,16 +1929,16 @@ namespace VRDR
         }
 
         /// <summary>The day NCHS received the death record.</summary>
-        /// <value>month</value>
+        /// <value>day, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.ReceiptDay = 13 </para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Receipt Day: {ExampleDeathRecord.ReceiptDay}");</para>
         /// </example>
-        [Property("ReceiptDay", Property.Types.UInt32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, true)]
+        [Property("ReceiptDay", Property.Types.Int32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, true)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
-        public uint? ReceiptDay
+        public int? ReceiptDay
         {
             get
             {
@@ -1984,9 +1984,9 @@ namespace VRDR
                 DateTimeOffset parsedDate;
                 if (DateTimeOffset.TryParse(value, out parsedDate))
                 {
-                    ReceiptYear = (uint?)parsedDate.Year;
-                    ReceiptMonth = (uint?)parsedDate.Month;
-                    ReceiptDay = (uint?)parsedDate.Day;
+                    ReceiptYear = parsedDate.Year;
+                    ReceiptMonth = parsedDate.Month;
+                    ReceiptDay = parsedDate.Day;
                 }
             }
         }
@@ -2002,7 +2002,7 @@ namespace VRDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Coder STatus {ExampleDeathRecord.CoderStatus}");</para>
         /// </example>
-        [Property("CoderStatus", Property.Types.UInt32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, false)]
+        [Property("CoderStatus", Property.Types.Int32, "Coded Content", "Coding Status", true, IGURL.CodingStatusValues, false)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code=codingstatus)", "")]
         public int? CoderStatus
         {

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -1971,7 +1971,7 @@ namespace VRDR
             get
             {
                 // We support this legacy-style API entrypoint via the new partial date and time entrypoints
-                if (ReceiptYear != null && ReceiptMonth != null && ReceiptDay != null)
+                if (ReceiptYear != null && ReceiptYear != -1 && ReceiptMonth != null && ReceiptMonth != -1 && ReceiptDay != null && ReceiptDay != -1)
                 {
                     Date result = new Date((int)ReceiptYear, (int)ReceiptMonth, (int)ReceiptDay);
                     return result.ToString();

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -1959,7 +1959,7 @@ namespace VRDR
             get
             {
                 // We support this legacy API entrypoint via the new partial date entrypoints
-                if (BirthYear != null && BirthMonth != null && BirthDay != null)
+                if (BirthYear != null && BirthYear != -1 && BirthMonth != null && BirthMonth != -1 && BirthDay != null && BirthDay != -1)
                 {
                     Date result = new Date((int)BirthYear, (int)BirthMonth, (int)BirthDay);
                     return result.ToString();
@@ -4701,7 +4701,7 @@ namespace VRDR
             get
             {
                 // We support this legacy API entrypoint via the new partial date and time entrypoints
-                if (DeathYear != null && DeathMonth != null && DeathDay != null && DeathTime != null)
+                if (DeathYear != null && DeathYear != -1 && DeathMonth != null && DeathMonth != -1 && DeathDay != null && DeathDay != -1 && DeathTime != null && DeathTime != "-1")
                 {
                     DateTimeOffset parsedTime;
                     if (DateTimeOffset.TryParse(DeathTime, out parsedTime))
@@ -4710,7 +4710,7 @@ namespace VRDR
                         return result.ToString("s");
                     }
                 }
-                else if (DeathYear != null && DeathMonth != null && DeathDay != null)
+                else if (DeathYear != null && DeathYear != -1 && DeathMonth != null && DeathMonth != -1 && DeathDay != null && DeathDay != -1)
                 {
                     DateTime result = new DateTime((int)DeathYear, (int)DeathMonth, (int)DeathDay);
                     return result.ToString("s");
@@ -4888,7 +4888,7 @@ namespace VRDR
             get
             {
                 // We support this legacy-style API entrypoint via the new partial date and time entrypoints
-                if (SurgeryYear != null && SurgeryMonth != null && SurgeryDay != null)
+                if (SurgeryYear != null && SurgeryYear != -1 && SurgeryMonth != null && SurgeryMonth != -1 && SurgeryDay != null && SurgeryDay != -1)
                 {
                     Date result = new Date((int)SurgeryYear, (int)SurgeryMonth, (int)SurgeryDay);
                     return result.ToString();
@@ -6348,7 +6348,7 @@ namespace VRDR
             get
             {
                 // We support this legacy API entrypoint via the new partial date and time entrypoints
-                if (InjuryYear != null && InjuryMonth != null && InjuryDay != null && InjuryTime != null)
+                if (InjuryYear != null && InjuryYear != -1 && InjuryMonth != null && InjuryMonth != -1 && InjuryDay != null && InjuryDay != -1 && InjuryTime != null && InjuryTime != "-1")
                 {
                     DateTimeOffset parsedTime;
                     if (DateTimeOffset.TryParse(InjuryTime, out parsedTime))
@@ -6357,7 +6357,7 @@ namespace VRDR
                         return result.ToString("s");
                     }
                 }
-                else if (InjuryYear != null && InjuryMonth != null && InjuryDay != null)
+                else if (InjuryYear != null && InjuryYear != -1 && InjuryMonth != null && InjuryMonth != -1 && InjuryDay != null && InjuryDay != -1)
                 {
                     DateTime result = new DateTime((int)InjuryYear, (int)InjuryMonth, (int)InjuryDay);
                     return result.ToString("s");

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -4617,7 +4617,7 @@ namespace VRDR
             }
         }
         /// <summary>Decedent's Time of Death.</summary>
-        /// <value>the decedent's time of death</value>
+        /// <value>the decedent's time of death, or "-1" if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.DeathTime = "07:15";</para>
@@ -6300,7 +6300,7 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Time of Injury.</summary>
-        /// <value>the decedent's time of injury</value>
+        /// <value>the decedent's time of injury, or "-1" if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.InjuryTime = "07:15";</para>

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -1855,16 +1855,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Year of Birth.</summary>
-        /// <value>the decedent's year of birth</value>
+        /// <value>the decedent's year of birth, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.BirthYear = 1928;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Year of Birth: {ExampleDeathRecord.BirthYear}");</para>
         /// </example>
-        [Property("BirthYear", Property.Types.UInt32, "Decedent Demographics", "Decedent's Year of Birth.", true, IGURL.Decedent, true, 14)]
+        [Property("BirthYear", Property.Types.Int32, "Decedent Demographics", "Decedent's Year of Birth.", true, IGURL.Decedent, true, 14)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate", "")]
-        public uint? BirthYear
+        public int? BirthYear
         {
             get
             {
@@ -1885,16 +1885,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Month of Birth.</summary>
-        /// <value>the decedent's month of birth</value>
+        /// <value>the decedent's month of birth, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.BirthMonth = 11;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Month of Birth: {ExampleDeathRecord.BirthMonth}");</para>
         /// </example>
-        [Property("BirthMonth", Property.Types.UInt32, "Decedent Demographics", "Decedent's Month of Birth.", true, IGURL.Decedent, true, 14)]
+        [Property("BirthMonth", Property.Types.Int32, "Decedent Demographics", "Decedent's Month of Birth.", true, IGURL.Decedent, true, 14)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate", "")]
-        public uint? BirthMonth
+        public int? BirthMonth
         {
             get
             {
@@ -1915,16 +1915,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Day of Birth.</summary>
-        /// <value>the decedent's dau of birth</value>
+        /// <value>the decedent's day of birth, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.BirthDay = 11;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Day of Birth: {ExampleDeathRecord.BirthDay}");</para>
         /// </example>
-        [Property("BirthDay", Property.Types.UInt32, "Decedent Demographics", "Decedent's Day of Birth.", true, IGURL.Decedent, true, 14)]
+        [Property("BirthDay", Property.Types.Int32, "Decedent Demographics", "Decedent's Day of Birth.", true, IGURL.Decedent, true, 14)]
         [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate", "")]
-        public uint? BirthDay
+        public int? BirthDay
         {
             get
             {
@@ -1972,9 +1972,9 @@ namespace VRDR
                 DateTimeOffset parsedDate;
                 if (DateTimeOffset.TryParse(value, out parsedDate))
                 {
-                    BirthYear = (uint?)parsedDate.Year;
-                    BirthMonth = (uint?)parsedDate.Month;
-                    BirthDay = (uint?)parsedDate.Day;
+                    BirthYear = parsedDate.Year;
+                    BirthMonth = parsedDate.Month;
+                    BirthDay = parsedDate.Day;
                 }
             }
         }
@@ -4522,20 +4522,21 @@ namespace VRDR
         }
         // The idea here is that we have getters and setters for each of the parts of the death datetime, which get used in IJEMortality.cs
         // These getters and setters 1) use the DeathDateObs Observation 2) get and set values on the PartialDateTime extension using helpers that
-        // can be reused across year, month, etc. 3) interpret null as data being absent, and so set the data absent reason if value is null 4) when
-        // getting, look also in the valueDateTime and return the year from there if it happens to be set (but never bother to set it ourselves)
+        // can be reused across year, month, etc. 3) interpret -1 and null as data being absent (intentionally and unintentially, respectively),
+        // and so set the data absent reason if value is -1 or null 4) when getting, look also in the valueDateTime and return the year from there
+        // if it happens to be set (but never bother to set it ourselves)
 
         /// <summary>Decedent's Year of Death.</summary>
-        /// <value>the decedent's year of death</value>
+        /// <value>the decedent's year of death, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.DeathYear = 2018;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Year of Death: {ExampleDeathRecord.DeathYear}");</para>
         /// </example>
-        [Property("DeathYear", Property.Types.UInt32, "Death Investigation", "Decedent's Year of Death.", true, IGURL.DeathDate, true, 25)]
+        [Property("DeathYear", Property.Types.Int32, "Death Investigation", "Decedent's Year of Death.", true, IGURL.DeathDate, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
-        public uint? DeathYear
+        public int? DeathYear
         {
             get
             {
@@ -4557,16 +4558,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Month of Death.</summary>
-        /// <value>the decedent's month of death</value>
+        /// <value>the decedent's month of death, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.DeathMonth = 6;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Month of Death: {ExampleDeathRecord.DeathMonth}");</para>
         /// </example>
-        [Property("DeathMonth", Property.Types.UInt32, "Death Investigation", "Decedent's Month of Death.", true, IGURL.DeathDate, true, 25)]
+        [Property("DeathMonth", Property.Types.Int32, "Death Investigation", "Decedent's Month of Death.", true, IGURL.DeathDate, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
-        public uint? DeathMonth
+        public int? DeathMonth
         {
             get
             {
@@ -4587,16 +4588,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Day of Death.</summary>
-        /// <value>the decedent's day of death</value>
+        /// <value>the decedent's day of death, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.DeathDay = 16;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Day of Death: {ExampleDeathRecord.DeathDay}");</para>
         /// </example>
-        [Property("DeathDay", Property.Types.UInt32, "Death Investigation", "Decedent's Day of Death.", true, IGURL.DeathDate, true, 25)]
+        [Property("DeathDay", Property.Types.Int32, "Death Investigation", "Decedent's Day of Death.", true, IGURL.DeathDate, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='81956-5')", "")]
-        public uint? DeathDay
+        public int? DeathDay
         {
             get
             {
@@ -4722,9 +4723,9 @@ namespace VRDR
                 DateTimeOffset parsedTime;
                 if (DateTimeOffset.TryParse(value, out parsedTime))
                 {
-                    DeathYear = (uint?)parsedTime.Year;
-                    DeathMonth = (uint?)parsedTime.Month;
-                    DeathDay = (uint?)parsedTime.Day;
+                    DeathYear = parsedTime.Year;
+                    DeathMonth = parsedTime.Month;
+                    DeathDay = parsedTime.Day;
                     TimeSpan timeSpan = new TimeSpan(0, parsedTime.Hour, parsedTime.Minute, parsedTime.Second);
                     DeathTime = timeSpan.ToString(@"hh\:mm\:ss");
                 }
@@ -4783,16 +4784,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Year of Surgery.</summary>
-        /// <value>the decedent's year of surgery</value>
+        /// <value>the decedent's year of surgery, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.SurgeryYear = 2018;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Year of Surgery: {ExampleDeathRecord.SurgeryYear}");</para>
         /// </example>
-        [Property("SurgeryYear", Property.Types.UInt32, "Death Investigation", "Decedent's Year of Surgery.", true, IGURL.SurgeryDate, true, 25)]
+        [Property("SurgeryYear", Property.Types.Int32, "Death Investigation", "Decedent's Year of Surgery.", true, IGURL.SurgeryDate, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80992-1')", "")]
-        public uint? SurgeryYear
+        public int? SurgeryYear
         {
             get
             {
@@ -4813,16 +4814,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Month of Surgery.</summary>
-        /// <value>the decedent's month of surgery</value>
+        /// <value>the decedent's month of surgery, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.SurgeryMonth = 6;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Month of Surgery: {ExampleDeathRecord.SurgeryMonth}");</para>
         /// </example>
-        [Property("SurgeryMonth", Property.Types.UInt32, "Death Investigation", "Decedent's Month of Surgery.", true, IGURL.SurgeryDate, true, 25)]
+        [Property("SurgeryMonth", Property.Types.Int32, "Death Investigation", "Decedent's Month of Surgery.", true, IGURL.SurgeryDate, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80992-1')", "")]
-        public uint? SurgeryMonth
+        public int? SurgeryMonth
         {
             get
             {
@@ -4843,16 +4844,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Day of Surgery.</summary>
-        /// <value>the decedent's day of surgery</value>
+        /// <value>the decedent's day of surgery, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.SurgeryDay = 16;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Day of Surgery: {ExampleDeathRecord.SurgeryDay}");</para>
         /// </example>
-        [Property("SurgeryDay", Property.Types.UInt32, "Death Investigation", "Decedent's Day of Surgery.", true, IGURL.SurgeryDate, true, 25)]
+        [Property("SurgeryDay", Property.Types.Int32, "Death Investigation", "Decedent's Day of Surgery.", true, IGURL.SurgeryDate, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='80992-1')", "")]
-        public uint? SurgeryDay
+        public int? SurgeryDay
         {
             get
             {
@@ -4900,9 +4901,9 @@ namespace VRDR
                 DateTimeOffset parsedDate;
                 if (DateTimeOffset.TryParse(value, out parsedDate))
                 {
-                    SurgeryYear = (uint?)parsedDate.Year;
-                    SurgeryMonth = (uint?)parsedDate.Month;
-                    SurgeryDay = (uint?)parsedDate.Day;
+                    SurgeryYear = parsedDate.Year;
+                    SurgeryMonth = parsedDate.Month;
+                    SurgeryDay = parsedDate.Day;
                 }
             }
         }
@@ -6197,16 +6198,16 @@ namespace VRDR
 
 
         /// <summary>Decedent's Year of Injury.</summary>
-        /// <value>the decedent's year of injury</value>
+        /// <value>the decedent's year of injury, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.InjuryYear = 2018;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Year of Injury: {ExampleDeathRecord.InjuryYear}");</para>
         /// </example>
-        [Property("InjuryYear", Property.Types.UInt32, "Death Investigation", "Decedent's Year of Injury.", true, IGURL.InjuryIncident, true, 25)]
+        [Property("InjuryYear", Property.Types.Int32, "Death Investigation", "Decedent's Year of Injury.", true, IGURL.InjuryIncident, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        public uint? InjuryYear
+        public int? InjuryYear
         {
             get
             {
@@ -6231,16 +6232,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Month of Injury.</summary>
-        /// <value>the decedent's month of injury</value>
+        /// <value>the decedent's month of injury, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.InjuryMonth = 7;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Month of Injury: {ExampleDeathRecord.InjuryMonth}");</para>
         /// </example>
-        [Property("InjuryMonth", Property.Types.UInt32, "Death Investigation", "Decedent's Month of Injury.", true, IGURL.InjuryIncident, true, 25)]
+        [Property("InjuryMonth", Property.Types.Int32, "Death Investigation", "Decedent's Month of Injury.", true, IGURL.InjuryIncident, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        public uint? InjuryMonth
+        public int? InjuryMonth
         {
             get
             {
@@ -6265,16 +6266,16 @@ namespace VRDR
         }
 
         /// <summary>Decedent's Day of Injury.</summary>
-        /// <value>the decedent's day of injury</value>
+        /// <value>the decedent's day of injury, or -1 if explicitly unknown, or null if never specified</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleDeathRecord.InjuryDay = 22;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Day of Injury: {ExampleDeathRecord.InjuryDay}");</para>
         /// </example>
-        [Property("InjuryDay", Property.Types.UInt32, "Death Investigation", "Decedent's Day of Injury.", true, IGURL.InjuryIncident, true, 25)]
+        [Property("InjuryDay", Property.Types.Int32, "Death Investigation", "Decedent's Day of Injury.", true, IGURL.InjuryIncident, true, 25)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='11374-6')", "")]
-        public uint? InjuryDay
+        public int? InjuryDay
         {
             get
             {
@@ -6369,9 +6370,9 @@ namespace VRDR
                 DateTimeOffset parsedTime;
                 if (DateTimeOffset.TryParse(value, out parsedTime))
                 {
-                    InjuryYear = (uint?)parsedTime.Year;
-                    InjuryMonth = (uint?)parsedTime.Month;
-                    InjuryDay = (uint?)parsedTime.Day;
+                    InjuryYear = parsedTime.Year;
+                    InjuryMonth = parsedTime.Month;
+                    InjuryDay = parsedTime.Day;
                     TimeSpan timeSpan = new TimeSpan(0, parsedTime.Hour, parsedTime.Minute, parsedTime.Second);
                     InjuryTime = timeSpan.ToString(@"hh\:mm\:ss");
                 }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -3028,8 +3028,7 @@ namespace VRDR
         {
             get
             {
-                // TODO: How do we want to handle this?
-                if (DOI_YR == "9999" || DOI_YR == "    ") // was "if record.InjuryIncidentTimeSet()"
+                if (DOI_YR != "9999" && DOI_YR != "    ")
                 {
                     return "M"; // Military time
                 }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -387,13 +387,14 @@ namespace VRDR
         }
 
         /// <summary>Get a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
-        private string NumericAllowingUnknown_Get(string ijeFieldName, string fhirFieldName, bool fieldExists = true)
+        private string NumericAllowingUnknown_Get(string ijeFieldName, string fhirFieldName)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            if (!fieldExists)
-            {
-                return new String(' ', info.Length);
-            }
+            // TODO: Handle different between null and -1
+            //if (!fieldExists)
+            //{
+            //    return new String(' ', info.Length);
+            //}
             uint? value = (uint?)typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
             if (value != null)
             {
@@ -414,6 +415,7 @@ namespace VRDR
         private void NumericAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
+            // TODO: Handle different between null and -1
             if (value == new string('9', info.Length) || value == new string(' ', info.Length))
             {
                 typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, null);
@@ -425,13 +427,14 @@ namespace VRDR
         }
 
         /// <summary>Get a value on the DeathRecord that is a time with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
-        private string TimeAllowingUnknown_Get(string ijeFieldName, string fhirFieldName, bool fieldExists = true)
+        private string TimeAllowingUnknown_Get(string ijeFieldName, string fhirFieldName)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            if (!fieldExists)
-            {
-                return new String(' ', info.Length);
-            }
+            // TODO: Handle different between null and -1?
+            //if (!fieldExists)
+            //{
+            //    return new String(' ', info.Length);
+            //}
             string timeString = (string)typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
             if (timeString != null)
             {
@@ -449,6 +452,7 @@ namespace VRDR
         private void TimeAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
+            // TODO: Handle different between null and -1?
             if (value == new string('9', info.Length) || value == new string(' ', info.Length))
             {
                 typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, null);
@@ -2827,7 +2831,7 @@ namespace VRDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("DOI_MO", "InjuryMonth", record.InjuryIncidentTimeSet());
+                return NumericAllowingUnknown_Get("DOI_MO", "InjuryMonth");
             }
             set
             {
@@ -2841,7 +2845,7 @@ namespace VRDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("DOI_DY", "InjuryDay", record.InjuryIncidentTimeSet());
+                return NumericAllowingUnknown_Get("DOI_DY", "InjuryDay");
             }
             set
             {
@@ -2855,7 +2859,7 @@ namespace VRDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("DOI_YR", "InjuryYear", record.InjuryIncidentTimeSet());
+                return NumericAllowingUnknown_Get("DOI_YR", "InjuryYear");
             }
             set
             {
@@ -2869,7 +2873,7 @@ namespace VRDR
         {
             get
             {
-                return TimeAllowingUnknown_Get("TOI_HR", "InjuryTime", record.InjuryIncidentTimeSet());
+                return TimeAllowingUnknown_Get("TOI_HR", "InjuryTime");
             }
             set
             {
@@ -2979,7 +2983,7 @@ namespace VRDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("SUR_MO", "SurgeryMonth", record.SurgeryDateSet());
+                return NumericAllowingUnknown_Get("SUR_MO", "SurgeryMonth");
             }
             set
             {
@@ -2996,7 +3000,7 @@ namespace VRDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("SUR_DY", "SurgeryDay", record.SurgeryDateSet());
+                return NumericAllowingUnknown_Get("SUR_DY", "SurgeryDay");
             }
             set
             {
@@ -3013,7 +3017,7 @@ namespace VRDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("SUR_YR", "SurgeryYear", record.SurgeryDateSet());
+                return NumericAllowingUnknown_Get("SUR_YR", "SurgeryYear");
             }
             set
             {
@@ -3030,7 +3034,8 @@ namespace VRDR
         {
             get
             {
-                if (record.InjuryIncidentTimeSet())
+                // TODO: How do we want to handle this?
+                if (DOI_YR == "9999" || DOI_YR == "    ") // was "if record.InjuryIncidentTimeSet()"
                 {
                     return "M"; // Military time
                 }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -386,43 +386,38 @@ namespace VRDR
             }
         }
 
-        /// <summary>Get a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
+        /// <summary>Get a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and -1 on the
+        /// FHIR side to represent'unknown' and blank on the IJE side and null on the FHIR side to represent unspecified</summary>
         private string NumericAllowingUnknown_Get(string ijeFieldName, string fhirFieldName)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            // TODO: Handle different between null and -1
-            //if (!fieldExists)
-            //{
-            //    return new String(' ', info.Length);
-            //}
-            uint? value = (uint?)typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
-            if (value != null)
+            int? value = (int?)typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record);
+            if (value == null) return new String(' ', info.Length); // No value specified
+            if (value == -1) return new String('9', info.Length); // Explicitly set to unknown
+            string valueString = Convert.ToString(value);
+            if (valueString.Length > info.Length)
             {
-                string valueString = Convert.ToString(value);
-                if (valueString.Length > info.Length)
-                {
-                    validationErrors.Add($"Error: FHIR field {fhirFieldName} contains string '{valueString}' that's not the expected length for IJE field {ijeFieldName} of length {info.Length}");
-                }
-                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
+                validationErrors.Add($"Error: FHIR field {fhirFieldName} contains string '{valueString}' that's not the expected length for IJE field {ijeFieldName} of length {info.Length}");
             }
-            else
-            {
-                return new String('9', info.Length);
-            }
+            return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
         }
 
-        /// <summary>Set a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
+        /// <summary>Set a value on the DeathRecord that is a numeric string with the option of being set to all 9s on the IJE side and -1 on the
+        /// FHIR side to represent'unknown' and blank on the IJE side and null on the FHIR side to represent unspecified</summary>
         private void NumericAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            // TODO: Handle different between null and -1
-            if (value == new string('9', info.Length) || value == new string(' ', info.Length))
+            if (value == new string(' ', info.Length))
             {
                 typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, null);
             }
+            else if (value == new string('9', info.Length))
+            {
+                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, -1);
+            }
             else
             {
-                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, Convert.ToUInt32(value));
+                typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, Convert.ToInt32(value));
             }
         }
 


### PR DESCRIPTION
This pull request

1. Updates all the date and time properties in DeathRecord to support -1 or "-1" to mean "explicitly unknown" and null to mean just unspecified, changing the type from uint to int so that -1 is a valid value
2. Updates the DeathRecord FHIR implementation to use a data absent reason of "unknown" to mean "explicitly unknown" and "temp-unknown" to mean "unspecified", setting as "temp-unknown" as a default unless otherwise specified
3. Updates the IJE conversion code to convert -1 or "-1" to a string of all 9s and null to a string of all blanks
4. Adjusts and improves the tests to cover the change
5. Updates the README to document the change in behavior of the date the time properties
