### PR TITLE
Provide different error for DSTATE missing vs incorrect

### DIFF
--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -404,6 +404,19 @@ namespace VRDR.Tests
             Assert.Equal("Dmiddle", ije.DMIDDLE.Trim());
         }
 
+        // If the DSTATE is not set we should get a different message from it being set to an invalid value
+        [Fact]
+        public void DSTATE_Errors()
+        {
+            DeathRecord record = new DeathRecord();
+            record.DeathLocationJurisdiction = ""; // No jurisdiction code
+            ArgumentOutOfRangeException e = Assert.Throws<ArgumentOutOfRangeException>(() => new IJEMortality(record));
+            Assert.Equal("Specified argument was out of the range of valid values. (Parameter 'Found 1 validation errors:\nDSTATE field is missing.')", e.Message);
+            record.DeathLocationJurisdiction = "QQ"; // Not a valid jurisdiction code
+            e = Assert.Throws<ArgumentOutOfRangeException>(() => new IJEMortality(record));
+            Assert.Equal("Specified argument was out of the range of valid values. (Parameter 'Found 1 validation errors:\nDSTATE value of QQ is invalid.')", e.Message);
+        }
+
         private string FixturePath(string filePath)
         {
             if (Path.IsPathRooted(filePath))

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -843,7 +843,11 @@ namespace VRDR
             get
             {
                 string value = LeftJustified_Get("DSTATE", "DeathLocationJurisdiction");
-                if (dataLookup.JurisdictionNameToJurisdictionCode(value) == null)
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    validationErrors.Add("DSTATE field is missing.");
+                }
+                else if (dataLookup.JurisdictionNameToJurisdictionCode(value) == null)
                 {
                     validationErrors.Add("DSTATE value of " + value + " is invalid.");
                 }


### PR DESCRIPTION
This pull request updates DSTATE validation to provide a different error when there is no value provided as compared to when an invalid value is provided.