### PR TITLE
Improve handling of middle names in IJE

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ deathRecord.DeathDay = -1;
 deathRecord.DeathTime = "-1";
 ```
 
+#### Names in FHIR
+
+FHIR manages names in a way that there is a fundamental incompatibility with IJE: in FHIR the
+"middle name" is stored as the second element in an array of given names. That means that it's not
+possible to set a middle name without first setting a first name. The library handles this by
+
+1. Requiring the entire given name (first name and any middle names) to be set all at once when
+using the DeathRecord class
+2. Raising an exception if a middle name is set before a first name when using the IJEMortality
+class
+3. Resetting the middle name if the first name is set again when using the IJEMortality class;
+setting the first name and then the middle name ensures no issues will occur.
+
 #### Helper Methods for Value Sets
 
 For fields that contain coded values it can involve some extra effort to provide the code, the code

--- a/VRDR.CLI/Program.cs
+++ b/VRDR.CLI/Program.cs
@@ -477,7 +477,7 @@ namespace VRDR.CLI
                 DeathRecord d = new DeathRecord(File.ReadAllText(args[1]));
                 IJEMortality ije1 = new IJEMortality(d, false);
                 // Loop over every property (these are the fields); Order by priority
-                List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Priority).ToList();
+                List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Location).ToList();
                 foreach (PropertyInfo property in properties)
                 {
                     // Grab the field attributes
@@ -485,7 +485,7 @@ namespace VRDR.CLI
                     // Grab the field value
                     string field = Convert.ToString(property.GetValue(ije1, null));
                     // Print the key/value pair to console
-                    Console.WriteLine(info.Name + ": " + field);
+                    Console.WriteLine($"{info.Name}: {field.Trim()}");
                 }
 
                 return 0;
@@ -762,7 +762,7 @@ namespace VRDR.CLI
                         var d = submission.DeathRecord;
                         IJEMortality ije1 = new IJEMortality(d, false);
                         // Loop over every property (these are the fields); Order by priority
-                        List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Priority).ToList();
+                        List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Location).ToList();
                         foreach (PropertyInfo property in properties)
                         {
                             // Grab the field attributes
@@ -770,7 +770,7 @@ namespace VRDR.CLI
                             // Grab the field value
                             string field = Convert.ToString(property.GetValue(ije1, null));
                             // Print the key/value pair to console
-                            Console.WriteLine(info.Name + ": " + field);
+                            Console.WriteLine($"{info.Name}: {field.Trim()}");
                         }
                         break;
                 }

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -944,9 +944,9 @@ namespace VRDR
                 string[] names = record.GivenNames;
                 if (names.Length > 0)
                 {
-                    return names[0];
+                    return Truncate(names[0], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
@@ -966,20 +966,21 @@ namespace VRDR
                 string[] names = record.GivenNames;
                 if (names.Length > 1)
                 {
-                    return names[1];
+                    return Truncate(names[1], 1).PadRight(1, ' ');
                 }
-                return "";
+                return " ";
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (String.IsNullOrWhiteSpace(GNAME)) throw new ArgumentException("Middle name cannot be set before first name");
                     if (String.IsNullOrWhiteSpace(DMIDDLE))
                     {
                         if (record.GivenNames != null)
                         {
                             List<string> names = record.GivenNames.ToList();
-                            names.Add(value.Trim());
+                            if (names.Count() > 1) names[1] = value.Trim(); else names.Add(value.Trim());
                             record.GivenNames = names.ToArray();
                         }
                     }
@@ -3348,9 +3349,9 @@ namespace VRDR
                 string[] names = record.SpouseGivenNames;
                 if (names.Length > 0)
                 {
-                    return names[0];
+                    return Truncate(names[0], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
@@ -3730,18 +3731,19 @@ namespace VRDR
                 string[] names = record.GivenNames;
                 if (names.Length > 1)
                 {
-                    return names[1];
+                    return Truncate(names[1], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (String.IsNullOrWhiteSpace(GNAME)) throw new ArgumentException("Middle name cannot be set before first name");
                     if (record.GivenNames != null)
                     {
                         List<string> names = record.GivenNames.ToList();
-                        names.Add(value.Trim());
+                        if (names.Count() > 1) names[1] = value.Trim(); else names.Add(value.Trim());
                         record.GivenNames = names.ToArray();
                     }
                 }
@@ -3757,9 +3759,9 @@ namespace VRDR
                 string[] names = record.FatherGivenNames;
                 if (names != null && names.Length > 0)
                 {
-                    return names[0];
+                    return Truncate(names[0], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
@@ -3779,18 +3781,19 @@ namespace VRDR
                 string[] names = record.FatherGivenNames;
                 if (names != null && names.Length > 1)
                 {
-                    return names[1];
+                    return Truncate(names[1], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (String.IsNullOrWhiteSpace(DDADF)) throw new ArgumentException("Middle name cannot be set before first name");
                     if (record.FatherGivenNames != null)
                     {
                         List<string> names = record.FatherGivenNames.ToList();
-                        names.Add(value.Trim());
+                        if (names.Count() > 1) names[1] = value.Trim(); else names.Add(value.Trim());
                         record.FatherGivenNames = names.ToArray();
                     }
                 }
@@ -3806,9 +3809,9 @@ namespace VRDR
                 string[] names = record.MotherGivenNames;
                 if (names != null && names.Length > 0)
                 {
-                    return names[0];
+                    return Truncate(names[0], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
@@ -3828,18 +3831,19 @@ namespace VRDR
                 string[] names = record.MotherGivenNames;
                 if (names != null && names.Length > 1)
                 {
-                    return names[1];
+                    return Truncate(names[1], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (String.IsNullOrWhiteSpace(DMOMF)) throw new ArgumentException("Middle name cannot be set before first name");
                     if (record.MotherGivenNames != null)
                     {
                         List<string> names = record.MotherGivenNames.ToList();
-                        names.Add(value.Trim());
+                        if (names.Count() > 1) names[1] = value.Trim(); else names.Add(value.Trim());
                         record.MotherGivenNames = names.ToArray();
                     }
                 }
@@ -4362,18 +4366,19 @@ namespace VRDR
                 string[] names = record.SpouseGivenNames;
                 if (names != null && names.Length > 1)
                 {
-                    return names[1];
+                    return Truncate(names[1], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (String.IsNullOrWhiteSpace(SPOUSEF)) throw new ArgumentException("Middle name cannot be set before first name");
                     if (record.SpouseGivenNames != null)
                     {
                         List<string> names = record.SpouseGivenNames.ToList();
-                        names.Add(value.Trim());
+                        if (names.Count() > 1) names[1] = value.Trim(); else names.Add(value.Trim());
                         record.SpouseGivenNames = names.ToArray();
                     }
                 }
@@ -4749,9 +4754,9 @@ namespace VRDR
                 string[] names = record.CertifierGivenNames;
                 if (names != null && names.Length > 0)
                 {
-                    return names[0];
+                    return Truncate(names[0], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
@@ -4771,18 +4776,19 @@ namespace VRDR
                 string[] names = record.CertifierGivenNames;
                 if (names != null && names.Length > 1)
                 {
-                    return names[1];
+                    return Truncate(names[1], 50).PadRight(50, ' ');
                 }
-                return "";
+                return new string(' ', 50);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (String.IsNullOrWhiteSpace(CERTFIRST)) throw new ArgumentException("Middle name cannot be set before first name");
                     if (record.GivenNames != null)
                     {
                         List<string> names = record.CertifierGivenNames.ToList();
-                        names.Add(value.Trim());
+                        if (names.Count() > 1) names[1] = value.Trim(); else names.Add(value.Trim());
                         record.CertifierGivenNames = names.ToArray();
                     }
                 }


### PR DESCRIPTION
This pull request

1. Adds a major test that goes through each field and makes sure that no other field stomps on its value when being set
2. Updates how middle names are handled in response to the results of that test:
    1. raising an exception if a middle name is set before a first name in IJEMortality
    2. returns the correct length strings for middle names in IJEMortality
3. Adding further tests to cover the expected behavior of middle names
4. Incidentally fixes the display order of IJE fields in the CLI
