### PR TITLE
ci(release): default to auto-merge; use deploy key to chain workflows

### DIFF
--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY_AUTO_PR }}
       - run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -49,7 +50,6 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         id: cpr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
             chore(release): ${{ steps.get-version.outputs.version }}
           title: |
@@ -63,3 +63,6 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+      - name: Enable auto-merge
+        run: |
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --auto


### PR DESCRIPTION
- use GitHub CLI to enable auto-merge on auto-created release PR
- use [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys) to create the release PR in order to chain further workflow runs
- add GitHub Action Secret `DEPLOY_KEY_AUTO_PR` (SSH private key)