### PR TITLE
fix: exclude display text for selected code

### DIFF
--- a/VRDR/DeathRecord_constructors.cs
+++ b/VRDR/DeathRecord_constructors.cs
@@ -67,7 +67,7 @@ namespace VRDR
             Composition.Attester.First().Party = new ResourceReference("urn:uuid:" + Certifier.Id);
             Composition.Attester.First().ModeElement = new Code<Hl7.Fhir.Model.Composition.CompositionAttestationMode>(Hl7.Fhir.Model.Composition.CompositionAttestationMode.Legal);
             Hl7.Fhir.Model.Composition.EventComponent eventComponent = new Hl7.Fhir.Model.Composition.EventComponent();
-            eventComponent.Code.Add(new CodeableConcept(CodeSystems.SCT, "103693007", "Diagnostic procedure (procedure)", null));
+            eventComponent.Code.Add(new CodeableConcept(CodeSystems.SCT, "103693007", null, null));
             eventComponent.Detail.Add(new ResourceReference("urn:uuid:" + DeathCertification.Id));
             Composition.Event.Add(eventComponent);
             Bundle.AddResourceEntry(Composition, "urn:uuid:" + Composition.Id);

--- a/VRDR/DeathRecord_fieldsAndCreateMethods.cs
+++ b/VRDR/DeathRecord_fieldsAndCreateMethods.cs
@@ -88,7 +88,7 @@ namespace VRDR
             string[] deathcertification_profile = { ProfileURL.DeathCertification };
             DeathCertification.Meta.Profile = deathcertification_profile;
             DeathCertification.Status = EventStatus.Completed;
-            DeathCertification.Category = new CodeableConcept(CodeSystems.SCT, "103693007", "Diagnostic procedure", null);
+            DeathCertification.Category = new CodeableConcept(CodeSystems.SCT, "103693007", null, null);
             DeathCertification.Code = new CodeableConcept(CodeSystems.SCT, "308646001", "Death certification", null);
             // Not linked to Composition or inserted in bundle, since this is run before the composition exists.
         }


### PR DESCRIPTION
[Death Certification Procedure](https://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-death-certification.html) (SNOMED 103693007) with display texts is causing validation issues. Exclude `code.display` when producing output.