### PR TITLE
fix: partial date time handling of day, month and year

### DIFF
--- a/VRDR.Tests/DeathRecord_Should.cs
+++ b/VRDR.Tests/DeathRecord_Should.cs
@@ -2995,7 +2995,7 @@ namespace VRDR.Tests
         public void Get_DateOfDeath()
         {
             Assert.Null(DeathCertificateDocument2_JSON.DateOfDeath);
-            Assert.Null(DeathCertificateDocument2_JSON.DeathDay);
+            Assert.Equal(-1, DeathCertificateDocument2_JSON.DeathDay); // partial unknowns return as -1
             Assert.Equal(2020, (DeathCertificateDocument2_JSON.DeathYear));
             Assert.Equal("2020-11-12T00:00:00", DeathCertificateDocument1_JSON.DateOfDeath);
             Assert.Equal(2020, (DeathCertificateDocument1_JSON.DeathYear));
@@ -4200,23 +4200,46 @@ namespace VRDR.Tests
             Assert.Equal("  ", ije.DOI_MO);
             Assert.Equal("  ", ije.DOI_DY);
             Assert.Equal("    ", ije.TOI_HR);
+            Assert.Equal("    ", ije.DOD_YR);
+            /* // depends on outcome of temp-unknown discussion with Saul
+            Assert.Equal("99", ije.DOD_MO);
+            Assert.Equal("99", ije.DOD_DY);
+            Assert.Equal("9999", ije.TOD);
+
+            Assert.Equal("9999", ije.DOI_YR);
+            Assert.Equal("99", ije.DOI_MO);
+            Assert.Equal("99", ije.DOI_DY);
+            Assert.Equal("9999", ije.TOI_HR);
+            */
         }
 
         [Fact]
         public void TestUknownTimeOfDeathForFHIR() {
             var dr = new DeathRecord();
+            dr.DeathDay = -1;
+            dr.DeathMonth = -1;
+            dr.DeathYear = -1;
             dr.DeathTime = "-1";
             var fhir = dr.ToJson();
             Assert.Null(dr.DateOfDeath);
+            Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"",\s*""_valueUnsignedInt"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
+            Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"",\s*""_valueUnsignedInt"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
+            Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"",\s*""_valueUnsignedInt"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
             Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time"",\s*""_valueTime"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
         }
 
          [Fact]
         public void TestUknownTimeOfInjuryForFHIR() {
             var dr = new DeathRecord();
+            dr.InjuryDay = -1;
+            dr.InjuryMonth = -1;
+            dr.InjuryYear = -1;
             dr.InjuryTime = "-1";
             var fhir = dr.ToJson();
             Assert.Null(dr.InjuryDate);
+            Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"",\s*""_valueUnsignedInt"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
+            Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"",\s*""_valueUnsignedInt"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
+            Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"",\s*""_valueUnsignedInt"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
             Assert.Matches(@"\{\s*""url"":\s*""http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time"",\s*""_valueTime"":\s*\{\s*""extension"":\s*\[\s*\{\s*""url"":\s*""http://hl7.org/fhir/StructureDefinition/data-absent-reason"",\s*""valueCode"":\s*""unknown""\s*\}\s*\]\s*\}\s*\}", fhir);
         }
 

--- a/VRDR.Tests/fixtures/json/TempUnknownDateOfDeath.json
+++ b/VRDR.Tests/fixtures/json/TempUnknownDateOfDeath.json
@@ -1821,31 +1821,37 @@
             {
               "extension": [
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "temp-unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "temp-unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "temp-unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "temp-unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "temp-unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "temp-unknown"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",

--- a/VRDR.Tests/fixtures/json/UnknownDateOfDeath.json
+++ b/VRDR.Tests/fixtures/json/UnknownDateOfDeath.json
@@ -1821,31 +1821,37 @@
             {
               "extension": [
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",
@@ -2044,31 +2050,37 @@
             {
               "extension": [
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",

--- a/VRDR.Tests/fixtures/json/UnknownDateOfInjury.json
+++ b/VRDR.Tests/fixtures/json/UnknownDateOfInjury.json
@@ -1821,31 +1821,37 @@
             {
               "extension": [
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
-                  "extension": [
-                    {
-                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                      "valueCode": "unknown"
-                    }
-                  ],
-                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day"
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                  "_valueUnsignedInt": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",


### PR DESCRIPTION
Fixed partial date time handling of day, month and year in date of death and date of injury with correct FHIR structure using _valueUnsignedInt with extensions