### PR TITLE
ci: handle dependabot pull requests

### DIFF
--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -3,14 +3,13 @@ name: Lint commit message
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
 
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -18,6 +17,11 @@ jobs:
         run: |
           npm install -g @commitlint/cli @commitlint/config-conventional
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
-      - name: Validate PR commits with commitlint
+      - name: Validate pull request title with commitlint
         if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.title }}" | commitlint --verbose
+        run: echo ${{ github.event.pull_request.title }} | commitlint --verbose
+      - name: Validate pull request title with commitlint
+        if: github.event_name == 'workflow_dispatch'
+        run: gh pr view --json title -t "{{.title}}" | commitlint --verbose
+        env:          
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,22 @@
+name: Maintenance
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  pull-requests: write
+  actions: write
+
+jobs:
+  dependabot-pr:
+    if: startsWith(github.event.pull_request.title, 'Bump ') && startsWith(github.event.pull_request.head.ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE=$(echo ${{github.event.pull_request.title}} | sed "s/Bump /chore: bump /")
+          gh pr edit ${{ github.event.pull_request.number}} --title "$TITLE"          
+          gh workflow run lint-commit-message.yml --ref ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Handle maintenance pull requests opened by `dependabot` to conform to conventional commit, by replacing **Bump ...** with **chore: bump ...**