### PR TITLE
feat: ennhance checkout step in sync-release-pr workflow

### DIFF
--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }} 
+          persist-credentials: true
       - run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"


### PR DESCRIPTION
Add token and persist-credentials options to checkout step