### PR TITLE
ci: automatic create release pull-request; lint commit message

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -1,0 +1,23 @@
+name: Lint commit message
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install commitlint
+        run: |
+          npm install -g @commitlint/cli @commitlint/config-conventional
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.title }}" | commitlint --verbose

--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -39,13 +39,8 @@ jobs:
         run: |
           dotnet tool install --global Versionize
       - name: Bump version and create changelog
-        if: github.event_name == 'workflow_dispatch'
         run: |
-          versionize --proj-version-bump-logic --skip-tag --aggregate-pre-releases --changelog-all
-      - name: Bump pre-release version and create changelog
-        if: github.event_name == 'push'
-        run: |
-          versionize --pre-release pre --proj-version-bump-logic --skip-tag --aggregate-pre-releases --changelog-all
+          versionize --proj-version-bump-logic --skip-tag --changelog-all
       - name: Get current version
         id: get-version
         run: |

--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -39,6 +39,11 @@ jobs:
         run: |
           dotnet tool install --global Versionize
       - name: Bump version and create changelog
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          versionize --proj-version-bump-logic --skip-tag --aggregate-pre-releases --changelog-all
+      - name: Bump pre-release version and create changelog
+        if: github.event_name == 'push'
         run: |
           versionize --pre-release pre --proj-version-bump-logic --skip-tag --aggregate-pre-releases --changelog-all
       - name: Get current version

--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -1,0 +1,65 @@
+name: Sync release pull-request
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master", "main" ]
+
+permissions:
+  contents: 'write'
+  pull-requests: 'write'
+
+jobs:
+  parse-commit:
+    runs-on: ubuntu-latest
+    outputs:
+      subject: ${{ steps.commit-subject.outputs.subject }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get commit subject
+        id: commit-subject
+        run: |
+          echo "subject=$(git log -n 1 --pretty=%s)" >> $GITHUB_OUTPUT
+  release-pull-request:
+    runs-on: ubuntu-latest
+    needs: verify-commit
+    if: startsWith(needs.parse-commit.outputs.subject, 'chore(release):') != true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+      - name: Setup Versionize
+        run: |
+          dotnet tool install --global Versionize
+      - name: Bump version and create changelog
+        run: |
+          versionize --pre-release pre --proj-version-bump-logic --skip-tag --aggregate-pre-releases --changelog-all
+      - name: Get current version
+        id: get-version
+        run: |
+          echo "version=$(versionize inspect)" >> $GITHUB_OUTPUT
+      - name: Create release Pull Request
+        uses: peter-evans/create-pull-request@v5
+        id: cpr
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            chore(release): ${{ steps.get-version.outputs.version }}
+          title: |
+            chore(release): ${{ steps.get-version.outputs.version }}
+          body: ""
+          branch: actions/release
+          reviewers: ${{ github.actor }}
+          delete-branch: true          
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -22,7 +22,7 @@ jobs:
           echo "subject=$(git log -n 1 --pretty=%s)" >> $GITHUB_OUTPUT
   release-pull-request:
     runs-on: ubuntu-latest
-    needs: verify-commit
+    needs: parse-commit
     if: startsWith(needs.parse-commit.outputs.subject, 'chore(release):') != true
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ dotnet run --project VRDR.HTTP
 
 The service will be listening locally at `http://localhost:8080`.
 
-#### Contributing
+## Contributing
 This repository follows [Semantic Versioning](https://semver.org/). Bug fixes and feature enhancements should be merged into the `master` branch via Pull Requests (PR), instead of directly committing to the `master` branch. Once a PR is merged, a new version of the library will be automatically published to NuGet.
 
 ```

--- a/README.md
+++ b/README.md
@@ -678,30 +678,32 @@ dotnet run --project VRDR.HTTP
 The service will be listening locally at `http://localhost:8080`.
 
 #### Contributing
-Changes related to an upcoming IG version should be merged to the IG-develop-vx.x.x branch. Bug fixes related to the current version should be merged to the master branch and a new release should be created.
+This repository follows [Semantic Versioning](https://semver.org/). Bug fixes and feature enhancements should be merged into the `master` branch via Pull Requests (PR), instead of directly committing to the `master` branch. Once a PR is merged, a new version of the library will be automatically published to NuGet.
 
-##### Create a branch for IG changes:
 ```
-git fetch origin
-git checkout IG-develop-vx.x.x
-git pull origin IG-develop-vx.x.x
-git checkout -b <your-ticketnumber-branch-name>
-<commit-your-IG-related-changes>
-<test-with-changes-from-master>
-git push origin <your-ticketnumber-branch-name>
-```
-Create merge request to the IG-develop-vx.x.x branch.
-
-##### Create a branch for bug fixes in master
-```
-git checkout master
 git pull origin master
-git checkout -b <your-ticketnumber-branch-name>
-<commit-bug-related-changes>
-git push origin <your-ticketnumber-branch-name>
+git checkout -b <your-working-branch-name>
+<commit-your-changes>
+<test-with-changes-from-master>
+git push -u origin <your-working-branch-name>
 ```
-Create a merge request to the master branch.
-Finally, merge master into the IG-develop-vx.x.x branch.
+Once the working branch is pushed to the respository, follow these steps:
+
+1. Create a new PR with the working branch as base, and master as head.
+1. The PR title and description should follow the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format. The PR title should be structured as  `<type>[optional scope]: <short-message>`, where a type can be:
+  - **feat:** introduces a new feature to the codebase (correlates with MINOR in Semantic Versioning).
+  - **fix:** patches a bug in the codebase (correlates with PATCH in Semantic Versioning).
+  - Other types such as `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`, and others are allowed as well (correlates with PATCH in Semantic Versioning).
+  
+  (The PR title needs to be concise and conform to the style guide for change tracking purposes. The PR description can include additional details about the changes associated with this PR.)
+1. Assign one or more reviewers to review your changes. At least one approved review is required before the PR can be merged.
+1. If the PR addresses an existing Issue, link the PR with the Issue to resolve it through the PR.
+1. Once the PR is approved by a reviewer, with all discussions resolved and all checks passed, click the Squash and Merge button. Avoid using "Create a merge commit." The PR title and description will automatically fill in the commit message boxes.
+
+#### Release Pull Request
+
+With each commit to the default branch, a release pull request will be automatically created/updated. This PR increments the package version and updates the CHANGELOG using a special branch named `actions/release`. You don't need to wait for this special PR to be merged into the default branch before merging additional pull requests. It consolidates subsequent commits to the default branch; only one instance of release pull request will be active.
+
 
 #### Publishing a Version
 


### PR DESCRIPTION
**TL;DR:**
- The only significant formatting convention to pay attention to are PR Title and PR Description, these are converted to commit subject and commit body/footer when the PR is merged to the main branch;
  - `feat: <short-message>` advances minor version
  - every other type advances patch version
  - major version is advanced manually
- Use `Squash and Merge` when merging any PR;
- GitHub Issue formatting is insignificant, as these can be created by the community;
- Messages from commits toward a branch associated with a PR are insignificant; 

**Adapt:**
- [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [Semantic Versioning](https://semver.org/spec/v2.0.0.html)