### PR TITLE
feat: add scope parameter to Credentials class

### DIFF
--- a/VRDR.Client/Client.cs
+++ b/VRDR.Client/Client.cs
@@ -237,6 +237,11 @@ namespace VRDR
             parameters.Add("client_secret", this.Credentials.ClientSecret);
             parameters.Add("username", this.Credentials.Username);
             parameters.Add("password", this.Credentials.Pass);
+            if (this.Credentials.Scope != null)
+            {
+                parameters.Add("scope", this.Credentials.Scope);
+            }
+            
 
             var request = new HttpRequestMessage(HttpMethod.Post, this.Credentials.Url) { Content = new FormUrlEncodedContent(parameters) };
             var response = await client.SendAsync(request);

--- a/VRDR.Client/Credentials.cs
+++ b/VRDR.Client/Credentials.cs
@@ -16,14 +16,18 @@ namespace VRDR
         public String Username { get; }
         /// <summary>The password provided by SAMS</summary>
         public String Pass { get; }
+        /// <summary>The scope of the request</summary>
+        public String? Scope {get;}
+        
         /// <summary>Constructor</summary>
-        public Credentials(String url, String clientID, String clientSecret, String username, String pass)
+        public Credentials(String url, String clientID, String clientSecret, String username, String pass, String? scope = null)
         {
             this.Url = url;
             this.ClientId = clientID;
             this.ClientSecret = clientSecret;
             this.Username = username;
             this.Pass = pass;
+            this.Scope = scope;
         }
     }
 }


### PR DESCRIPTION
This change adds support for a scope parameter in the VRDR.Client. This change will allow users to specify the scope when making a token request. Specifying scope: [openid profile email] is a new requirement from SAMS to conform with the Open ID Connect specification.

