### PR TITLE
Empty strings that should be null/not present for a blank death record

### DIFF
--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3432,7 +3432,7 @@ namespace VRDR.Tests
             Assert.Equal("000000000042", mortalityrosterbundle.StateLocalIdentifier1);
             Assert.Equal("100000000001", mortalityrosterbundle.StateLocalIdentifier2);
             Assert.Equal("", mortalityrosterbundle.CertificationRole["code"]); // should be empty
-            Assert.Equal(null, mortalityrosterbundle.PregnancyStatusHelper); // should be missing
+            Assert.Null(mortalityrosterbundle.PregnancyStatusHelper); // should be missing
             // TODO: Fill out tests
         }
         [Fact]

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3432,7 +3432,7 @@ namespace VRDR.Tests
             Assert.Equal("000000000042", mortalityrosterbundle.StateLocalIdentifier1);
             Assert.Equal("100000000001", mortalityrosterbundle.StateLocalIdentifier2);
             Assert.Equal("", mortalityrosterbundle.CertificationRole["code"]); // should be empty
-            Assert.Equal("", mortalityrosterbundle.PregnancyStatusHelper); // should be missing
+            Assert.Equal(null, mortalityrosterbundle.PregnancyStatusHelper); // should be missing
             // TODO: Fill out tests
         }
         [Fact]
@@ -3689,13 +3689,22 @@ namespace VRDR.Tests
         public void GetShouldNotReturnEmptyString()
         {
             // An empty string field should never return an empty string to mean no value, should return null
+            Console.WriteLine("Running test");
             DeathRecord blank = new DeathRecord();
             List<PropertyInfo> properties = typeof(DeathRecord).GetProperties().ToList();
             foreach (PropertyInfo property in properties)
             {
                 if (property.PropertyType.ToString() == "System.String")
                 {
-                    Assert.Null(property.GetValue(blank));
+                    object value = property.GetValue(blank);
+                    if(value != null){
+                        if (property.Name == "DeathRecordIdentifier") {
+                            Assert.Equal(value, "0000XX000000");
+                        } else {
+                          Console.Write("Expected null for " + property.Name + " but got '" + value + "'.");
+                          Assert.Null(value);
+                        }
+                    }
                 }
             }
         }

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3686,6 +3686,21 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void GetShouldNotReturnEmptyString()
+        {
+            // An empty string field should never return an empty string to mean no value, should return null
+            DeathRecord blank = new DeathRecord();
+            List<PropertyInfo> properties = typeof(DeathRecord).GetProperties().ToList();
+            foreach (PropertyInfo property in properties)
+            {
+                if (property.PropertyType.ToString() == "System.String")
+                {
+                    Assert.Null(property.GetValue(blank));
+                }
+            }
+        }
+
+        [Fact]
         public void EmptyRecordRoundTrip()
         {
             // If we have an empty record and copy it over to a new empty record we shouldn't wind up with any blank strings

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -3689,7 +3689,6 @@ namespace VRDR.Tests
         public void GetShouldNotReturnEmptyString()
         {
             // An empty string field should never return an empty string to mean no value, should return null
-            Console.WriteLine("Running test");
             DeathRecord blank = new DeathRecord();
             List<PropertyInfo> properties = typeof(DeathRecord).GetProperties().ToList();
             foreach (PropertyInfo property in properties)
@@ -3697,13 +3696,10 @@ namespace VRDR.Tests
                 if (property.PropertyType.ToString() == "System.String")
                 {
                     object value = property.GetValue(blank);
-                    if(value != null){
-                        if (property.Name == "DeathRecordIdentifier") {
-                            Assert.Equal(value, "0000XX000000");
-                        } else {
-                          Console.Write("Expected null for " + property.Name + " but got '" + value + "'.");
-                          Assert.Null(value);
-                        }
+                    if (property.Name == "DeathRecordIdentifier") {
+                        Assert.Equal(value, "0000XX000000");
+                    } else {
+                      Assert.Null(value);
                     }
                 }
             }

--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
+using System.Text.RegularExpressions;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Xunit;
@@ -3682,6 +3683,61 @@ namespace VRDR.Tests
                 }
                 Assert.Equal(value, ((string)property.GetValue(ije)).Trim());
             }
+        }
+
+        [Fact]
+        public void EmptyRecordRoundTrip()
+        {
+            // If we have an empty record and copy it over to a new empty record we shouldn't wind up with any blank strings
+            DeathRecord blank = new DeathRecord();
+            DeathRecord copy = new DeathRecord();
+            List<PropertyInfo> properties = typeof(DeathRecord).GetProperties().ToList();
+            foreach (PropertyInfo property in properties)
+            {
+                property.SetValue(copy, property.GetValue(blank));
+            }
+            Assert.DoesNotContain("\"\"", blank.ToJson());
+            Assert.DoesNotContain("\"\"", copy.ToJson());
+        }
+
+        [Fact]
+        public void SetWithEmptyStrings()
+        {
+            // Starting with an empty record and setting all fields with the "empty" version of the field (e.g., for strings use "")
+            // should not actually set any fields to empty strings in the resulting JSON
+            DeathRecord blank = new DeathRecord();
+            List<PropertyInfo> properties = typeof(DeathRecord).GetProperties().ToList();
+            foreach (PropertyInfo property in properties)
+            {
+                switch (property.PropertyType.ToString())
+                {
+                    case "System.String":
+                        property.SetValue(blank, "");
+                        break;
+                    case "System.String[]":
+                        property.SetValue(blank, new string[] { "", "" });
+                        break;
+                    case "System.Collections.Generic.Dictionary`2[System.String,System.String]":
+                        property.SetValue(blank, new Dictionary<string, string> { { "code", "" }, { "system", ""}, { "display", "" } });
+                        break;
+                    case "System.Collections.Generic.IEnumerable`1[System.ValueTuple`4[System.Int32,System.Int32,System.String,System.Boolean]]":
+                        property.SetValue(blank, new[] { (LineNumber: 1, Position: 1, Code: "", ECode: false) });
+                        break;
+                    case "System.Collections.Generic.IEnumerable`1[System.ValueTuple`3[System.Int32,System.String,System.Boolean]]":
+                        property.SetValue(blank, new[] { (Position: 1, Code: "", Pregnancy: false) });
+                        break;
+                    case "System.Tuple`2[System.String,System.String][]":
+                        property.SetValue(blank, new Tuple<string, string>[] { Tuple.Create(NvssRace.White, "") });
+                        break;
+                    default:
+                        // Make sure we're not missing any string types in the test
+                        if (property.Name.ToString() == "CausesOfDeath") continue; // This is a convenience method that we don't need to test
+                        if (property.PropertyType.ToString().Contains("String")) Console.WriteLine($"Missing string type {property.PropertyType} for property {property.Name}");
+                        Assert.DoesNotContain("String", property.PropertyType.ToString()); // Make sure we're not missing any string types
+                        break;
+                }
+            }
+            Assert.DoesNotContain("\"\"", blank.ToJson());
         }
 
         private string FixturePath(string filePath)

--- a/VRDR/DeathRecord.xml
+++ b/VRDR/DeathRecord.xml
@@ -3361,6 +3361,11 @@
             <param name="contents">string that represents </param>
             <returns>a new DeathRecord that corresponds to the given descriptive format</returns>
         </member>
+        <member name="M:VRDR.DeathRecord.updateGivenHumanName(System.String[],System.Collections.Generic.List{Hl7.Fhir.Model.HumanName})">
+            <summary>Helper method to create a HumanName from a list of strings.</summary>
+            <param name="value">A list of strings to be converted into a name.</param>
+            <param name="names">The current list of HumanName attributes for the person.</param>
+        </member>
         <member name="T:VRDR.Property">
             <summary>Property attribute used to describe a DeathRecord property.</summary>
         </member>

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -150,7 +150,7 @@ namespace VRDR
             {
                 if (ManualUnderlyingCauseOfDeathObs != null && ManualUnderlyingCauseOfDeathObs.Value != null && ManualUnderlyingCauseOfDeathObs.Value as CodeableConcept != null)
                 {
-                    string codeableConceptValueCode = CodeableConceptToDict((CodeableConcept)AutomatedUnderlyingCauseOfDeathObs.Value)["code"];
+                    string codeableConceptValueCode = CodeableConceptToDict((CodeableConcept)ManualUnderlyingCauseOfDeathObs.Value)["code"];
                     if(String.IsNullOrEmpty(codeableConceptValueCode)){
                       return null;
                     }

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -125,12 +125,12 @@ namespace VRDR
             }
             set
             {
-                if (AutomatedUnderlyingCauseOfDeathObs == null)
-                {
-                    CreateAutomatedUnderlyingCauseOfDeathObs();
-                }
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (AutomatedUnderlyingCauseOfDeathObs == null)
+                    {
+                        CreateAutomatedUnderlyingCauseOfDeathObs();
+                    }
                     AutomatedUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
                 }
             }
@@ -163,12 +163,12 @@ namespace VRDR
             }
             set
             {
-                if (ManualUnderlyingCauseOfDeathObs == null)
-                {
-                    CreateManualUnderlyingCauseOfDeathObs();
-                }
                 if (!String.IsNullOrWhiteSpace(value))
                 {
+                    if (ManualUnderlyingCauseOfDeathObs == null)
+                    {
+                        CreateManualUnderlyingCauseOfDeathObs();
+                    }
                     ManualUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
                 }
             }
@@ -1815,38 +1815,38 @@ namespace VRDR
                 // Rebuild the list of observations
                 foreach ((int LineNumber, int Position, string Code, bool ECode) eac in value)
                 {
-                    Observation ob = new Observation();
-                    ob.Id = Guid.NewGuid().ToString();
-                    ob.Meta = new Meta();
-                    string[] entityAxis_profile = { ProfileURL.EntityAxisCauseOfDeath };
-                    ob.Meta.Profile = entityAxis_profile;
-                    ob.Status = ObservationStatus.Final;
-                    ob.Code = new CodeableConcept(CodeSystems.LOINC, "80356-9", "Cause of death entity axis code [Automated]", null);
-                    ob.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    AddReferenceToComposition(ob.Id, "CodedContent");
-
-                    ob.Effective = new FhirDateTime();
                     if(!String.IsNullOrEmpty(eac.Code))
                     {
+                        Observation ob = new Observation();
+                        ob.Id = Guid.NewGuid().ToString();
+                        ob.Meta = new Meta();
+                        string[] entityAxis_profile = { ProfileURL.EntityAxisCauseOfDeath };
+                        ob.Meta.Profile = entityAxis_profile;
+                        ob.Status = ObservationStatus.Final;
+                        ob.Code = new CodeableConcept(CodeSystems.LOINC, "80356-9", "Cause of death entity axis code [Automated]", null);
+                        ob.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                        AddReferenceToComposition(ob.Id, "CodedContent");
+
+                        ob.Effective = new FhirDateTime();
                         ob.Value = new CodeableConcept(CodeSystems.ICD10, eac.Code, null, null);
+                        Observation.ComponentComponent lineNumComp = new Observation.ComponentComponent();
+                        lineNumComp.Value = new Integer(eac.LineNumber);
+                        lineNumComp.Code = new CodeableConcept(CodeSystems.Component, "lineNumber", "lineNumber", null);
+                        ob.Component.Add(lineNumComp);
+
+                        Observation.ComponentComponent positionComp = new Observation.ComponentComponent();
+                        positionComp.Value = new Integer(eac.Position);
+                        positionComp.Code = new CodeableConcept(CodeSystems.Component, "position", "Position", null);
+                        ob.Component.Add(positionComp);
+
+                        Observation.ComponentComponent eCodeComp = new Observation.ComponentComponent();
+                        eCodeComp.Value = new FhirBoolean(eac.ECode);
+                        eCodeComp.Code = new CodeableConcept(CodeSystems.Component, "eCodeIndicator", "eCodeIndicator", null);
+                        ob.Component.Add(eCodeComp);
+
+                        Bundle.AddResourceEntry(ob, "urn:uuid:" + ob.Id);
+                        EntityAxisCauseOfDeathObsList.Add(ob);
                     }
-                    Observation.ComponentComponent lineNumComp = new Observation.ComponentComponent();
-                    lineNumComp.Value = new Integer(eac.LineNumber);
-                    lineNumComp.Code = new CodeableConcept(CodeSystems.Component, "lineNumber", "lineNumber", null);
-                    ob.Component.Add(lineNumComp);
-
-                    Observation.ComponentComponent positionComp = new Observation.ComponentComponent();
-                    positionComp.Value = new Integer(eac.Position);
-                    positionComp.Code = new CodeableConcept(CodeSystems.Component, "position", "Position", null);
-                    ob.Component.Add(positionComp);
-
-                    Observation.ComponentComponent eCodeComp = new Observation.ComponentComponent();
-                    eCodeComp.Value = new FhirBoolean(eac.ECode);
-                    eCodeComp.Code = new CodeableConcept(CodeSystems.Component, "eCodeIndicator", "eCodeIndicator", null);
-                    ob.Component.Add(eCodeComp);
-
-                    Bundle.AddResourceEntry(ob, "urn:uuid:" + ob.Id);
-                    EntityAxisCauseOfDeathObsList.Add(ob);
                 }
             }
         }
@@ -1912,38 +1912,37 @@ namespace VRDR
                 // Rebuild the list of observations
                 foreach ((int Position, string Code, bool Pregnancy) rac in value)
                 {
-                    Observation ob = new Observation();
-                    ob.Id = Guid.NewGuid().ToString();
-                    ob.Meta = new Meta();
-                    string[] recordAxis_profile = { ProfileURL.RecordAxisCauseOfDeath };
-                    ob.Meta.Profile = recordAxis_profile;
-                    ob.Status = ObservationStatus.Final;
-                    ob.Code = new CodeableConcept(CodeSystems.LOINC, "80357-7", "Cause of death record axis code [Automated]", null);
-                    ob.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                    AddReferenceToComposition(ob.Id, "CodedContent");
-
-                    ob.Effective = new FhirDateTime();
                     if(!String.IsNullOrEmpty(rac.Code))
                     {
-                      ob.Value = new CodeableConcept(CodeSystems.ICD10, rac.Code, null, null);
-                    }
-                    Observation.ComponentComponent positionComp = new Observation.ComponentComponent();
-                    positionComp.Value = new Integer(rac.Position);
-                    positionComp.Code = new CodeableConcept(CodeSystems.Component, "position", "Position", null);
-                    ob.Component.Add(positionComp);
+                        Observation ob = new Observation();
+                        ob.Id = Guid.NewGuid().ToString();
+                        ob.Meta = new Meta();
+                        string[] recordAxis_profile = { ProfileURL.RecordAxisCauseOfDeath };
+                        ob.Meta.Profile = recordAxis_profile;
+                        ob.Status = ObservationStatus.Final;
+                        ob.Code = new CodeableConcept(CodeSystems.LOINC, "80357-7", "Cause of death record axis code [Automated]", null);
+                        ob.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                        AddReferenceToComposition(ob.Id, "CodedContent");
+                        ob.Effective = new FhirDateTime();
+                        ob.Value = new CodeableConcept(CodeSystems.ICD10, rac.Code, null, null);
+                        Observation.ComponentComponent positionComp = new Observation.ComponentComponent();
+                        positionComp.Value = new Integer(rac.Position);
+                        positionComp.Code = new CodeableConcept(CodeSystems.Component, "position", "Position", null);
+                        ob.Component.Add(positionComp);
 
-                    // Record axis codes have an unusual and obscure handling of a Pregnancy flag, for more information see
-                    // http://build.fhir.org/ig/HL7/vrdr/branches/master/StructureDefinition-vrdr-record-axis-cause-of-death.html#usage
-                    if (rac.Pregnancy)
-                    {
-                        Observation.ComponentComponent pregComp = new Observation.ComponentComponent();
-                        pregComp.Value = new FhirBoolean(true);
-                        pregComp.Code = new CodeableConcept(CodeSystems.Component, "wouldBeUnderlyingCauseOfDeathWithoutPregnancy", "Would be underlying cause of death without pregnancy, if true");
-                        ob.Component.Add(pregComp);
-                    }
+                        // Record axis codes have an unusual and obscure handling of a Pregnancy flag, for more information see
+                        // http://build.fhir.org/ig/HL7/vrdr/branches/master/StructureDefinition-vrdr-record-axis-cause-of-death.html#usage
+                        if (rac.Pregnancy)
+                        {
+                            Observation.ComponentComponent pregComp = new Observation.ComponentComponent();
+                            pregComp.Value = new FhirBoolean(true);
+                            pregComp.Code = new CodeableConcept(CodeSystems.Component, "wouldBeUnderlyingCauseOfDeathWithoutPregnancy", "Would be underlying cause of death without pregnancy, if true");
+                            ob.Component.Add(pregComp);
+                        }
 
-                    Bundle.AddResourceEntry(ob, "urn:uuid:" + ob.Id);
-                    RecordAxisCauseOfDeathObsList.Add(ob);
+                        Bundle.AddResourceEntry(ob, "urn:uuid:" + ob.Id);
+                        RecordAxisCauseOfDeathObsList.Add(ob);
+                    }
                 }
             }
         }
@@ -2125,13 +2124,13 @@ namespace VRDR
             }
             set
             {
-                if (CodingStatusValues == null)
-                {
-                    CreateCodingStatusValues();
-                }
-                CodingStatusValues.Remove("shipmentNumber");
                 if (!String.IsNullOrEmpty(value))
                 {
+                    if (CodingStatusValues == null)
+                    {
+                        CreateCodingStatusValues();
+                    }
+                    CodingStatusValues.Remove("shipmentNumber");
                     CodingStatusValues.Add("shipmentNumber", new FhirString(value));
                 }
             }

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -1860,8 +1860,10 @@ namespace VRDR
                     AddReferenceToComposition(ob.Id, "CodedContent");
 
                     ob.Effective = new FhirDateTime();
-                    ob.Value = new CodeableConcept(CodeSystems.ICD10, rac.Code, null, null);
-
+                    if(!String.IsNullOrEmpty(rac.Code))
+                    {
+                      ob.Value = new CodeableConcept(CodeSystems.ICD10, rac.Code, null, null);
+                    }
                     Observation.ComponentComponent positionComp = new Observation.ComponentComponent();
                     positionComp.Value = new Integer(rac.Position);
                     positionComp.Code = new CodeableConcept(CodeSystems.Component, "position", "Position", null);

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -111,10 +111,14 @@ namespace VRDR
             {
                 if (AutomatedUnderlyingCauseOfDeathObs != null && AutomatedUnderlyingCauseOfDeathObs.Value != null && AutomatedUnderlyingCauseOfDeathObs.Value as CodeableConcept != null)
                 {
-
-                    return CodeableConceptToDict((CodeableConcept)AutomatedUnderlyingCauseOfDeathObs.Value)["code"];
+                    string codeableConceptValueCode = CodeableConceptToDict((CodeableConcept)AutomatedUnderlyingCauseOfDeathObs.Value)["code"];
+                    if (String.IsNullOrEmpty(codeableConceptValueCode))
+                    {
+                      return null;
+                    }
+                    return codeableConceptValueCode;
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -122,7 +126,10 @@ namespace VRDR
                 {
                     CreateAutomatedUnderlyingCauseOfDeathObs();
                 }
-                AutomatedUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    AutomatedUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
+                }
             }
         }
 
@@ -143,10 +150,13 @@ namespace VRDR
             {
                 if (ManualUnderlyingCauseOfDeathObs != null && ManualUnderlyingCauseOfDeathObs.Value != null && ManualUnderlyingCauseOfDeathObs.Value as CodeableConcept != null)
                 {
-
-                    return CodeableConceptToDict((CodeableConcept)ManualUnderlyingCauseOfDeathObs.Value)["code"];
+                    string codeableConceptValueCode = CodeableConceptToDict((CodeableConcept)AutomatedUnderlyingCauseOfDeathObs.Value)["code"];
+                    if(String.IsNullOrEmpty(codeableConceptValueCode)){
+                      return null;
+                    }
+                    return codeableConceptValueCode;
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -154,7 +164,10 @@ namespace VRDR
                 {
                     CreateManualUnderlyingCauseOfDeathObs();
                 }
-                ManualUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    ManualUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
+                }
             }
         }
 

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -125,14 +125,15 @@ namespace VRDR
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (AutomatedUnderlyingCauseOfDeathObs == null)
-                    {
-                        CreateAutomatedUnderlyingCauseOfDeathObs();
-                    }
-                    AutomatedUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
+                    return;
                 }
+                if (AutomatedUnderlyingCauseOfDeathObs == null)
+                {
+                    CreateAutomatedUnderlyingCauseOfDeathObs();
+                }
+                AutomatedUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
             }
         }
 
@@ -163,14 +164,15 @@ namespace VRDR
             }
             set
             {
-                if (!String.IsNullOrWhiteSpace(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (ManualUnderlyingCauseOfDeathObs == null)
-                    {
-                        CreateManualUnderlyingCauseOfDeathObs();
-                    }
-                    ManualUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
+                    return;
                 }
+                if (ManualUnderlyingCauseOfDeathObs == null)
+                {
+                    CreateManualUnderlyingCauseOfDeathObs();
+                }
+                ManualUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
             }
         }
 
@@ -2124,15 +2126,16 @@ namespace VRDR
             }
             set
             {
-                if (!String.IsNullOrEmpty(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (CodingStatusValues == null)
-                    {
-                        CreateCodingStatusValues();
-                    }
-                    CodingStatusValues.Remove("shipmentNumber");
-                    CodingStatusValues.Add("shipmentNumber", new FhirString(value));
+                    return;
                 }
+                if (CodingStatusValues == null)
+                {
+                    CreateCodingStatusValues();
+                }
+                CodingStatusValues.Remove("shipmentNumber");
+                CodingStatusValues.Add("shipmentNumber", new FhirString(value));
             }
         }
         /// <summary>

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -1763,8 +1763,10 @@ namespace VRDR
                     AddReferenceToComposition(ob.Id, "CodedContent");
 
                     ob.Effective = new FhirDateTime();
-                    ob.Value = new CodeableConcept(CodeSystems.ICD10, eac.Code, null, null);
-
+                    if(!String.IsNullOrEmpty(eac.Code))
+                    {
+                        ob.Value = new CodeableConcept(CodeSystems.ICD10, eac.Code, null, null);
+                    }
                     Observation.ComponentComponent lineNumComp = new Observation.ComponentComponent();
                     lineNumComp.Value = new Integer(eac.LineNumber);
                     lineNumComp.Code = new CodeableConcept(CodeSystems.Component, "lineNumber", "lineNumber", null);
@@ -2063,7 +2065,7 @@ namespace VRDR
                     CreateCodingStatusValues();
                 }
                 CodingStatusValues.Remove("shipmentNumber");
-                if (value != null)
+                if (!String.IsNullOrEmpty(value))
                 {
                     CodingStatusValues.Add("shipmentNumber", new FhirString(value));
                 }

--- a/VRDR/DeathRecord_responseOnlyProperties.cs
+++ b/VRDR/DeathRecord_responseOnlyProperties.cs
@@ -82,7 +82,7 @@ namespace VRDR
         {
             get
             {
-                if (ActivityAtDeath.ContainsKey("code"))
+                if (ActivityAtDeath.ContainsKey("code") && !String.IsNullOrWhiteSpace(ActivityAtDeath["code"]))
                 {
                     return ActivityAtDeath["code"];
                 }
@@ -90,7 +90,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("ActivityAtDeath", value, VRDR.ValueSets.ActivityAtTimeOfDeath.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("ActivityAtDeath", value, VRDR.ValueSets.ActivityAtTimeOfDeath.Codes);
+                }
             }
         }
 
@@ -112,11 +115,11 @@ namespace VRDR
                 if (AutomatedUnderlyingCauseOfDeathObs != null && AutomatedUnderlyingCauseOfDeathObs.Value != null && AutomatedUnderlyingCauseOfDeathObs.Value as CodeableConcept != null)
                 {
                     string codeableConceptValueCode = CodeableConceptToDict((CodeableConcept)AutomatedUnderlyingCauseOfDeathObs.Value)["code"];
-                    if (String.IsNullOrEmpty(codeableConceptValueCode))
+                    if (!String.IsNullOrWhiteSpace(codeableConceptValueCode))
                     {
-                      return null;
+                      return codeableConceptValueCode;
                     }
-                    return codeableConceptValueCode;
+                    return null;
                 }
                 return null;
             }
@@ -126,7 +129,7 @@ namespace VRDR
                 {
                     CreateAutomatedUnderlyingCauseOfDeathObs();
                 }
-                if (!String.IsNullOrEmpty(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     AutomatedUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
                 }
@@ -151,7 +154,7 @@ namespace VRDR
                 if (ManualUnderlyingCauseOfDeathObs != null && ManualUnderlyingCauseOfDeathObs.Value != null && ManualUnderlyingCauseOfDeathObs.Value as CodeableConcept != null)
                 {
                     string codeableConceptValueCode = CodeableConceptToDict((CodeableConcept)ManualUnderlyingCauseOfDeathObs.Value)["code"];
-                    if(String.IsNullOrEmpty(codeableConceptValueCode)){
+                    if(String.IsNullOrWhiteSpace(codeableConceptValueCode)){
                       return null;
                     }
                     return codeableConceptValueCode;
@@ -164,7 +167,7 @@ namespace VRDR
                 {
                     CreateManualUnderlyingCauseOfDeathObs();
                 }
-                if (!String.IsNullOrEmpty(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     ManualUnderlyingCauseOfDeathObs.Value = new CodeableConcept(CodeSystems.ICD10, value, null, null);
                 }
@@ -227,7 +230,7 @@ namespace VRDR
         {
             get
             {
-                if (PlaceOfInjury.ContainsKey("code"))
+                if (PlaceOfInjury.ContainsKey("code") && !String.IsNullOrWhiteSpace(PlaceOfInjury["code"]))
                 {
                     return PlaceOfInjury["code"];
                 }
@@ -235,7 +238,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("PlaceOfInjury", value, VRDR.ValueSets.PlaceOfInjury.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("PlaceOfInjury", value, VRDR.ValueSets.PlaceOfInjury.Codes);
+                }
             }
         }
 
@@ -303,7 +309,7 @@ namespace VRDR
         {
             get
             {
-                if (FirstEditedRaceCode.ContainsKey("code"))
+                if (FirstEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FirstEditedRaceCode["code"]))
                 {
                     return FirstEditedRaceCode["code"];
                 }
@@ -311,7 +317,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FirstEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FirstEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -379,7 +388,7 @@ namespace VRDR
         {
             get
             {
-                if (SecondEditedRaceCode.ContainsKey("code"))
+                if (SecondEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SecondEditedRaceCode["code"]))
                 {
                     return SecondEditedRaceCode["code"];
                 }
@@ -387,7 +396,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SecondEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SecondEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -455,7 +467,7 @@ namespace VRDR
         {
             get
             {
-                if (ThirdEditedRaceCode.ContainsKey("code"))
+                if (ThirdEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(ThirdEditedRaceCode["code"]))
                 {
                     return ThirdEditedRaceCode["code"];
                 }
@@ -463,7 +475,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("ThirdEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("ThirdEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -531,7 +546,7 @@ namespace VRDR
         {
             get
             {
-                if (FourthEditedRaceCode.ContainsKey("code"))
+                if (FourthEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FourthEditedRaceCode["code"]))
                 {
                     return FourthEditedRaceCode["code"];
                 }
@@ -539,7 +554,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FourthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FourthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -607,7 +625,7 @@ namespace VRDR
         {
             get
             {
-                if (FifthEditedRaceCode.ContainsKey("code"))
+                if (FifthEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FifthEditedRaceCode["code"]))
                 {
                     return FifthEditedRaceCode["code"];
                 }
@@ -615,7 +633,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FifthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FifthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -683,7 +704,7 @@ namespace VRDR
         {
             get
             {
-                if (SixthEditedRaceCode.ContainsKey("code"))
+                if (SixthEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SixthEditedRaceCode["code"]))
                 {
                     return SixthEditedRaceCode["code"];
                 }
@@ -691,7 +712,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SixthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SixthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -759,7 +783,7 @@ namespace VRDR
         {
             get
             {
-                if (SeventhEditedRaceCode.ContainsKey("code"))
+                if (SeventhEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SeventhEditedRaceCode["code"]))
                 {
                     return SeventhEditedRaceCode["code"];
                 }
@@ -767,7 +791,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SeventhEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SeventhEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -835,7 +862,7 @@ namespace VRDR
         {
             get
             {
-                if (EighthEditedRaceCode.ContainsKey("code"))
+                if (EighthEditedRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(EighthEditedRaceCode["code"]))
                 {
                     return EighthEditedRaceCode["code"];
                 }
@@ -843,7 +870,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("EighthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("EighthEditedRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -911,7 +941,7 @@ namespace VRDR
         {
             get
             {
-                if (FirstAmericanIndianRaceCode.ContainsKey("code"))
+                if (FirstAmericanIndianRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FirstAmericanIndianRaceCode["code"]))
                 {
                     return FirstAmericanIndianRaceCode["code"];
                 }
@@ -919,7 +949,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FirstAmericanIndianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FirstAmericanIndianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -987,7 +1020,7 @@ namespace VRDR
         {
             get
             {
-                if (SecondAmericanIndianRaceCode.ContainsKey("code"))
+                if (SecondAmericanIndianRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SecondAmericanIndianRaceCode["code"]))
                 {
                     return SecondAmericanIndianRaceCode["code"];
                 }
@@ -995,7 +1028,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SecondAmericanIndianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SecondAmericanIndianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1063,7 +1099,7 @@ namespace VRDR
         {
             get
             {
-                if (FirstOtherAsianRaceCode.ContainsKey("code"))
+                if (FirstOtherAsianRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FirstOtherAsianRaceCode["code"]))
                 {
                     return FirstOtherAsianRaceCode["code"];
                 }
@@ -1071,7 +1107,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FirstOtherAsianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FirstOtherAsianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1139,7 +1178,7 @@ namespace VRDR
         {
             get
             {
-                if (SecondOtherAsianRaceCode.ContainsKey("code"))
+                if (SecondOtherAsianRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SecondOtherAsianRaceCode["code"]))
                 {
                     return SecondOtherAsianRaceCode["code"];
                 }
@@ -1147,7 +1186,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SecondOtherAsianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SecondOtherAsianRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1215,7 +1257,7 @@ namespace VRDR
         {
             get
             {
-                if (FirstOtherPacificIslanderRaceCode.ContainsKey("code"))
+                if (FirstOtherPacificIslanderRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FirstOtherPacificIslanderRaceCode["code"]))
                 {
                     return FirstOtherPacificIslanderRaceCode["code"];
                 }
@@ -1223,7 +1265,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FirstOtherPacificIslanderRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FirstOtherPacificIslanderRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1291,7 +1336,7 @@ namespace VRDR
         {
             get
             {
-                if (SecondOtherPacificIslanderRaceCode.ContainsKey("code"))
+                if (SecondOtherPacificIslanderRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SecondOtherPacificIslanderRaceCode["code"]))
                 {
                     return SecondOtherPacificIslanderRaceCode["code"];
                 }
@@ -1299,7 +1344,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SecondOtherPacificIslanderRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SecondOtherPacificIslanderRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1367,7 +1415,7 @@ namespace VRDR
         {
             get
             {
-                if (FirstOtherRaceCode.ContainsKey("code"))
+                if (FirstOtherRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(FirstOtherRaceCode["code"]))
                 {
                     return FirstOtherRaceCode["code"];
                 }
@@ -1375,7 +1423,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FirstOtherRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FirstOtherRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1443,7 +1494,7 @@ namespace VRDR
         {
             get
             {
-                if (SecondOtherRaceCode.ContainsKey("code"))
+                if (SecondOtherRaceCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(SecondOtherRaceCode["code"]))
                 {
                     return SecondOtherRaceCode["code"];
                 }
@@ -1451,7 +1502,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SecondOtherRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SecondOtherRaceCode", value, VRDR.ValueSets.RaceCode.Codes);
+                }
             }
         }
 
@@ -1519,7 +1573,7 @@ namespace VRDR
         {
             get
             {
-                if (HispanicCode.ContainsKey("code"))
+                if (HispanicCode.ContainsKey("code") && !String.IsNullOrWhiteSpace(HispanicCode["code"]))
                 {
                     return HispanicCode["code"];
                 }
@@ -1527,7 +1581,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("HispanicCode", value, VRDR.ValueSets.HispanicOrigin.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("HispanicCode", value, VRDR.ValueSets.HispanicOrigin.Codes);
+                }
             }
         }
 
@@ -1595,7 +1652,7 @@ namespace VRDR
         {
             get
             {
-                if (HispanicCodeForLiteral.ContainsKey("code"))
+                if (HispanicCodeForLiteral.ContainsKey("code") && !String.IsNullOrWhiteSpace(HispanicCodeForLiteral["code"]))
                 {
                     return HispanicCodeForLiteral["code"];
                 }
@@ -1603,7 +1660,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("HispanicCodeForLiteral", value, VRDR.ValueSets.HispanicOrigin.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("HispanicCodeForLiteral", value, VRDR.ValueSets.HispanicOrigin.Codes);
+                }
             }
         }
 
@@ -1671,7 +1731,7 @@ namespace VRDR
         {
             get
             {
-                if (RaceRecode40.ContainsKey("code"))
+                if (RaceRecode40.ContainsKey("code") && !String.IsNullOrWhiteSpace(RaceRecode40["code"]))
                 {
                     return RaceRecode40["code"];
                 }
@@ -1679,7 +1739,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("RaceRecode40", value, VRDR.ValueSets.RaceRecode40.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("RaceRecode40", value, VRDR.ValueSets.RaceRecode40.Codes);
+                }
             }
         }
 
@@ -2135,7 +2198,7 @@ namespace VRDR
         {
             get
             {
-                if (IntentionalReject.ContainsKey("code"))
+                if (IntentionalReject.ContainsKey("code") && !String.IsNullOrWhiteSpace(IntentionalReject["code"]))
                 {
                     return IntentionalReject["code"];
                 }
@@ -2143,7 +2206,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("IntentionalReject", value, VRDR.ValueSets.IntentionalReject.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("IntentionalReject", value, VRDR.ValueSets.IntentionalReject.Codes);
+                }
             }
         }
 
@@ -2209,7 +2275,7 @@ namespace VRDR
         {
             get
             {
-                if (AcmeSystemReject.ContainsKey("code"))
+                if (AcmeSystemReject.ContainsKey("code") && !String.IsNullOrWhiteSpace(AcmeSystemReject["code"]))
                 {
                     return AcmeSystemReject["code"];
                 }
@@ -2217,7 +2283,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("AcmeSystemReject", value, VRDR.ValueSets.AcmeSystemReject.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("AcmeSystemReject", value, VRDR.ValueSets.AcmeSystemReject.Codes);
+                }
             }
         }
 
@@ -2283,7 +2352,7 @@ namespace VRDR
         {
             get
             {
-                if (TransaxConversion.ContainsKey("code"))
+                if (TransaxConversion.ContainsKey("code") && !String.IsNullOrWhiteSpace(TransaxConversion["code"]))
                 {
                     return TransaxConversion["code"];
                 }
@@ -2291,7 +2360,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("TransaxConversion", value, VRDR.ValueSets.TransaxConversion.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("TransaxConversion", value, VRDR.ValueSets.TransaxConversion.Codes);
+                }
             }
         }
 

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -323,7 +323,7 @@ namespace VRDR
                 {
                     return Composition.Date;
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -353,7 +353,7 @@ namespace VRDR
                         return stateSpecificData.Value.ToString();
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1093,7 +1093,7 @@ namespace VRDR
                         return intervalComp.Value.ToString();
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1106,7 +1106,6 @@ namespace VRDR
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                 if (intervalComp != null)
                 {
-
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                 }
                 else
@@ -1220,7 +1219,7 @@ namespace VRDR
                         return intervalComp.Value.ToString();
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1233,7 +1232,6 @@ namespace VRDR
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                 if (intervalComp != null)
                 {
-
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                 }
                 else
@@ -1320,9 +1318,7 @@ namespace VRDR
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
-
                 CauseOfDeathConditionC.Value = new CodeableConcept(null, null, null, value);
-
             }
         }
 
@@ -1348,7 +1344,7 @@ namespace VRDR
                         return intervalComp.Value.ToString();
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1361,7 +1357,6 @@ namespace VRDR
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                 if (intervalComp != null)
                 {
-
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                 }
                 else
@@ -1474,7 +1469,7 @@ namespace VRDR
                         return intervalComp.Value.ToString();
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -1487,7 +1482,6 @@ namespace VRDR
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
                 if (intervalComp != null)
                 {
-
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                 }
                 else
@@ -2485,7 +2479,7 @@ namespace VRDR
                         return ethnicity.Value.ToString();
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -2956,7 +2950,7 @@ namespace VRDR
                 {
                     return Decedent.MaritalStatus.Text;
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -3690,7 +3684,7 @@ namespace VRDR
                         return (Convert.ToString(stateComp.Value));
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -3794,7 +3788,7 @@ namespace VRDR
                 {
                     return CodeableConceptToDict((CodeableConcept)UsualWork.Value)["text"];
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -3833,7 +3827,7 @@ namespace VRDR
                         return CodeableConceptToDict((CodeableConcept)component.Value)["text"];
                     }
                 }
-                return "";
+                return null;
             }
             set
             {
@@ -6565,7 +6559,7 @@ namespace VRDR
                         }
                     }
                 }
-                return "";
+                return null;
             }
             set
             {

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -333,7 +333,7 @@ namespace VRDR
             }
             set
             {
-                if (!String.IsNullOrEmpty(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     Composition.Date = value;
                 }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -295,7 +295,7 @@ namespace VRDR
         {
             get
             {
-                if (FilingFormat.ContainsKey("code"))
+                if (FilingFormat.ContainsKey("code") && !String.IsNullOrWhiteSpace(FilingFormat["code"]))
                 {
                     return FilingFormat["code"];
                 }
@@ -303,7 +303,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("FilingFormat", value, VRDR.ValueSets.FilingFormat.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FilingFormat", value, VRDR.ValueSets.FilingFormat.Codes);
+                }
             }
         }
 
@@ -435,7 +438,7 @@ namespace VRDR
         {
             get
             {
-                if (ReplaceStatus.ContainsKey("code"))
+                if (ReplaceStatus.ContainsKey("code") && !String.IsNullOrWhiteSpace(ReplaceStatus["code"]))
                 {
                     return ReplaceStatus["code"];
                 }
@@ -443,7 +446,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("ReplaceStatus", value, VRDR.ValueSets.ReplaceStatus.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("ReplaceStatus", value, VRDR.ValueSets.ReplaceStatus.Codes);
+                }
             }
         }
 
@@ -520,13 +526,13 @@ namespace VRDR
                     string code = CertificationRole["code"];
                     if (code == "OTH")
                     {
-                        if (CertificationRole.ContainsKey("text"))
+                        if (CertificationRole.ContainsKey("text") && !String.IsNullOrWhiteSpace(CertificationRole["text"]))
                         {
                             return (CertificationRole["text"]);
                         }
                         return ("Other");
                     }
-                    else
+                    else if (!String.IsNullOrWhiteSpace(code))
                     {
                         return code;
                     }
@@ -628,7 +634,7 @@ namespace VRDR
         {
             get
             {
-                if (MannerOfDeathType.ContainsKey("code"))
+                if (MannerOfDeathType.ContainsKey("code") && !String.IsNullOrWhiteSpace(MannerOfDeathType["code"]))
                 {
                     return MannerOfDeathType["code"];
                 }
@@ -636,7 +642,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("MannerOfDeathType", value, VRDR.ValueSets.MannerOfDeath.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("MannerOfDeathType", value, VRDR.ValueSets.MannerOfDeath.Codes);
+                }
             }
         }
 
@@ -1834,7 +1843,7 @@ namespace VRDR
         {
             get
             {
-                if (SexAtDeath.ContainsKey("code"))
+                if (SexAtDeath.ContainsKey("code") && !String.IsNullOrWhiteSpace(SexAtDeath["code"]))
                 {
                     return SexAtDeath["code"];
                 }
@@ -1842,7 +1851,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SexAtDeath", value, VRDR.ValueSets.AdministrativeGender.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SexAtDeath", value, VRDR.ValueSets.AdministrativeGender.Codes);
+                }
             }
         }
 
@@ -2124,6 +2136,11 @@ namespace VRDR
                     Extension withinCityLimits = new Extension();
                     withinCityLimits.Url = ExtensionURL.WithinCityLimitsIndicator;
                     withinCityLimits.Value = DictToCoding(value);
+                    // Coding coding = DictToCoding(value);
+                    // if (coding != null)
+                    // {
+                    //     withinCityLimits.Value = coding;
+                    // }
                     Decedent.Address.FirstOrDefault().Extension.Add(withinCityLimits);
                 }
             }
@@ -2144,7 +2161,7 @@ namespace VRDR
         {
             get
             {
-                if (ResidenceWithinCityLimits.ContainsKey("code"))
+                if (ResidenceWithinCityLimits.ContainsKey("code") && !String.IsNullOrWhiteSpace(ResidenceWithinCityLimits["code"]))
                 {
                     return ResidenceWithinCityLimits["code"];
                 }
@@ -2152,7 +2169,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("ResidenceWithinCityLimits", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("ResidenceWithinCityLimits", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                }
             }
         }
 
@@ -2251,7 +2271,7 @@ namespace VRDR
         {
             get
             {
-                if (Ethnicity1.ContainsKey("code"))
+                if (Ethnicity1.ContainsKey("code") && !String.IsNullOrWhiteSpace(Ethnicity1["code"]))
                 {
                     return Ethnicity1["code"];
                 }
@@ -2259,7 +2279,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity1", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("Ethnicity1", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                }
             }
         }
 
@@ -2327,7 +2350,7 @@ namespace VRDR
         {
             get
             {
-                if (Ethnicity2.ContainsKey("code"))
+                if (Ethnicity2.ContainsKey("code") && !String.IsNullOrWhiteSpace(Ethnicity2["code"]))
                 {
                     return Ethnicity2["code"];
                 }
@@ -2335,7 +2358,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity2", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("Ethnicity2", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                }
             }
         }
 
@@ -2403,7 +2429,7 @@ namespace VRDR
         {
             get
             {
-                if (Ethnicity3.ContainsKey("code"))
+                if (Ethnicity3.ContainsKey("code") && !String.IsNullOrWhiteSpace(Ethnicity3["code"]))
                 {
                     return Ethnicity3["code"];
                 }
@@ -2411,7 +2437,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity3", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("Ethnicity3", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                }
             }
         }
 
@@ -2479,7 +2508,7 @@ namespace VRDR
         {
             get
             {
-                if (Ethnicity4.ContainsKey("code"))
+                if (Ethnicity4.ContainsKey("code") && !String.IsNullOrWhiteSpace(Ethnicity4["code"]))
                 {
                     return Ethnicity4["code"];
                 }
@@ -2487,7 +2516,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("Ethnicity4", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("Ethnicity4", value, VRDR.ValueSets.HispanicNoUnknown.Codes);
+                }
             }
         }
 
@@ -2703,7 +2735,7 @@ namespace VRDR
         {
             get
             {
-                if (RaceMissingValueReason.ContainsKey("code"))
+                if (RaceMissingValueReason.ContainsKey("code") && !String.IsNullOrWhiteSpace(RaceMissingValueReason["code"]))
                 {
                     return RaceMissingValueReason["code"];
                 }
@@ -2711,7 +2743,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("RaceMissingValueReason", value, VRDR.ValueSets.RaceMissingValueReason.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("RaceMissingValueReason", value, VRDR.ValueSets.RaceMissingValueReason.Codes);
+                }
             }
         }
 
@@ -2929,7 +2964,7 @@ namespace VRDR
         {
             get
             {
-                if (MaritalStatus.ContainsKey("code"))
+                if (MaritalStatus.ContainsKey("code") && !String.IsNullOrWhiteSpace(MaritalStatus["code"]))
                 {
                     return MaritalStatus["code"];
                 }
@@ -2937,7 +2972,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("MaritalStatus", value, VRDR.ValueSets.MaritalStatus.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("MaritalStatus", value, VRDR.ValueSets.MaritalStatus.Codes);
+                }
             }
         }
 
@@ -2958,7 +2996,7 @@ namespace VRDR
         {
             get
             {
-                if (MaritalStatusEditFlag.ContainsKey("code"))
+                if (MaritalStatusEditFlag.ContainsKey("code") && !String.IsNullOrWhiteSpace(MaritalStatusEditFlag["code"]))
                 {
                     return MaritalStatusEditFlag["code"];
                 }
@@ -3453,7 +3491,7 @@ namespace VRDR
         {
             get
             {
-                if (SpouseAlive.ContainsKey("code"))
+                if (SpouseAlive.ContainsKey("code") && !String.IsNullOrWhiteSpace(SpouseAlive["code"]))
                 {
                     return SpouseAlive["code"];
                 }
@@ -3461,7 +3499,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("SpouseAlive", value, VRDR.ValueSets.SpouseAlive.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("SpouseAlive", value, VRDR.ValueSets.SpouseAlive.Codes);
+                }
             }
         }
 
@@ -3533,7 +3574,7 @@ namespace VRDR
         {
             get
             {
-                if (EducationLevel.ContainsKey("code"))
+                if (EducationLevel.ContainsKey("code") && !String.IsNullOrWhiteSpace(EducationLevel["code"]))
                 {
                     return EducationLevel["code"];
                 }
@@ -3541,7 +3582,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("EducationLevel", value, VRDR.ValueSets.EducationLevel.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("EducationLevel", value, VRDR.ValueSets.EducationLevel.Codes);
+                }
             }
         }
 
@@ -3615,7 +3659,7 @@ namespace VRDR
         {
             get
             {
-                if (EducationLevelEditFlag.ContainsKey("code"))
+                if (EducationLevelEditFlag.ContainsKey("code") && !String.IsNullOrWhiteSpace(EducationLevelEditFlag["code"]))
                 {
                     return EducationLevelEditFlag["code"];
                 }
@@ -3623,7 +3667,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("EducationLevelEditFlag", value, VRDR.ValueSets.EditBypass01234.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                   SetCodeValue("EducationLevelEditFlag", value, VRDR.ValueSets.EditBypass01234.Codes);
+                }
             }
         }
 
@@ -3949,7 +3996,7 @@ namespace VRDR
         {
             get
             {
-                if (MilitaryService.ContainsKey("code"))
+                if (MilitaryService.ContainsKey("code") && !String.IsNullOrWhiteSpace(MilitaryService["code"]))
                 {
                     return (MilitaryService["code"]);
                 }
@@ -3957,7 +4004,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("MilitaryService", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("MilitaryService", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                }
             }
         }
 
@@ -4462,7 +4512,7 @@ namespace VRDR
         {
             get
             {
-                if (DecedentDispositionMethod.ContainsKey("code"))
+                if (DecedentDispositionMethod.ContainsKey("code") && !String.IsNullOrWhiteSpace(DecedentDispositionMethod["code"]))
                 {
                     return DecedentDispositionMethod["code"];
                 }
@@ -4470,7 +4520,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("DecedentDispositionMethod", value, VRDR.ValueSets.MethodOfDisposition.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("DecedentDispositionMethod", value, VRDR.ValueSets.MethodOfDisposition.Codes);
+                }
             }
         }
 
@@ -4540,7 +4593,7 @@ namespace VRDR
         {
             get
             {
-                if (AutopsyPerformedIndicator.ContainsKey("code"))
+                if (AutopsyPerformedIndicator.ContainsKey("code") && !String.IsNullOrWhiteSpace(AutopsyPerformedIndicator["code"]))
                 {
                     return AutopsyPerformedIndicator["code"];
                 }
@@ -4548,7 +4601,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("AutopsyPerformedIndicator", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("AutopsyPerformedIndicator", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                }
             }
         }
         // The idea here is that we have getters and setters for each of the parts of the death datetime, which get used in IJEMortality.cs
@@ -5017,7 +5073,7 @@ namespace VRDR
         {
             get
             {
-                if (AutopsyResultsAvailable.ContainsKey("code"))
+                if (AutopsyResultsAvailable.ContainsKey("code") && !String.IsNullOrWhiteSpace(AutopsyResultsAvailable["code"]))
                 {
                     return AutopsyResultsAvailable["code"];
                 }
@@ -5025,7 +5081,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("AutopsyResultsAvailable", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("AutopsyResultsAvailable", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                }
             }
         }
 
@@ -5374,7 +5433,7 @@ namespace VRDR
         {
             get
             {
-                if (DeathLocationType != null && DeathLocationType.ContainsKey("code"))
+                if (DeathLocationType != null && DeathLocationType.ContainsKey("code") && !String.IsNullOrWhiteSpace(DeathLocationType["code"]))
                 {
                     return DeathLocationType["code"];
                 }
@@ -5382,7 +5441,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("DeathLocationType", value, VRDR.ValueSets.PlaceOfDeath.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("DeathLocationType", value, VRDR.ValueSets.PlaceOfDeath.Codes);
+                }
             }
         }
 
@@ -5629,11 +5691,14 @@ namespace VRDR
         {
             get
             {
-                return AgeAtDeathEditFlag.ContainsKey("code") ? AgeAtDeathEditFlag["code"] : null;
+                return AgeAtDeathEditFlag.ContainsKey("code") && !String.IsNullOrWhiteSpace(AgeAtDeathEditFlag["code"]) ? AgeAtDeathEditFlag["code"] : null;
             }
             set
             {
-                SetCodeValue("AgeAtDeathEditFlag", value, VRDR.ValueSets.EditBypass01.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("AgeAtDeathEditFlag", value, VRDR.ValueSets.EditBypass01.Codes);
+                }
             }
         }
 
@@ -5707,7 +5772,7 @@ namespace VRDR
         {
             get
             {
-                if (PregnancyStatus.ContainsKey("code"))
+                if (PregnancyStatus.ContainsKey("code") && !String.IsNullOrWhiteSpace(PregnancyStatus["code"]))
                 {
                     return PregnancyStatus["code"];
                 }
@@ -5715,7 +5780,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("PregnancyStatus", value, VRDR.ValueSets.PregnancyStatus.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("PregnancyStatus", value, VRDR.ValueSets.PregnancyStatus.Codes);
+                }
             }
         }
         /// <summary>Decedent's Pregnancy Status at Death Edit Flag.</summary>
@@ -5791,7 +5859,7 @@ namespace VRDR
         {
             get
             {
-                if (PregnancyStatusEditFlag.ContainsKey("code"))
+                if (PregnancyStatusEditFlag.ContainsKey("code") && !String.IsNullOrWhiteSpace(PregnancyStatusEditFlag["code"]))
                 {
                     return PregnancyStatusEditFlag["code"];
                 }
@@ -5799,7 +5867,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("PregnancyStatusEditFlag", value, VRDR.ValueSets.EditBypass012.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("PregnancyStatusEditFlag", value, VRDR.ValueSets.EditBypass012.Codes);
+                }
             }
         }
 
@@ -5874,7 +5945,7 @@ namespace VRDR
         {
             get
             {
-                if (ExaminerContacted.ContainsKey("code"))
+                if (ExaminerContacted.ContainsKey("code") && !String.IsNullOrWhiteSpace(ExaminerContacted["code"]))
                 {
                     return ExaminerContacted["code"];
                 }
@@ -5882,7 +5953,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("ExaminerContacted", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("ExaminerContacted", value, VRDR.ValueSets.YesNoUnknown.Codes);
+                }
             }
         }
 
@@ -6145,7 +6219,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue1_1", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue1_1", value);
+                }
             }
         }
 
@@ -6167,7 +6244,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue1_2", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue1_2", value);
+                }
             }
         }
 
@@ -6190,7 +6270,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue1_3", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue1_3", value);
+                }
             }
         }
 
@@ -6213,7 +6296,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue1_4", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue1_4", value);
+                }
             }
         }
 
@@ -6236,7 +6322,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue1_5", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue1_5", value);
+                }
             }
         }
 
@@ -6259,7 +6348,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue1_6", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue1_6", value);
+                }
             }
         }
 
@@ -6282,7 +6374,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue8_1", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue8_1", value);
+                }
             }
         }
 
@@ -6305,7 +6400,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue8_2", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue8_2", value);
+                }
             }
         }
 
@@ -6328,7 +6426,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue8_3", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue8_3", value);
+                }
             }
         }
 
@@ -6351,7 +6452,10 @@ namespace VRDR
             }
             set
             {
-                SetEmergingIssue("EmergingIssue20", value);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetEmergingIssue("EmergingIssue20", value);
+                }
             }
         }
 
@@ -6710,7 +6814,7 @@ namespace VRDR
         {
             get
             {
-                if (InjuryAtWork.ContainsKey("code"))
+                if (InjuryAtWork.ContainsKey("code") && !String.IsNullOrWhiteSpace(InjuryAtWork["code"]))
                 {
                     return InjuryAtWork["code"];
                 }
@@ -6718,7 +6822,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("InjuryAtWork", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                if(!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("InjuryAtWork", value, VRDR.ValueSets.YesNoUnknownNotApplicable.Codes);
+                }
             }
         }
 
@@ -6813,7 +6920,7 @@ namespace VRDR
                         }
                         return ("Other");
                     }
-                    else
+                    else if (!String.IsNullOrWhiteSpace(code))
                     {
                         return code;
                     }
@@ -6919,7 +7026,7 @@ namespace VRDR
         {
             get
             {
-                if (TobaccoUse.ContainsKey("code"))
+                if (TobaccoUse.ContainsKey("code") && !String.IsNullOrWhiteSpace(TobaccoUse["code"]))
                 {
                     return TobaccoUse["code"];
                 }
@@ -6927,7 +7034,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("TobaccoUse", value, VRDR.ValueSets.ContributoryTobaccoUse.Codes);
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("TobaccoUse", value, VRDR.ValueSets.ContributoryTobaccoUse.Codes);
+                }
             }
         }
 

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -115,6 +115,10 @@ namespace VRDR
             // The setter is private because the value is derived so should never be set directly
             private set
             {
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    return;
+                }
                 if (Bundle.Identifier == null)
                 {
                     Bundle.Identifier = new Identifier();

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -2489,6 +2489,7 @@ namespace VRDR
             }
             set
             {
+                // TODO: This setter should not do anything if the value is null or an empty string
                 if (InputRaceAndEthnicityObs == null)
                 {
                     CreateInputRaceEthnicityObs();
@@ -5160,6 +5161,7 @@ namespace VRDR
             }
             set
             {
+                // TODO: This setter should not do anything if the value is null or an empty string
                 if (DeathLocationLoc == null)
                 {
                     CreateDeathLocation();

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -957,7 +957,10 @@ namespace VRDR
                     ConditionContributingToDeath.Meta.Profile = condition_profile;
                     ConditionContributingToDeath.Status = ObservationStatus.Final;
                     ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
-                    ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                       ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
+                    }
                     AddReferenceToComposition(ConditionContributingToDeath.Id, "DeathCertification");
                     Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
                 }
@@ -2963,7 +2966,10 @@ namespace VRDR
             }
             set
             {
-                SetCodeValue("MaritalStatusEditFlag", value, VRDR.ValueSets.EditBypass0124.Codes);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    SetCodeValue("MaritalStatusEditFlag", value, VRDR.ValueSets.EditBypass0124.Codes);
+                }
             }
         }
 
@@ -2996,7 +3002,10 @@ namespace VRDR
                 {
                     Decedent.MaritalStatus = new CodeableConcept();
                 }
-                Decedent.MaritalStatus.Text = value;
+                if (!String.IsNullOrEmpty(value))
+                {
+                    Decedent.MaritalStatus.Text = value;
+                }
             }
         }
 
@@ -3800,7 +3809,11 @@ namespace VRDR
             {
                 if (UsualWork != null && UsualWork.Value != null && UsualWork.Value as CodeableConcept != null)
                 {
-                    return CodeableConceptToDict((CodeableConcept)UsualWork.Value)["text"];
+                    Dictionary<string, string> dict = CodeableConceptToDict((CodeableConcept)UsualWork.Value);
+                    if (dict.ContainsKey("text"))
+                    {
+                        return dict["text"];
+                    }
                 }
                 return null;
             }
@@ -4366,7 +4379,7 @@ namespace VRDR
                 {
                     CreateDispositionLocation();
                 }
-                if (value != null && !String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     DispositionLocation.Name = value;
                 }
@@ -6054,7 +6067,7 @@ namespace VRDR
                     CreateInjuryLocationLoc();
                     // LinkObservationToLocation(InjuryIncidentObs, InjuryLocationLoc);
                 }
-                if (value != null && !String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     InjuryLocationLoc.Name = value;
                 }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -5652,7 +5652,7 @@ namespace VRDR
             }
             set
             {
-                if (IsDictEmptyOrDefault(value))
+                if (IsDictEmptyOrDefault(value) && AgeAtDeathObs == null)
                 {
                     return;
                 }
@@ -5661,6 +5661,10 @@ namespace VRDR
                     CreateAgeAtDeathObs();
                 }
                 AgeAtDeathObs.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
+                if (IsDictEmptyOrDefault(value))
+                {
+                    return;
+                }
                 Extension editFlag = new Extension(ExtensionURL.BypassEditFlag, DictToCodeableConcept(value));
                 AgeAtDeathObs.Value.Extension.Add(editFlag);
             }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -327,7 +327,10 @@ namespace VRDR
             }
             set
             {
-                Composition.Date = value;
+                if (!String.IsNullOrEmpty(value))
+                {
+                    Composition.Date = value;
+                }
             }
         }
 
@@ -348,7 +351,8 @@ namespace VRDR
                 if (Composition != null)
                 {
                     Extension stateSpecificData = Composition.Extension.Where(ext => ext.Url == ExtensionURL.StateSpecificField).FirstOrDefault();
-                    if (stateSpecificData != null && stateSpecificData.Value as FhirString != null)
+                    // Console.WriteLine("KLKL" + stateSpecificData.Value.ToString());
+                    if (stateSpecificData != null && stateSpecificData.Value as FhirString != null /*&& !String.IsNullOrEmpty((stateSpecificData.Value as FhirString).ToString())*/)
                     {
                         return stateSpecificData.Value.ToString();
                     }
@@ -1571,18 +1575,25 @@ namespace VRDR
             }
             set
             {
-                HumanName name = Decedent.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                if (name != null)
+                // Remove any blank or null values.
+                value = value.Where(v => !String.IsNullOrEmpty(v)).ToArray();
+                // Set names if there are any non-blank values.
+                if (value.Length > 0)
                 {
-                    name.Given = value;
+                  HumanName name = Decedent.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+                  if (name != null)
+                  {
+                      name.Given = value;
+                  }
+                  else
+                  {
+                      name = new HumanName();
+                      name.Use = HumanName.NameUse.Official;
+                      name.Given = value;
+                      Decedent.Name.Add(name);
+                  }
                 }
-                else
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Given = value;
-                    Decedent.Name.Add(name);
-                }
+
             }
         }
 
@@ -5164,7 +5175,7 @@ namespace VRDR
                 {
                     DeathLocationLoc.Position = new Location.PositionComponent();
                 }
-                if (value != null)
+                if (!String.IsNullOrEmpty(value))
                 {
                     DeathLocationLoc.Position.Latitude = Convert.ToDecimal(value);
                 }
@@ -5202,7 +5213,7 @@ namespace VRDR
                 {
                     DeathLocationLoc.Position = new Location.PositionComponent();
                 }
-                if (value != null)
+                if (!String.IsNullOrEmpty(value))
                 {
                     DeathLocationLoc.Position.Longitude = Convert.ToDecimal(value);
                 }
@@ -5944,7 +5955,7 @@ namespace VRDR
                 {
                     InjuryLocationLoc.Position = new Location.PositionComponent();
                 }
-                if (value != null)
+                if (!String.IsNullOrEmpty(value))
                 {
                     InjuryLocationLoc.Position.Latitude = Convert.ToDecimal(value);
                 }
@@ -5986,7 +5997,7 @@ namespace VRDR
                 {
                     InjuryLocationLoc.Position = new Location.PositionComponent();
                 }
-                if (value != null)
+                if (!String.IsNullOrEmpty(value))
                 {
                     InjuryLocationLoc.Position.Longitude = Convert.ToDecimal(value);
                 }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -367,11 +367,11 @@ namespace VRDR
             set
             {
                 // TODO: Handle case where Composition == null (either create it or throw exception)
+                Composition.Extension.RemoveAll(ext => ext.Url == ExtensionURL.StateSpecificField);
                 if (String.IsNullOrWhiteSpace(value))
                 {
                     return;
                 }
-                Composition.Extension.RemoveAll(ext => ext.Url == ExtensionURL.StateSpecificField);
                 Extension stateSpecificData = new Extension();
                 stateSpecificData.Url = ExtensionURL.StateSpecificField;
                 stateSpecificData.Value = new FhirString(value);
@@ -1818,11 +1818,11 @@ namespace VRDR
             }
             set
             {
+                Decedent.Extension.RemoveAll(ext => ext.Url == ExtensionURL.NVSSSexAtDeath);
                 if (IsDictEmptyOrDefault(value) && Decedent.Extension == null)
                 {
                     return;
                 }
-                Decedent.Extension.RemoveAll(ext => ext.Url == ExtensionURL.NVSSSexAtDeath);
                 Extension sex = new Extension();
                 sex.Url = ExtensionURL.NVSSSexAtDeath;
                 sex.Value = DictToCodeableConcept(value);
@@ -2191,11 +2191,11 @@ namespace VRDR
             }
             set
             {
+                Decedent.Identifier.RemoveAll(iden => iden.System == CodeSystems.US_SSN);
                 if (String.IsNullOrWhiteSpace(value))
                 {
                     return;
                 }
-                Decedent.Identifier.RemoveAll(iden => iden.System == CodeSystems.US_SSN);
                 Identifier ssn = new Identifier();
                 ssn.Type = new CodeableConcept(CodeSystems.HL7_identifier_type, "SB", "Social Beneficiary Identifier", null);
                 ssn.System = CodeSystems.US_SSN;
@@ -2551,14 +2551,14 @@ namespace VRDR
             }
             set
             {
-                if (String.IsNullOrWhiteSpace(value)) {
-                    return;
-                }
                 if (InputRaceAndEthnicityObs == null)
                 {
                     CreateInputRaceEthnicityObs();
                 }
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
+                if (String.IsNullOrWhiteSpace(value)) {
+                    return;
+                }
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCode, NvssEthnicity.Literal, NvssEthnicity.Literal, null);
                 component.Value = new FhirString(value);
@@ -3897,15 +3897,15 @@ namespace VRDR
             }
             set
             {
-                if ((String.IsNullOrWhiteSpace(value)))
-                {
-                    return;
-                }
                 if (UsualWork == null)
                 {
                     CreateUsualWork();
                 }
                 UsualWork.Component.RemoveAll(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == "21844-6");
+                if ((String.IsNullOrWhiteSpace(value)))
+                {
+                    return;
+                }
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.LOINC, "21844-6", "History of Usual industry", null);
                 component.Value = new CodeableConcept(CodeSystems.NullFlavor_HL7_V3, "UNK", "unknown", value);     // code is required
@@ -5652,15 +5652,15 @@ namespace VRDR
             }
             set
             {
-                if (IsDictEmptyOrDefault(value) && AgeAtDeathObs == null)
-                {
-                    return;
-                }
                 if (AgeAtDeathObs == null)
                 {
                     CreateAgeAtDeathObs();
                 }
                 AgeAtDeathObs.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
+                if (IsDictEmptyOrDefault(value) && AgeAtDeathObs == null)
+                {
+                    return;
+                }
                 Extension editFlag = new Extension(ExtensionURL.BypassEditFlag, DictToCodeableConcept(value));
                 AgeAtDeathObs.Value.Extension.Add(editFlag);
             }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -224,9 +224,11 @@ namespace VRDR
                 {
                     CreateDeathCertification();
                 }
-
-                Composition.Attester.First().Time = value;
-                DeathCertification.Performed = new FhirDateTime(value);
+                if(!String.IsNullOrEmpty(value))
+                {
+                    Composition.Attester.First().Time = value;
+                    DeathCertification.Performed = new FhirDateTime(value);
+                }
             }
         }
 
@@ -365,7 +367,10 @@ namespace VRDR
                 Composition.Extension.RemoveAll(ext => ext.Url == ExtensionURL.StateSpecificField);
                 Extension stateSpecificData = new Extension();
                 stateSpecificData.Url = ExtensionURL.StateSpecificField;
-                stateSpecificData.Value = new FhirString(value);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    stateSpecificData.Value = new FhirString(value);
+                }
                 Composition.Extension.Add(stateSpecificData);
             }
         }
@@ -664,18 +669,7 @@ namespace VRDR
                 {
                     CreateCertifier();
                 }
-                HumanName name = Certifier.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                if (name != null)
-                {
-                    name.Given = value;
-                }
-                else
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Given = value;
-                    Certifier.Name.Add(name);
-                }
+                updateGivenHumanName(value, Certifier.Name);
             }
         }
 
@@ -1024,23 +1018,48 @@ namespace VRDR
                 {
                     if (value.Length > 0)
                     {
-                        COD1A = value[0].Item1;
-                        INTERVAL1A = value[0].Item2;
+                        if (!String.IsNullOrEmpty(value[0].Item1))
+                        {
+                            COD1A = value[0].Item1;
+                        }
+                        if (!String.IsNullOrEmpty(value[0].Item2))
+                        {
+                            INTERVAL1A = value[0].Item2;
+                        }
                     }
                     if (value.Length > 1)
                     {
-                        COD1B = value[1].Item1;
-                        INTERVAL1B = value[1].Item2;
+                        if (!String.IsNullOrEmpty(value[1].Item1))
+                        {
+                            COD1B = value[1].Item1;
+                        }
+                        if (!String.IsNullOrEmpty(value[1].Item2))
+                        {
+                          INTERVAL1B = value[1].Item2;
+                        }
                     }
                     if (value.Length > 2)
                     {
-                        COD1C = value[2].Item1;
-                        INTERVAL1C = value[2].Item2;
+                        if (!String.IsNullOrEmpty(value[2].Item1))
+                        {
+                            COD1C = value[2].Item1;
+
+                        }
+                        if (!String.IsNullOrEmpty(value[2].Item2))
+                        {
+                            INTERVAL1C = value[2].Item2;
+                        }
                     }
                     if (value.Length > 3)
                     {
-                        COD1D = value[3].Item1;
-                        INTERVAL1D = value[3].Item2;
+                        if (!String.IsNullOrEmpty(value[3].Item1))
+                        {
+                            COD1D = value[3].Item1;
+                        }
+                        if (!String.IsNullOrEmpty(value[3].Item2))
+                        {
+                            INTERVAL1D = value[3].Item2;
+                        }
                     }
                 }
             }
@@ -1071,7 +1090,10 @@ namespace VRDR
                 {
                     CauseOfDeathConditionA = CauseOfDeathCondition(0);
                 }
-                CauseOfDeathConditionA.Value = new CodeableConcept(null, null, null, value);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    CauseOfDeathConditionA.Value = new CodeableConcept(null, null, null, value);
+                }
             }
         }
 
@@ -1108,7 +1130,7 @@ namespace VRDR
                 // Find correct component; if doesn't exist add another
                 var intervalComp = CauseOfDeathConditionA.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null &&
                        ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "69440-6");
-                if (intervalComp != null)
+                if (intervalComp != null && !String.IsNullOrEmpty(value))
                 {
                     ((Observation.ComponentComponent)intervalComp).Value = new FhirString(value);
                 }
@@ -1116,7 +1138,10 @@ namespace VRDR
                 {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new FhirString(value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        component.Value = new FhirString(value);
+                    }
                     CauseOfDeathConditionA.Component.Add(component);
                 }
             }
@@ -1197,7 +1222,10 @@ namespace VRDR
                 {
                     CauseOfDeathConditionB = CauseOfDeathCondition(1);
                 }
-                CauseOfDeathConditionB.Value = new CodeableConcept(null, null, null, value);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    CauseOfDeathConditionB.Value = new CodeableConcept(null, null, null, value);
+                }
             }
         }
 
@@ -1242,7 +1270,10 @@ namespace VRDR
                 {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new FhirString(value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        component.Value = new FhirString(value);
+                    }
                     CauseOfDeathConditionB.Component.Add(component);
                 }
             }
@@ -1322,7 +1353,10 @@ namespace VRDR
                 {
                     CauseOfDeathConditionC = CauseOfDeathCondition(2);
                 }
-                CauseOfDeathConditionC.Value = new CodeableConcept(null, null, null, value);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    CauseOfDeathConditionC.Value = new CodeableConcept(null, null, null, value);
+                }
             }
         }
 
@@ -1367,7 +1401,10 @@ namespace VRDR
                 {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new FhirString(value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        component.Value = new FhirString(value);
+                    }
                     CauseOfDeathConditionC.Component.Add(component);
                 }
             }
@@ -1447,7 +1484,10 @@ namespace VRDR
                 {
                     CauseOfDeathConditionD = CauseOfDeathCondition(3);
                 }
-                CauseOfDeathConditionD.Value = new CodeableConcept(null, null, null, value);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    CauseOfDeathConditionD.Value = new CodeableConcept(null, null, null, value);
+                }
             }
         }
 
@@ -1492,7 +1532,10 @@ namespace VRDR
                 {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "69440-6", "Disease onset to death interval", null);
-                    component.Value = new FhirString(value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        component.Value = new FhirString(value);
+                    }
                     CauseOfDeathConditionD.Component.Add(component);
                 }
             }
@@ -1575,25 +1618,7 @@ namespace VRDR
             }
             set
             {
-                // Remove any blank or null values.
-                value = value.Where(v => !String.IsNullOrEmpty(v)).ToArray();
-                // Set names if there are any non-blank values.
-                if (value.Length > 0)
-                {
-                  HumanName name = Decedent.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                  if (name != null)
-                  {
-                      name.Given = value;
-                  }
-                  else
-                  {
-                      name = new HumanName();
-                      name.Use = HumanName.NameUse.Official;
-                      name.Given = value;
-                      Decedent.Name.Add(name);
-                  }
-                }
-
+                updateGivenHumanName(value, Decedent.Name);
             }
         }
 
@@ -2494,7 +2519,6 @@ namespace VRDR
             }
             set
             {
-                // TODO: This setter should not do anything if the value is null or an empty string
                 if (InputRaceAndEthnicityObs == null)
                 {
                     CreateInputRaceEthnicityObs();
@@ -2502,7 +2526,10 @@ namespace VRDR
                 InputRaceAndEthnicityObs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCode, NvssEthnicity.Literal, NvssEthnicity.Literal, null);
-                component.Value = new FhirString(value);
+                if (!String.IsNullOrEmpty(value))
+                {
+                    component.Value = new FhirString(value);
+                }
                 InputRaceAndEthnicityObs.Component.Add(component);
             }
         }
@@ -3003,19 +3030,7 @@ namespace VRDR
                 {
                     CreateFather();
                 }
-                HumanName name = Father.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                if (name != null && value != null)
-                {
-                    name.Given = value;
-                }
-                else if (value != null)
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Given = value;
-                    Father.Name.Add(name);
-                }
-
+                updateGivenHumanName(value, Father.Name);
             }
         }
 
@@ -3129,19 +3144,7 @@ namespace VRDR
                 {
                     CreateMother();
                 }
-                HumanName name = Mother.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                if (name != null && value != null)
-                {
-                    name.Given = value;
-                }
-                else if (value != null)
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Given = value;
-                    Mother.Name.Add(name);
-                }
-
+                updateGivenHumanName(value, Mother.Name);
             }
         }
 
@@ -3256,19 +3259,7 @@ namespace VRDR
                 {
                     CreateSpouse();
                 }
-                HumanName name = Spouse.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
-                if (name != null && value != null)
-                {
-                    name.Given = value;
-                }
-                else if (value != null)
-                {
-                    name = new HumanName();
-                    name.Use = HumanName.NameUse.Official;
-                    name.Given = value;
-                    Spouse.Name.Add(name);
-                }
-
+                updateGivenHumanName(value, Spouse.Name);
             }
         }
 
@@ -3714,13 +3705,19 @@ namespace VRDR
                     var stateComp = BirthRecordIdentifier.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "21842-0");
                     if (stateComp != null)
                     {
-                        ((Observation.ComponentComponent)stateComp).Value = new FhirString(value);
+                        if (!String.IsNullOrEmpty(value))
+                        {
+                          ((Observation.ComponentComponent)stateComp).Value = new FhirString(value);
+                        }
                     }
                     else
                     {
                         Observation.ComponentComponent component = new Observation.ComponentComponent();
                         component.Code = new CodeableConcept(CodeSystems.LOINC, "21842-0", "Birthplace", null);
-                        component.Value = new FhirString(value);
+                        if (!String.IsNullOrEmpty(value))
+                        {
+                            component.Value = new FhirString(value);
+                        }
                         BirthRecordIdentifier.Component.Add(component);
                     }
                 }
@@ -3768,13 +3765,19 @@ namespace VRDR
                     var stateComp = BirthRecordIdentifier.Component.FirstOrDefault(entry => ((Observation.ComponentComponent)entry).Code != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80904-6");
                     if (stateComp != null)
                     {
-                        ((Observation.ComponentComponent)stateComp).Value = new FhirDateTime(value);
+                        if (!String.IsNullOrEmpty(value))
+                        {
+                            ((Observation.ComponentComponent)stateComp).Value = new FhirDateTime(value);
+                        }
                     }
                     else
                     {
                         Observation.ComponentComponent component = new Observation.ComponentComponent();
                         component.Code = new CodeableConcept(CodeSystems.LOINC, "80904-6", "Birth year", null);
-                        component.Value = new FhirDateTime(value);
+                        if (!String.IsNullOrEmpty(value))
+                        {
+                            component.Value = new FhirDateTime(value);
+                        }
                         BirthRecordIdentifier.Component.Add(component);
                     }
                 }
@@ -4221,7 +4224,10 @@ namespace VRDR
                 {
                     CreateFuneralHome();
                 }
-                FuneralHome.Name = value;
+                if (!String.IsNullOrEmpty(value))
+                {
+                    FuneralHome.Name = value;
+                }
             }
         }
 
@@ -4654,7 +4660,10 @@ namespace VRDR
                 {
                     CreateDeathDateObs();
                 }
-                SetPartialTime(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), value);
+                if(!String.IsNullOrEmpty(value))
+                {
+                    SetPartialTime(DeathDateObs.Value.Extension.Find(ext => ext.Url == ExtensionURL.PartialDateTime), value);
+                }
             }
         }
 
@@ -4782,13 +4791,19 @@ namespace VRDR
                          && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault() != null && ((Observation.ComponentComponent)entry).Code.Coding.FirstOrDefault().Code == "80616-6");
                 if (pronComp != null)
                 {
-                    ((Observation.ComponentComponent)pronComp).Value = new FhirDateTime(value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        ((Observation.ComponentComponent)pronComp).Value = new FhirDateTime(value);
+                    }
                 }
                 else
                 {
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     component.Code = new CodeableConcept(CodeSystems.LOINC, "80616-6", "Date and time pronounced dead [US Standard Certificate of Death]", null);
-                    component.Value = new FhirDateTime(value);
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        component.Value = new FhirDateTime(value);
+                    }
                     DeathDateObs.Component.Add(component);
                 }
             }
@@ -5133,7 +5148,7 @@ namespace VRDR
                 {
                     CreateDeathLocation();
                 }
-                if (value != null && !String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     DeathLocationLoc.Name = value;
                 }
@@ -5166,7 +5181,6 @@ namespace VRDR
             }
             set
             {
-                // TODO: This setter should not do anything if the value is null or an empty string
                 if (DeathLocationLoc == null)
                 {
                     CreateDeathLocation();
@@ -5179,7 +5193,6 @@ namespace VRDR
                 {
                     DeathLocationLoc.Position.Latitude = Convert.ToDecimal(value);
                 }
-
             }
         }
 
@@ -5251,13 +5264,16 @@ namespace VRDR
                     DeathLocationLoc.Meta = new Meta();
                     string[] deathlocation_profile = { ProfileURL.DeathLocation };
                     DeathLocationLoc.Meta.Profile = deathlocation_profile;
-                    DeathLocationLoc.Description = value;
+                    if (!String.IsNullOrEmpty(value))
+                    {
+                        DeathLocationLoc.Description = value;
+                    }
                     DeathLocationLoc.Type.Add(new CodeableConcept(CodeSystems.LocationType, "death", "death location", null));
                     // LinkObservationToLocation(DeathDateObs, DeathLocationLoc);
                     AddReferenceToComposition(DeathLocationLoc.Id, "DeathInvestigation");
                     Bundle.AddResourceEntry(DeathLocationLoc, "urn:uuid:" + DeathLocationLoc.Id);
                 }
-                else
+                else if (!String.IsNullOrEmpty(value))
                 {
                     DeathLocationLoc.Description = value;
                 }
@@ -6053,7 +6069,7 @@ namespace VRDR
         /// <summary>Set an emerging issue value, creating an empty EmergingIssues Observation as needed.</summary>
         private void SetEmergingIssue(string identifier, string value)
         {
-            if (value == null && EmergingIssues == null)
+            if (String.IsNullOrEmpty(value) && EmergingIssues == null)
             {
                 return;
             }
@@ -6074,7 +6090,10 @@ namespace VRDR
             EmergingIssues.Component.RemoveAll(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == identifier);
             Observation.ComponentComponent component = new Observation.ComponentComponent();
             component.Code = new CodeableConcept(CodeSystems.ComponentCode, identifier, null, null);
-            component.Value = new FhirString(value);
+            if (!String.IsNullOrEmpty(value))
+            {
+                component.Value = new FhirString(value);
+            }
             EmergingIssues.Component.Add(component);
         }
 

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -63,8 +63,8 @@ namespace VRDR
                 {
                     Extension ext = new Extension(ExtensionURL.CertificateNumber, new FhirString(value));
                     Bundle.Identifier.Extension.Add(ext);
+                    UpdateDeathRecordIdentifier();
                 }
-                UpdateDeathRecordIdentifier();
             }
         }
 

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -5652,15 +5652,15 @@ namespace VRDR
             }
             set
             {
+                if (IsDictEmptyOrDefault(value))
+                {
+                    return;
+                }
                 if (AgeAtDeathObs == null)
                 {
                     CreateAgeAtDeathObs();
                 }
                 AgeAtDeathObs.Value.Extension.RemoveAll(ext => ext.Url == ExtensionURL.BypassEditFlag);
-                if (IsDictEmptyOrDefault(value) && AgeAtDeathObs == null)
-                {
-                    return;
-                }
                 Extension editFlag = new Extension(ExtensionURL.BypassEditFlag, DictToCodeableConcept(value));
                 AgeAtDeathObs.Value.Extension.Add(editFlag);
             }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -1031,45 +1031,45 @@ namespace VRDR
                 {
                     if (value.Length > 0)
                     {
-                        if (!String.IsNullOrEmpty(value[0].Item1))
+                        if (!String.IsNullOrWhiteSpace(value[0].Item1))
                         {
                             COD1A = value[0].Item1;
                         }
-                        if (!String.IsNullOrEmpty(value[0].Item2))
+                        if (!String.IsNullOrWhiteSpace(value[0].Item2))
                         {
                             INTERVAL1A = value[0].Item2;
                         }
                     }
                     if (value.Length > 1)
                     {
-                        if (!String.IsNullOrEmpty(value[1].Item1))
+                        if (!String.IsNullOrWhiteSpace(value[1].Item1))
                         {
                             COD1B = value[1].Item1;
                         }
-                        if (!String.IsNullOrEmpty(value[1].Item2))
+                        if (!String.IsNullOrWhiteSpace(value[1].Item2))
                         {
                           INTERVAL1B = value[1].Item2;
                         }
                     }
                     if (value.Length > 2)
                     {
-                        if (!String.IsNullOrEmpty(value[2].Item1))
+                        if (!String.IsNullOrWhiteSpace(value[2].Item1))
                         {
                             COD1C = value[2].Item1;
 
                         }
-                        if (!String.IsNullOrEmpty(value[2].Item2))
+                        if (!String.IsNullOrWhiteSpace(value[2].Item2))
                         {
                             INTERVAL1C = value[2].Item2;
                         }
                     }
                     if (value.Length > 3)
                     {
-                        if (!String.IsNullOrEmpty(value[3].Item1))
+                        if (!String.IsNullOrWhiteSpace(value[3].Item1))
                         {
                             COD1D = value[3].Item1;
                         }
-                        if (!String.IsNullOrEmpty(value[3].Item2))
+                        if (!String.IsNullOrWhiteSpace(value[3].Item2))
                         {
                             INTERVAL1D = value[3].Item2;
                         }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -220,15 +220,16 @@ namespace VRDR
             }
             set
             {
-               if(!String.IsNullOrEmpty(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (DeathCertification == null)
-                    {
-                        CreateDeathCertification();
-                    }
-                    Composition.Attester.First().Time = value;
-                    DeathCertification.Performed = new FhirDateTime(value);
+                    return;
                 }
+                if (DeathCertification == null)
+                {
+                    CreateDeathCertification();
+                }
+                Composition.Attester.First().Time = value;
+                DeathCertification.Performed = new FhirDateTime(value);
             }
         }
 
@@ -366,14 +367,15 @@ namespace VRDR
             set
             {
                 // TODO: Handle case where Composition == null (either create it or throw exception)
-                if (!String.IsNullOrEmpty(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    Composition.Extension.RemoveAll(ext => ext.Url == ExtensionURL.StateSpecificField);
-                    Extension stateSpecificData = new Extension();
-                    stateSpecificData.Url = ExtensionURL.StateSpecificField;
-                    stateSpecificData.Value = new FhirString(value);
-                    Composition.Extension.Add(stateSpecificData);
+                    return;
                 }
+                Composition.Extension.RemoveAll(ext => ext.Url == ExtensionURL.StateSpecificField);
+                Extension stateSpecificData = new Extension();
+                stateSpecificData.Url = ExtensionURL.StateSpecificField;
+                stateSpecificData.Value = new FhirString(value);
+                Composition.Extension.Add(stateSpecificData);
             }
         }
 
@@ -949,27 +951,28 @@ namespace VRDR
             }
             set
             {
-                if (!String.IsNullOrEmpty(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (ConditionContributingToDeath != null)
-                    {
-                        ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
-                    }
-                    else
-                    {
-                        ConditionContributingToDeath = new Observation();
-                        ConditionContributingToDeath.Id = Guid.NewGuid().ToString();
-                        ConditionContributingToDeath.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
-                        ConditionContributingToDeath.Performer.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
-                        ConditionContributingToDeath.Meta = new Meta();
-                        string[] condition_profile = { ProfileURL.CauseOfDeathPart2 };
-                        ConditionContributingToDeath.Meta.Profile = condition_profile;
-                        ConditionContributingToDeath.Status = ObservationStatus.Final;
-                        ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
-                        ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
-                        AddReferenceToComposition(ConditionContributingToDeath.Id, "DeathCertification");
-                        Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
-                    }
+                    return;
+                }
+                if (ConditionContributingToDeath != null)
+                {
+                    ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
+                }
+                else
+                {
+                    ConditionContributingToDeath = new Observation();
+                    ConditionContributingToDeath.Id = Guid.NewGuid().ToString();
+                    ConditionContributingToDeath.Subject = new ResourceReference("urn:uuid:" + Decedent.Id);
+                    ConditionContributingToDeath.Performer.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
+                    ConditionContributingToDeath.Meta = new Meta();
+                    string[] condition_profile = { ProfileURL.CauseOfDeathPart2 };
+                    ConditionContributingToDeath.Meta.Profile = condition_profile;
+                    ConditionContributingToDeath.Status = ObservationStatus.Final;
+                    ConditionContributingToDeath.Code = (new CodeableConcept(CodeSystems.LOINC, "69441-4", "Other significant causes or conditions of death", null));
+                    ConditionContributingToDeath.Value = new CodeableConcept(null, null, null, value);
+                    AddReferenceToComposition(ConditionContributingToDeath.Id, "DeathCertification");
+                    Bundle.AddResourceEntry(ConditionContributingToDeath, "urn:uuid:" + ConditionContributingToDeath.Id);
                 }
             }
         }
@@ -1096,14 +1099,15 @@ namespace VRDR
             }
             set
             {
-                if (!String.IsNullOrEmpty(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (CauseOfDeathConditionA == null)
-                    {
-                        CauseOfDeathConditionA = CauseOfDeathCondition(0);
-                    }
-                    CauseOfDeathConditionA.Value = new CodeableConcept(null, null, null, value);
+                    return;
                 }
+                if (CauseOfDeathConditionA == null)
+                {
+                    CauseOfDeathConditionA = CauseOfDeathCondition(0);
+                }
+                CauseOfDeathConditionA.Value = new CodeableConcept(null, null, null, value);
             }
         }
 
@@ -3029,14 +3033,15 @@ namespace VRDR
             }
             set
             {
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    return;
+                }
                 if (Decedent.MaritalStatus == null)
                 {
                     Decedent.MaritalStatus = new CodeableConcept();
                 }
-                if (!String.IsNullOrEmpty(value))
-                {
-                    Decedent.MaritalStatus.Text = value;
-                }
+                Decedent.MaritalStatus.Text = value;
             }
         }
 
@@ -5270,6 +5275,10 @@ namespace VRDR
             }
             set
             {
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    return;
+                }
                 if (DeathLocationLoc == null)
                 {
                     CreateDeathLocation();
@@ -5278,11 +5287,7 @@ namespace VRDR
                 {
                     DeathLocationLoc.Position = new Location.PositionComponent();
                 }
-                if (!String.IsNullOrEmpty(value))
-                {
-                    DeathLocationLoc.Position.Longitude = Convert.ToDecimal(value);
-                }
-
+                DeathLocationLoc.Position.Longitude = Convert.ToDecimal(value);
             }
         }
 
@@ -6154,10 +6159,7 @@ namespace VRDR
             EmergingIssues.Component.RemoveAll(cmp => cmp.Code != null && cmp.Code.Coding != null && cmp.Code.Coding.Count() > 0 && cmp.Code.Coding.First().Code == identifier);
             Observation.ComponentComponent component = new Observation.ComponentComponent();
             component.Code = new CodeableConcept(CodeSystems.ComponentCode, identifier, null, null);
-            if (!String.IsNullOrEmpty(value))
-            {
-                component.Value = new FhirString(value);
-            }
+            component.Value = new FhirString(value);
             EmergingIssues.Component.Add(component);
         }
 

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -6109,7 +6109,7 @@ namespace VRDR
             }
             set
             {
-                if ((value == null && InjuryLocationLoc == null) || String.IsNullOrWhiteSpace(value))
+                if (String.IsNullOrWhiteSpace(value) && InjuryLocationLoc == null)
                 {
                     return;
                 }

--- a/VRDR/DeathRecord_submissionProperties.cs
+++ b/VRDR/DeathRecord_submissionProperties.cs
@@ -2136,11 +2136,6 @@ namespace VRDR
                     Extension withinCityLimits = new Extension();
                     withinCityLimits.Url = ExtensionURL.WithinCityLimitsIndicator;
                     withinCityLimits.Value = DictToCoding(value);
-                    // Coding coding = DictToCoding(value);
-                    // if (coding != null)
-                    // {
-                    //     withinCityLimits.Value = coding;
-                    // }
                     Decedent.Address.FirstOrDefault().Extension.Add(withinCityLimits);
                 }
             }

--- a/VRDR/DeathRecord_util.cs
+++ b/VRDR/DeathRecord_util.cs
@@ -246,8 +246,9 @@ namespace VRDR
                 {
                     coding.Display = dict["display"];
                 }
+                return coding;
             }
-            return coding;
+            return null;
         }
 
         /// <summary>Convert a "code" dictionary to a FHIR CodableConcept.</summary>

--- a/VRDR/DeathRecord_util.cs
+++ b/VRDR/DeathRecord_util.cs
@@ -258,7 +258,7 @@ namespace VRDR
             CodeableConcept codeableConcept = new CodeableConcept();
             Coding coding = DictToCoding(dict);
             codeableConcept.Coding.Add(coding);
-            if (dict != null && dict.ContainsKey("text") && dict["text"] != null && dict["text"].Length > 0)
+            if (dict != null && dict.ContainsKey("text") && !String.IsNullOrEmpty(dict["text"]))
             {
                 codeableConcept.Text = dict["text"];
             }
@@ -306,13 +306,9 @@ namespace VRDR
             {
                 Coding coding = codeableConcept.Coding.FirstOrDefault();
                 var codeDict = CodingToDict(coding);
-                if (codeableConcept != null && codeableConcept.Text != null && codeableConcept.Text.Length > 0)
+                if (codeableConcept != null && !String.IsNullOrEmpty(codeableConcept.Text))
                 {
                     codeDict["text"] = codeableConcept.Text;
-                }
-                else
-                {
-                    codeDict["text"] = "";
                 }
                 return codeDict;
             }

--- a/VRDR/DeathRecord_util.cs
+++ b/VRDR/DeathRecord_util.cs
@@ -989,6 +989,32 @@ namespace VRDR
             }
             return record;
         }
+
+        /// <summary>Helper method to create a HumanName from a list of strings.</summary>
+        /// <param name="value">A list of strings to be converted into a name.</param>
+        /// <param name="names">The current list of HumanName attributes for the person.</param>
+        public static void updateGivenHumanName(string[] value, List<HumanName> names)
+        {
+            // Remove any blank or null values.
+            value = value.Where(v => !String.IsNullOrEmpty(v)).ToArray();
+            // Set names only if there are non-blank values.
+            if (value.Length < 1)
+            {
+              return;
+            }
+            HumanName name = names.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+            if (name != null)
+            {
+                name.Given = value;
+            }
+            else
+            {
+                name = new HumanName();
+                name.Use = HumanName.NameUse.Official;
+                name.Given = value;
+                names.Add(name);
+            }
+        }
     }
 
     /// <summary>Property attribute used to describe a DeathRecord property.</summary>

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -2918,7 +2918,7 @@ namespace VRDR
             get
             {
                 var ret = record.CertificationRoleHelper;
-                if (Mappings.CertifierTypes.FHIRToIJE.ContainsKey(ret))
+                if (ret != null && Mappings.CertifierTypes.FHIRToIJE.ContainsKey(ret))
                 {
                     return Get_MappingFHIRToIJE(Mappings.CertifierTypes.FHIRToIJE, "CertificationRole", "CERTL");
                 }
@@ -3949,7 +3949,7 @@ namespace VRDR
             get
             {
                 var ret = record.TransportationRoleHelper;
-                if (Mappings.TransportationIncidentRole.FHIRToIJE.ContainsKey(ret))
+                if (ret != null && Mappings.TransportationIncidentRole.FHIRToIJE.ContainsKey(ret))
                 {
                     return Get_MappingFHIRToIJE(Mappings.TransportationIncidentRole.FHIRToIJE, "TransportationRole", "TRANSPRT");
                 }


### PR DESCRIPTION
This PR fixes cases where the properties of a blank death record should have `null` or no value rather than blank whitespace.