### PR TITLE
fix: set up git user in sync-release-pr workflow

### DIFF
--- a/.github/workflows/sync-release-pr.yml
+++ b/.github/workflows/sync-release-pr.yml
@@ -30,6 +30,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }} 
           persist-credentials: true
+      - run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:


### PR DESCRIPTION
Configure Git user for GitHub Actions workflow. Revert back to the old version.