### PR TITLE
fix: use leap year as default for datetime helper

### DIFF
--- a/VRDR.Tests/MortalityData_Should.cs
+++ b/VRDR.Tests/MortalityData_Should.cs
@@ -584,6 +584,13 @@ namespace VRDR.Tests
         }
 
         [Fact]
+        public void LeapYearDate()
+        {
+            IJEMortality ije = new IJEMortality();
+            ije.CERTDATE = "02292024";
+            Assert.Equal("02292024", ije.CERTDATE.Trim());
+        }
+        [Fact]
         public void TestTimeValues()
         {
             IJEMortality ijem;

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -316,12 +316,6 @@ namespace VRDR
                 {
                     return "";
                 }
-                // DateTimeOffset newDate;
-                // DateTimeOffset.TryParseExact(Truncate(value, info.Length), "MMddyy", null, DateTimeStyles.None, out newDate);
-                // if (newDate > DateTimeOffset.MinValue) {
-                //     date = newDate;
-                // }
-
                 int month;
                 if (Int32.TryParse(Truncate(value, info.Length).Substring(0, 2), out month))
                 {

--- a/VRDR/IJEMortality.cs
+++ b/VRDR/IJEMortality.cs
@@ -316,6 +316,12 @@ namespace VRDR
                 {
                     return "";
                 }
+                // DateTimeOffset newDate;
+                // DateTimeOffset.TryParseExact(Truncate(value, info.Length), "MMddyy", null, DateTimeStyles.None, out newDate);
+                // if (newDate > DateTimeOffset.MinValue) {
+                //     date = newDate;
+                // }
+
                 int month;
                 if (Int32.TryParse(Truncate(value, info.Length).Substring(0, 2), out month))
                 {
@@ -390,7 +396,7 @@ namespace VRDR
             }
             else
             {
-                date = new DateTimeOffset(1, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+                date = new DateTimeOffset(4, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
                 typeof(DeathRecord).GetProperty(fhirFieldName).SetValue(this.record, DateTimeStringHelper(info, value, dateTimeType, date, dateOnly, withTimezoneOffset));
             }
         }


### PR DESCRIPTION
Leap year entries are not handled correctly by the IJEMortality.DateTime_Set method. Change reference DateTimeOffset object to start on leap year.