### PR TITLE
Fix IJEMortality handling of NCHS-formatted ICD10 codes

### DIFF
--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -415,6 +415,34 @@ namespace VRDR.Tests
             e = Assert.Throws<ArgumentOutOfRangeException>(() => new IJEMortality(record));
             Assert.Equal("Specified argument was out of the range of valid values. (Parameter 'Found 1 validation errors:\nError: FHIR field DeathLocationJurisdiction has value 'QQ', which is invalid for IJE field DSTATE.')", e.Message);
         }
+        // NCHS has quirky ICD10 codes.  If someone tries to use an actual ICD10 code with periods it should throw an exception
+        [Fact]
+        public void ICD10_Errors()
+        {
+            // Create an empty IJE Mortality record
+            IJEMortality ije = new IJEMortality();
+            // Populate the IJE fields
+            ije.DOD_YR = "2022";
+            ije.DSTATE = "YC";
+            ije.FILENO = "123";
+            ije.AUXNO = "500";
+            ArgumentException e1 = Assert.Throws<ArgumentException>(() => ije.RAC = "T27.3T27.0");
+            ije.EAC = "11T273  21T270 &";
+            Assert.Equal("11T273  21T270 &", ije.EAC.Trim());
+            ije.EAC = "11T27   21T27  &";
+            Assert.Equal("11T27   21T27  &", ije.EAC.Trim());
+            ije.ACME_UC = "T273";
+            Assert.Equal("T273",ije.ACME_UC);
+            ArgumentException e2 = Assert.Throws<ArgumentException>(() => ije.ACME_UC = "T27.3");
+            ije.MAN_UC = "T273";
+            Assert.Equal("T273",ije.MAN_UC);
+            ArgumentException e3 = Assert.Throws<ArgumentException>(() => ije.MAN_UC = "T27.3");
+            ije.RAC = "T27  T27 1";
+            Assert.Equal("T27  T27 1", ije.RAC.Trim());
+            ije.RAC = "T273 T2701";
+            Assert.Equal("T273 T2701", ije.RAC.Trim());
+            ArgumentException e4 = Assert.Throws<ArgumentException>(() => ije.EAC = "11T27.321T27.0&");
+        }
 
         private string FixturePath(string filePath)
         {

--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -432,10 +432,10 @@ namespace VRDR.Tests
             ije.EAC = "11T27   21T27  &";
             Assert.Equal("11T27   21T27  &", ije.EAC.Trim());
             ije.ACME_UC = "T273";
-            Assert.Equal("T273",ije.ACME_UC);
+            Assert.Equal("T273", ije.ACME_UC);
             ArgumentException e2 = Assert.Throws<ArgumentException>(() => ije.ACME_UC = "T27.3");
             ije.MAN_UC = "T273";
-            Assert.Equal("T273",ije.MAN_UC);
+            Assert.Equal("T273", ije.MAN_UC);
             ArgumentException e3 = Assert.Throws<ArgumentException>(() => ije.MAN_UC = "T27.3");
             ije.RAC = "T27  T27 1";
             Assert.Equal("T27  T27 1", ije.RAC.Trim());

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -824,7 +824,7 @@ namespace VRDR
             // NCHS tacks on an extra character to some ICD10 codes, e.g., K7210 (K27.10)
             Regex NCHSICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB][0-9A-TV-Z]{0,2}$");
 
-            return (!String.IsNullOrEmpty(nchsicd10code) &&
+            return (String.IsNullOrEmpty(nchsicd10code) ||
                  NCHSICD10regex.Match(nchsicd10code).Success);
         }
 

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -775,21 +775,19 @@ namespace VRDR
         /// <summary>NCHS ICD10 to actual ICD10 </summary>
         private string NCHSICD10toActualICD10(string nchsicd10code)
         {
-            // ICD-10 diagnosis codes always begin with a letter (except U) followed by a digit.
-            // The third character is usually a digit, but could be an A or B [1].
-            // After the first three characters, there may be a decimal point, and up to three more alphanumeric characters.
-            // These alphanumeric characters are never U. Sometimes the decimal is left out.
-            // Regex ICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB].?[0-9A-TV-Z]{0,4}$");
-            // NCHS ICD10 codes are the same as above for the first three characters.
-            // The decimal point is always dropped.
-            // Some codes have a fourth character that reflects an actual ICD10 code.
-            // NCHS tacks on an extra character to some ICD10 codes, e.g., K7210 (K27.10)
-            // Regex NCHSICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB][0-9A-TV-Z]{0,2}$");
             string code = "";
 
             if (!String.IsNullOrEmpty(nchsicd10code))
             {
-                code = nchsicd10code.Trim();
+                if (ValidNCHSICD10(nchsicd10code.Trim()))
+                {
+                    code = nchsicd10code.Trim();
+                }
+                else
+                {
+                    throw new ArgumentException($"NCHS ICD10 code {nchsicd10code} is invalid.");
+                }
+
             }
 
             if (code.Length >= 4)    // codes of length 4 or 5 need to have a decimal inserted
@@ -811,6 +809,25 @@ namespace VRDR
                 return "";
             }
         }
+
+        /// <summary>Actual ICD10 to NCHS ICD10 </summary>
+        private bool ValidNCHSICD10(string nchsicd10code)
+        {
+            // ICD-10 diagnosis codes always begin with a letter (except U) followed by a digit.
+            // The third character is usually a digit, but could be an A or B [1].
+            // After the first three characters, there may be a decimal point, and up to three more alphanumeric characters.
+            // These alphanumeric characters are never U. Sometimes the decimal is left out.
+            // Regex ICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB].?[0-9A-TV-Z]{0,4}$");
+            // NCHS ICD10 codes are the same as above for the first three characters.
+            // The decimal point is always dropped.
+            // Some codes have a fourth character that reflects an actual ICD10 code.
+            // NCHS tacks on an extra character to some ICD10 codes, e.g., K7210 (K27.10)
+            Regex NCHSICD10regex = new Regex(@"^[A-TV-Z][0-9][0-9AB][0-9A-TV-Z]{0,2}$");
+
+            return (!String.IsNullOrEmpty(nchsicd10code) &&
+                 NCHSICD10regex.Match(nchsicd10code).Success);
+        }
+
 
         /////////////////////////////////////////////////////////////////////////////////
         //


### PR DESCRIPTION
add test case for setting ICD10 values (ACME_UC, MAN_UC, RAC, EAC), and throw exception when invalid NCHS icd10 strings are included, such as including periods.

We had no test cases for some of these, and the code didn't work properly.   Surprise.