### PR TITLE
fix: add System.Net.Http namespace reference

### DIFF
--- a/VRDR.Client/Client.cs
+++ b/VRDR.Client/Client.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using System.Net.Http;
 
 namespace VRDR
 {


### PR DESCRIPTION
Need to add specific namespace reference to `System.Net.Http`. Without it test suite fails.